### PR TITLE
Add tests for orchestrator filterTables and sync handlers

### DIFF
--- a/cmd/smt/sync.go
+++ b/cmd/smt/sync.go
@@ -239,11 +239,20 @@ func loadPreviousSnapshot(state *checkpoint.State, sourceType, schema string) (s
 	return snap, nil
 }
 
+// constraintLoader is the narrow slice of driver.Reader that
+// loadAllConstraints uses. Declaring it as an interface lets tests pass
+// a stub without standing up a full driver.
+type constraintLoader interface {
+	LoadIndexes(ctx context.Context, t *driver.Table) error
+	LoadForeignKeys(ctx context.Context, t *driver.Table) error
+	LoadCheckConstraints(ctx context.Context, t *driver.Table) error
+}
+
 // loadAllConstraints fills in the per-table indexes/FKs/checks. The
 // driver's ExtractSchema returns just columns + PK; the constraint
 // loaders are separate calls so the orchestrator can skip them when not
 // needed. For snapshot/sync we always want the full picture.
-func loadAllConstraints(ctx context.Context, src driver.Reader, tables []driver.Table) error {
+func loadAllConstraints(ctx context.Context, src constraintLoader, tables []driver.Table) error {
 	for i := range tables {
 		t := &tables[i]
 		if err := src.LoadIndexes(ctx, t); err != nil {
@@ -259,10 +268,15 @@ func loadAllConstraints(ctx context.Context, src driver.Reader, tables []driver.
 	return nil
 }
 
+// sqlExecutor is the narrow slice of driver.Writer that applyPlan uses.
+type sqlExecutor interface {
+	ExecRaw(ctx context.Context, query string, args ...any) (int64, error)
+}
+
 // applyPlan executes each statement against the target writer in order.
 // Stops at the first failure so the operator can investigate and re-run
 // (idempotent statements are the AI's responsibility, not ours).
-func applyPlan(ctx context.Context, tgt driver.Writer, plan schemadiff.Plan) error {
+func applyPlan(ctx context.Context, tgt sqlExecutor, plan schemadiff.Plan) error {
 	for i, s := range plan.Statements {
 		logging.Info("[%d/%d] %s (risk=%s)", i+1, len(plan.Statements), s.Description, s.Risk)
 		if _, err := tgt.ExecRaw(ctx, s.SQL); err != nil {

--- a/cmd/smt/sync.go
+++ b/cmd/smt/sync.go
@@ -239,7 +239,7 @@ func loadPreviousSnapshot(state *checkpoint.State, sourceType, schema string) (s
 	return snap, nil
 }
 
-// constraintLoader is the narrow slice of driver.Reader that
+// constraintLoader is the narrow subset of driver.Reader that
 // loadAllConstraints uses. Declaring it as an interface lets tests pass
 // a stub without standing up a full driver.
 type constraintLoader interface {
@@ -268,7 +268,7 @@ func loadAllConstraints(ctx context.Context, src constraintLoader, tables []driv
 	return nil
 }
 
-// sqlExecutor is the narrow slice of driver.Writer that applyPlan uses.
+// sqlExecutor is the narrow subset of driver.Writer that applyPlan uses.
 type sqlExecutor interface {
 	ExecRaw(ctx context.Context, query string, args ...any) (int64, error)
 }

--- a/cmd/smt/sync_test.go
+++ b/cmd/smt/sync_test.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"smt/internal/checkpoint"
+	"smt/internal/driver"
+	"smt/internal/schemadiff"
+)
+
+// stubExecutor records every SQL it's asked to run and optionally fails
+// on a specific statement index (failAt). Used for applyPlan tests.
+type stubExecutor struct {
+	executed []string
+	failAt   int // 1-based; 0 means never fail
+	failErr  error
+}
+
+func (s *stubExecutor) ExecRaw(_ context.Context, query string, _ ...any) (int64, error) {
+	s.executed = append(s.executed, query)
+	if s.failAt > 0 && len(s.executed) == s.failAt {
+		return 0, s.failErr
+	}
+	return 1, nil
+}
+
+func TestApplyPlan_HappyPath(t *testing.T) {
+	exec := &stubExecutor{}
+	plan := schemadiff.Plan{Statements: []schemadiff.Statement{
+		{SQL: "ALTER TABLE x ADD COLUMN a int", Description: "add a", Risk: schemadiff.RiskSafe},
+		{SQL: "ALTER TABLE x ADD COLUMN b int", Description: "add b", Risk: schemadiff.RiskSafe},
+	}}
+
+	if err := applyPlan(context.Background(), exec, plan); err != nil {
+		t.Fatalf("expected no err, got %v", err)
+	}
+	if len(exec.executed) != 2 {
+		t.Fatalf("expected 2 statements executed, got %d", len(exec.executed))
+	}
+}
+
+func TestApplyPlan_StopsAtFirstFailure(t *testing.T) {
+	exec := &stubExecutor{failAt: 2, failErr: errors.New("syntax error near token")}
+	plan := schemadiff.Plan{Statements: []schemadiff.Statement{
+		{SQL: "ALTER 1", Description: "stmt 1", Risk: schemadiff.RiskSafe},
+		{SQL: "ALTER 2 BAD", Description: "stmt 2", Risk: schemadiff.RiskBlocking},
+		{SQL: "ALTER 3", Description: "stmt 3", Risk: schemadiff.RiskSafe},
+	}}
+
+	err := applyPlan(context.Background(), exec, plan)
+	if err == nil {
+		t.Fatal("expected error from stmt 2 failure")
+	}
+	if !strings.Contains(err.Error(), "statement 2") {
+		t.Errorf("error should identify statement 2, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "ALTER 2 BAD") {
+		t.Errorf("error should include the failing SQL, got: %v", err)
+	}
+	if len(exec.executed) != 2 {
+		t.Fatalf("expected to stop after 2 statements, executed %d", len(exec.executed))
+	}
+}
+
+func TestApplyPlan_EmptyPlan(t *testing.T) {
+	exec := &stubExecutor{}
+	if err := applyPlan(context.Background(), exec, schemadiff.Plan{}); err != nil {
+		t.Fatalf("empty plan should be a no-op, got %v", err)
+	}
+	if len(exec.executed) != 0 {
+		t.Fatalf("empty plan executed %d statements", len(exec.executed))
+	}
+}
+
+// stubLoader records which tables had each loader called, and can fail
+// on a specific table+method combination.
+type stubLoader struct {
+	indexCalls   []string
+	fkCalls      []string
+	checkCalls   []string
+	failOnTable  string
+	failOnMethod string // "indexes" | "fks" | "checks"
+	err          error
+}
+
+func (s *stubLoader) LoadIndexes(_ context.Context, t *driver.Table) error {
+	s.indexCalls = append(s.indexCalls, t.Name)
+	if s.failOnTable == t.Name && s.failOnMethod == "indexes" {
+		return s.err
+	}
+	return nil
+}
+
+func (s *stubLoader) LoadForeignKeys(_ context.Context, t *driver.Table) error {
+	s.fkCalls = append(s.fkCalls, t.Name)
+	if s.failOnTable == t.Name && s.failOnMethod == "fks" {
+		return s.err
+	}
+	return nil
+}
+
+func (s *stubLoader) LoadCheckConstraints(_ context.Context, t *driver.Table) error {
+	s.checkCalls = append(s.checkCalls, t.Name)
+	if s.failOnTable == t.Name && s.failOnMethod == "checks" {
+		return s.err
+	}
+	return nil
+}
+
+func TestLoadAllConstraints_HappyPath(t *testing.T) {
+	loader := &stubLoader{}
+	tables := []driver.Table{{Name: "Users"}, {Name: "Posts"}}
+
+	if err := loadAllConstraints(context.Background(), loader, tables); err != nil {
+		t.Fatalf("expected no err, got %v", err)
+	}
+
+	for _, want := range []string{"Users", "Posts"} {
+		if !contains(loader.indexCalls, want) {
+			t.Errorf("LoadIndexes never called for %s", want)
+		}
+		if !contains(loader.fkCalls, want) {
+			t.Errorf("LoadForeignKeys never called for %s", want)
+		}
+		if !contains(loader.checkCalls, want) {
+			t.Errorf("LoadCheckConstraints never called for %s", want)
+		}
+	}
+}
+
+func TestLoadAllConstraints_StopsAtFirstFailure(t *testing.T) {
+	loader := &stubLoader{
+		failOnTable:  "Posts",
+		failOnMethod: "fks",
+		err:          errors.New("permission denied"),
+	}
+	tables := []driver.Table{{Name: "Users"}, {Name: "Posts"}, {Name: "Comments"}}
+
+	err := loadAllConstraints(context.Background(), loader, tables)
+	if err == nil {
+		t.Fatal("expected FK loader failure to surface")
+	}
+	if !strings.Contains(err.Error(), "Posts") {
+		t.Errorf("error should mention failing table Posts, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "FKs") {
+		t.Errorf("error should mention which constraint type failed, got: %v", err)
+	}
+	// Comments should never have been touched.
+	if contains(loader.indexCalls, "Comments") {
+		t.Errorf("loader continued past failure to Comments")
+	}
+}
+
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func TestLoadPreviousSnapshot_NoSnapshotReturnsHelpfulError(t *testing.T) {
+	state, err := checkpoint.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("setup state: %v", err)
+	}
+	defer state.Close()
+
+	_, err = loadPreviousSnapshot(state, "mssql", "dbo")
+	if err == nil {
+		t.Fatal("expected error when no snapshot exists")
+	}
+	if !strings.Contains(err.Error(), "smt snapshot") {
+		t.Errorf("error should tell user to run `smt snapshot`, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "mssql/dbo") {
+		t.Errorf("error should identify which (sourceType, schema) had no snapshot, got: %v", err)
+	}
+}
+
+func TestLoadPreviousSnapshot_RoundTrip(t *testing.T) {
+	state, err := checkpoint.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("setup state: %v", err)
+	}
+	defer state.Close()
+
+	want := schemadiff.Snapshot{
+		Schema:     "dbo",
+		SourceType: "mssql",
+		CapturedAt: time.Now().UTC().Truncate(time.Microsecond),
+		Tables:     []driver.Table{{Schema: "dbo", Name: "Users"}},
+	}
+	payload, _ := json.Marshal(want)
+	if _, err := state.SaveSnapshot(want.SourceType, want.Schema, want.CapturedAt, payload); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, err := loadPreviousSnapshot(state, "mssql", "dbo")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.SourceType != want.SourceType || got.Schema != want.Schema {
+		t.Errorf("snapshot round-trip mismatch: got %+v, want %+v", got, want)
+	}
+	if len(got.Tables) != 1 || got.Tables[0].Name != "Users" {
+		t.Errorf("table list not preserved: got %+v", got.Tables)
+	}
+}
+
+func TestLoadPreviousSnapshot_MalformedPayload(t *testing.T) {
+	state, err := checkpoint.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("setup state: %v", err)
+	}
+	defer state.Close()
+
+	// Save a payload that isn't valid JSON for a Snapshot.
+	if _, err := state.SaveSnapshot("mssql", "dbo", time.Now(), []byte("{not json")); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	_, err = loadPreviousSnapshot(state, "mssql", "dbo")
+	if err == nil {
+		t.Fatal("expected unmarshal error")
+	}
+	if !strings.Contains(err.Error(), "decoding stored snapshot") {
+		t.Errorf("error should mention decoding failure, got: %v", err)
+	}
+}

--- a/internal/orchestrator/phases_test.go
+++ b/internal/orchestrator/phases_test.go
@@ -1,0 +1,113 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"smt/internal/config"
+	"smt/internal/source"
+)
+
+func tbl(name string) source.Table { return source.Table{Name: name} }
+
+func TestFilterTables_NoConfig(t *testing.T) {
+	o := &Orchestrator{config: &config.Config{}}
+	in := []source.Table{tbl("Users"), tbl("Posts"), tbl("__schema_versions")}
+	out := o.filterTables(in)
+
+	if len(out) != 3 {
+		t.Fatalf("expected all 3 tables to pass through, got %d", len(out))
+	}
+}
+
+func TestFilterTables_ExcludeOnly(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Migration.ExcludeTables = []string{"__*", "temp_*"}
+	o := &Orchestrator{config: cfg}
+
+	in := []source.Table{tbl("Users"), tbl("__migrations"), tbl("temp_staging"), tbl("Posts")}
+	out := o.filterTables(in)
+
+	if len(out) != 2 {
+		t.Fatalf("expected 2 tables to remain, got %d", len(out))
+	}
+	for _, table := range out {
+		if table.Name == "__migrations" || table.Name == "temp_staging" {
+			t.Errorf("excluded table %s slipped through", table.Name)
+		}
+	}
+}
+
+func TestFilterTables_IncludeOnly(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Migration.IncludeTables = []string{"User*", "Post*"}
+	o := &Orchestrator{config: cfg}
+
+	in := []source.Table{tbl("Users"), tbl("UserSettings"), tbl("Posts"), tbl("Comments")}
+	out := o.filterTables(in)
+
+	if len(out) != 3 {
+		t.Fatalf("expected 3 tables matched (Users, UserSettings, Posts), got %d", len(out))
+	}
+	for _, table := range out {
+		if table.Name == "Comments" {
+			t.Errorf("non-matching table Comments was kept")
+		}
+	}
+}
+
+func TestFilterTables_IncludeAndExclude(t *testing.T) {
+	// Exclude wins over include — same precedence as the existing implementation.
+	cfg := &config.Config{}
+	cfg.Migration.IncludeTables = []string{"*"}
+	cfg.Migration.ExcludeTables = []string{"__*"}
+	o := &Orchestrator{config: cfg}
+
+	in := []source.Table{tbl("Users"), tbl("__schema")}
+	out := o.filterTables(in)
+
+	if len(out) != 1 || out[0].Name != "Users" {
+		t.Fatalf("expected only Users, got %+v", out)
+	}
+}
+
+func TestFilterTables_GlobPatterns(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Migration.ExcludeTables = []string{"audit_?", "*_archive"}
+	o := &Orchestrator{config: cfg}
+
+	in := []source.Table{
+		tbl("audit_1"),       // matches audit_?
+		tbl("audit_log"),     // does NOT match audit_? (? is single char)
+		tbl("posts"),         // kept
+		tbl("posts_archive"), // matches *_archive
+	}
+	out := o.filterTables(in)
+
+	want := map[string]bool{"audit_log": true, "posts": true}
+	if len(out) != len(want) {
+		t.Fatalf("expected 2 tables, got %d: %+v", len(out), out)
+	}
+	for _, table := range out {
+		if !want[table.Name] {
+			t.Errorf("unexpected table kept: %s", table.Name)
+		}
+	}
+}
+
+func TestMatchesAny_EmptyPatterns(t *testing.T) {
+	if matchesAny("Users", nil) {
+		t.Errorf("nil pattern list should match nothing")
+	}
+	if matchesAny("Users", []string{}) {
+		t.Errorf("empty pattern list should match nothing")
+	}
+}
+
+func TestMatchesAny_InvalidGlobIsTreatedAsNoMatch(t *testing.T) {
+	// filepath.Match returns ErrBadPattern for malformed globs; we swallow
+	// the error and treat it as a no-match so a typo in config doesn't
+	// crash the run. Document that behavior here.
+	if matchesAny("Users", []string{"[unclosed"}) {
+		t.Errorf("malformed glob should not match")
+	}
+}

--- a/internal/schemadiff/diff_test.go
+++ b/internal/schemadiff/diff_test.go
@@ -2,6 +2,8 @@ package schemadiff
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -156,6 +158,119 @@ func TestRender_StripsCodeFences(t *testing.T) {
 	}
 	if len(plan.Statements) != 1 {
 		t.Fatalf("expected 1 stmt, got %d", len(plan.Statements))
+	}
+}
+
+// failingAsker always returns the configured error. Used to simulate AI
+// provider outages / timeouts.
+type failingAsker struct{ err error }
+
+func (f *failingAsker) Ask(_ context.Context, _ string) (string, error) {
+	return "", f.err
+}
+
+func TestRender_NilAskerReturnsError(t *testing.T) {
+	prev := Snapshot{Tables: []driver.Table{table("Users", col("Id", "int", false))}}
+	curr := Snapshot{Tables: []driver.Table{table("Users",
+		col("Id", "int", false), col("Email", "varchar", true))}}
+	d := Compute(prev, curr)
+
+	_, err := Render(context.Background(), nil, d, "public", "postgres")
+	if err == nil {
+		t.Fatal("expected error when ai is nil")
+	}
+	if !strings.Contains(err.Error(), "AI provider") {
+		t.Errorf("error should explain AI is required, got: %v", err)
+	}
+}
+
+func TestRender_AIErrorPropagates(t *testing.T) {
+	asker := &failingAsker{err: errors.New("anthropic 429: rate limit")}
+	prev := Snapshot{Tables: []driver.Table{table("Users", col("Id", "int", false))}}
+	curr := Snapshot{Tables: []driver.Table{table("Users",
+		col("Id", "int", false), col("Email", "varchar", true))}}
+	d := Compute(prev, curr)
+
+	_, err := Render(context.Background(), asker, d, "public", "postgres")
+	if err == nil {
+		t.Fatal("expected propagated AI error")
+	}
+	if !strings.Contains(err.Error(), "rate limit") {
+		t.Errorf("underlying error should be wrapped, got: %v", err)
+	}
+}
+
+func TestRender_NonJSONResponseSurfacesRawText(t *testing.T) {
+	// Some local providers (Ollama with the wrong model) return prose
+	// instead of JSON. The error must include the raw text so the operator
+	// can see what the model said.
+	asker := &stubAsker{Response: "I cannot help with that request."}
+	prev := Snapshot{Tables: []driver.Table{table("Users", col("Id", "int", false))}}
+	curr := Snapshot{Tables: []driver.Table{table("Users",
+		col("Id", "int", false), col("Email", "varchar", true))}}
+	d := Compute(prev, curr)
+
+	_, err := Render(context.Background(), asker, d, "public", "postgres")
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "I cannot help") {
+		t.Errorf("error should include raw response for diagnosis, got: %v", err)
+	}
+}
+
+func TestRender_EmptyStatementsListReturnsEmptyPlan(t *testing.T) {
+	asker := &stubAsker{Response: `{"statements":[]}`}
+	prev := Snapshot{Tables: []driver.Table{table("Users", col("Id", "int", false))}}
+	curr := Snapshot{Tables: []driver.Table{table("Users",
+		col("Id", "int", false), col("Email", "varchar", true))}}
+	d := Compute(prev, curr)
+
+	plan, err := Render(context.Background(), asker, d, "public", "postgres")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !plan.IsEmpty() {
+		t.Errorf("expected empty plan from empty statements list, got %+v", plan)
+	}
+}
+
+func TestRender_ResponseWithExtraTextStillParses(t *testing.T) {
+	// Models sometimes prefix the JSON with "Here is the migration plan:".
+	// The renderer must extract the JSON object regardless.
+	asker := &stubAsker{Response: `Here is your migration plan:
+{"statements":[{"sql":"ALTER TABLE foo","description":"d","risk":"safe"}]}
+Hope this helps!`}
+
+	prev := Snapshot{Tables: []driver.Table{table("Users", col("Id", "int", false))}}
+	curr := Snapshot{Tables: []driver.Table{table("Users",
+		col("Id", "int", false), col("Email", "varchar", true))}}
+	d := Compute(prev, curr)
+
+	plan, err := Render(context.Background(), asker, d, "public", "postgres")
+	if err != nil {
+		t.Fatalf("expected JSON to parse despite surrounding prose, got %v", err)
+	}
+	if len(plan.Statements) != 1 {
+		t.Errorf("expected 1 statement, got %d", len(plan.Statements))
+	}
+}
+
+func TestRender_PromptIncludesTargetDialectAndSchema(t *testing.T) {
+	asker := &stubAsker{Response: `{"statements":[]}`}
+	prev := Snapshot{Tables: []driver.Table{table("Users", col("Id", "int", false))}}
+	curr := Snapshot{Tables: []driver.Table{table("Users",
+		col("Id", "int", false), col("Email", "varchar", true))}}
+	d := Compute(prev, curr)
+
+	if _, err := Render(context.Background(), asker, d, "my_schema", "mysql"); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if !strings.Contains(asker.GotPrompt, "mysql") {
+		t.Errorf("prompt should mention target dialect, got: %s", asker.GotPrompt)
+	}
+	if !strings.Contains(asker.GotPrompt, "my_schema") {
+		t.Errorf("prompt should mention target schema, got: %s", asker.GotPrompt)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds unit tests for the highest-risk pieces I called out as untested in our coverage audit: the orchestrator coordinator I wrote from scratch in Phase 4, and the new schema-diff sync handlers from Phase 6. Up to now those were only exercised by the live MSSQL→PG round-trip.

20 new tests across three files. All 17 packages pass `go test -short ./...`.

## What's tested

**`internal/orchestrator/phases_test.go`** (7 tests) — `filterTables` glob semantics:
- No config → passthrough
- Exclude only / include only / both (exclude wins)
- Glob `?` and `*` patterns
- Empty pattern lists, malformed glob → no-match (don't crash on typo'd config)

**`cmd/smt/sync_test.go`** (8 tests) — sync helper functions:
- `applyPlan`: happy path, mid-stream failure stops execution + surfaces failing statement / SQL, empty plan is no-op
- `loadAllConstraints`: each loader called per table; failure aborts before next table
- `loadPreviousSnapshot`: missing snapshot → helpful error pointing at `smt snapshot`; round-trip preserves payload; malformed payload → decoding error

**`internal/schemadiff/diff_test.go`** (5 new tests) — Render error paths:
- Nil Asker → error explains AI is required
- AI provider error wrapped and propagated
- Non-JSON response → error surfaces raw text (so operator can see what the local model said)
- Empty statements list → empty Plan, no error
- Response with surrounding prose → JSON object still extracted
- Prompt includes target dialect + target schema (regression guard)

## Refactor

`applyPlan` and `loadAllConstraints` now take narrow interfaces (`sqlExecutor`, `constraintLoader`) instead of the full `driver.Writer` / `driver.Reader`, so tests can stub without standing up a real driver. The driver types still satisfy these interfaces, so all callers are unchanged.

## Test plan

- [x] `go test -short ./...` — 17/17 packages pass
- [x] `gofmt -l .` — clean
- [x] `make build` — clean
- [ ] Reviewer eyeballs: are the test names clear about what they're protecting?