### PR TITLE
sync: rewrite Table.Schema to target schema before AI render (closes #4)

### DIFF
--- a/cmd/smt/sync.go
+++ b/cmd/smt/sync.go
@@ -167,6 +167,13 @@ func runSync(c *cli.Context) error {
 		return driver.NormalizeIdentifier(cfg.Target.Type, name)
 	})
 
+	// Point every table in the diff at the target schema. The diff carries
+	// source-side metadata in Table.Schema (e.g. the MySQL database name),
+	// and the AI uses that for the ALTER TABLE qualifier unless we override
+	// it. Without this, MySQL→MSSQL produces ALTER TABLE [smt_src_test].[Posts]
+	// against an MSSQL target whose schema is dbo. See issue #4.
+	diff = diff.WithTargetSchema(cfg.Target.Schema)
+
 	fmt.Printf("Diff: %s\n", diff.Summary())
 
 	mapper, err := driver.NewAITypeMapperFromSecrets()

--- a/internal/schemadiff/diff.go
+++ b/internal/schemadiff/diff.go
@@ -123,14 +123,19 @@ func (d Diff) Normalize(norm func(string) string) Diff {
 	return out
 }
 
-// WithTargetSchema rewrites the Schema field on every Table inside the
-// diff to the supplied name. This is required before handing the diff to
-// the AI renderer because the structural diff carries the SOURCE schema
-// in Table.Schema (populated by the source driver's introspection), and
-// the AI tends to honor that field when emitting qualified ALTER TABLE
-// statements — producing ALTERs against the source schema name on the
-// target, which usually fails (e.g. MySQL source schema "smt_src_test"
-// against MSSQL target schema "dbo": "Cannot find the object …").
+// WithTargetSchema rewrites every schema reference inside the diff to
+// the supplied target schema name. The structural diff carries SOURCE
+// schema names in two places that the AI renderer reads: Table.Schema
+// (the table's own qualifier) and ForeignKey.RefSchema (the referenced
+// table's qualifier in inline REFERENCES clauses). The AI honors both
+// when emitting qualified DDL — leaving either one as the source value
+// produces statements that fail on the target (e.g. MySQL source schema
+// "smt_src_test" against MSSQL target schema "dbo": "Cannot find the
+// object …", or "REFERENCES smt_src_test.parent" inside a target ADD FK).
+//
+// SMT migrates source.X to target.Y; we don't preserve cross-schema
+// relationships across engines, so every schema reference in the diff
+// resolves to the target schema after rewriting.
 //
 // Parallels Normalize: structural-only transformation, leaves all other
 // fields alone. Call after Normalize and before Render.
@@ -140,19 +145,37 @@ func (d Diff) WithTargetSchema(targetSchema string) Diff {
 		CurrCapturedAt: d.CurrCapturedAt,
 	}
 	for _, t := range d.AddedTables {
-		t.Schema = targetSchema
+		retargetTable(&t, targetSchema)
 		out.AddedTables = append(out.AddedTables, t)
 	}
 	for _, t := range d.RemovedTables {
-		t.Schema = targetSchema
+		retargetTable(&t, targetSchema)
 		out.RemovedTables = append(out.RemovedTables, t)
 	}
 	for _, td := range d.ChangedTables {
 		td.Schema = targetSchema
-		td.Curr.Schema = targetSchema
+		retargetTable(&td.Curr, targetSchema)
+		retargetForeignKeys(td.AddedForeignKeys, targetSchema)
+		retargetForeignKeys(td.RemovedForeignKeys, targetSchema)
 		out.ChangedTables = append(out.ChangedTables, td)
 	}
 	return out
+}
+
+// retargetTable rewrites the table's own Schema and the RefSchema on
+// every inline foreign key. Operates in place on the supplied pointer.
+func retargetTable(t *driver.Table, targetSchema string) {
+	t.Schema = targetSchema
+	retargetForeignKeys(t.ForeignKeys, targetSchema)
+}
+
+// retargetForeignKeys rewrites RefSchema on every entry in the supplied
+// slice. Slice elements are mutated directly (FKs are values, not
+// pointers, so a `for _, fk := range` loop would not stick).
+func retargetForeignKeys(fks []driver.ForeignKey, targetSchema string) {
+	for i := range fks {
+		fks[i].RefSchema = targetSchema
+	}
 }
 
 func normalizeTable(t driver.Table, norm func(string) string) driver.Table {

--- a/internal/schemadiff/diff.go
+++ b/internal/schemadiff/diff.go
@@ -123,6 +123,38 @@ func (d Diff) Normalize(norm func(string) string) Diff {
 	return out
 }
 
+// WithTargetSchema rewrites the Schema field on every Table inside the
+// diff to the supplied name. This is required before handing the diff to
+// the AI renderer because the structural diff carries the SOURCE schema
+// in Table.Schema (populated by the source driver's introspection), and
+// the AI tends to honor that field when emitting qualified ALTER TABLE
+// statements — producing ALTERs against the source schema name on the
+// target, which usually fails (e.g. MySQL source schema "smt_src_test"
+// against MSSQL target schema "dbo": "Cannot find the object …").
+//
+// Parallels Normalize: structural-only transformation, leaves all other
+// fields alone. Call after Normalize and before Render.
+func (d Diff) WithTargetSchema(targetSchema string) Diff {
+	out := Diff{
+		PrevCapturedAt: d.PrevCapturedAt,
+		CurrCapturedAt: d.CurrCapturedAt,
+	}
+	for _, t := range d.AddedTables {
+		t.Schema = targetSchema
+		out.AddedTables = append(out.AddedTables, t)
+	}
+	for _, t := range d.RemovedTables {
+		t.Schema = targetSchema
+		out.RemovedTables = append(out.RemovedTables, t)
+	}
+	for _, td := range d.ChangedTables {
+		td.Schema = targetSchema
+		td.Curr.Schema = targetSchema
+		out.ChangedTables = append(out.ChangedTables, td)
+	}
+	return out
+}
+
 func normalizeTable(t driver.Table, norm func(string) string) driver.Table {
 	t.Name = norm(t.Name)
 	for i := range t.Columns {

--- a/internal/schemadiff/diff_test.go
+++ b/internal/schemadiff/diff_test.go
@@ -291,6 +291,45 @@ func TestDiff_NormalizeRewritesIdentifiers(t *testing.T) {
 	}
 }
 
+// TestDiff_WithTargetSchemaRewritesTableSchema is a regression guard for
+// issue #4. The structural diff carries source schema names in
+// Table.Schema (populated by source introspection); when the AI sees
+// those values in the prompt JSON it emits ALTER TABLE qualified to the
+// source schema, which fails on the target. WithTargetSchema must
+// rewrite Schema across added / removed / changed tables.
+func TestDiff_WithTargetSchemaRewritesTableSchema(t *testing.T) {
+	prev := Snapshot{Tables: []driver.Table{
+		{Schema: "smt_src_test", Name: "kept", Columns: []driver.Column{col("Id", "int", false)}},
+		{Schema: "smt_src_test", Name: "dropped"},
+	}}
+	curr := Snapshot{Tables: []driver.Table{
+		{Schema: "smt_src_test", Name: "kept", Columns: []driver.Column{col("Id", "int", false), col("Email", "varchar", true)}},
+		{Schema: "smt_src_test", Name: "added"},
+	}}
+
+	d := Compute(prev, curr).WithTargetSchema("dbo")
+
+	check := func(label, got string) {
+		t.Helper()
+		if got != "dbo" {
+			t.Errorf("%s schema: got %q, want %q", label, got, "dbo")
+		}
+	}
+	if len(d.AddedTables) != 1 {
+		t.Fatalf("expected 1 added table, got %+v", d.AddedTables)
+	}
+	check("AddedTables[0]", d.AddedTables[0].Schema)
+	if len(d.RemovedTables) != 1 {
+		t.Fatalf("expected 1 removed table, got %+v", d.RemovedTables)
+	}
+	check("RemovedTables[0]", d.RemovedTables[0].Schema)
+	if len(d.ChangedTables) != 1 {
+		t.Fatalf("expected 1 changed table, got %+v", d.ChangedTables)
+	}
+	check("ChangedTables[0]", d.ChangedTables[0].Schema)
+	check("ChangedTables[0].Curr", d.ChangedTables[0].Curr.Schema)
+}
+
 func TestPlan_FilterByRisk(t *testing.T) {
 	plan := Plan{Statements: []Statement{
 		{SQL: "ALTER 1", Risk: RiskSafe},

--- a/internal/schemadiff/diff_test.go
+++ b/internal/schemadiff/diff_test.go
@@ -330,6 +330,75 @@ func TestDiff_WithTargetSchemaRewritesTableSchema(t *testing.T) {
 	check("ChangedTables[0].Curr", d.ChangedTables[0].Curr.Schema)
 }
 
+// TestDiff_WithTargetSchemaRewritesForeignKeyRefSchema is the second
+// regression guard for #4: foreign keys serialize ref_schema into the
+// AI prompt, so a same-schema FK addition that lands in the diff would
+// otherwise carry the source schema name and cause the AI to render
+// `REFERENCES smt_src_test.parent` against an MSSQL `dbo` target. Cover
+// AddedTables.ForeignKeys, ChangedTables.Curr.ForeignKeys, and the
+// AddedForeignKeys / RemovedForeignKeys slices.
+func TestDiff_WithTargetSchemaRewritesForeignKeyRefSchema(t *testing.T) {
+	srcFK := driver.ForeignKey{
+		Name: "fk_child_parent", Columns: []string{"parent_id"},
+		RefSchema: "smt_src_test", RefTable: "parent", RefColumns: []string{"id"},
+	}
+	addedFK := driver.ForeignKey{
+		Name: "fk_new", Columns: []string{"other_id"},
+		RefSchema: "smt_src_test", RefTable: "other", RefColumns: []string{"id"},
+	}
+	removedFK := driver.ForeignKey{
+		Name: "fk_legacy", RefSchema: "smt_src_test", RefTable: "legacy",
+	}
+
+	prev := Snapshot{Tables: []driver.Table{
+		{Schema: "smt_src_test", Name: "child", ForeignKeys: []driver.ForeignKey{srcFK}, Columns: []driver.Column{col("Id", "int", false)}},
+	}}
+	curr := Snapshot{Tables: []driver.Table{
+		{Schema: "smt_src_test", Name: "child", ForeignKeys: []driver.ForeignKey{srcFK}, Columns: []driver.Column{col("Id", "int", false), col("New", "int", true)}},
+		{Schema: "smt_src_test", Name: "fresh", ForeignKeys: []driver.ForeignKey{srcFK}},
+	}}
+
+	d := Compute(prev, curr)
+	// Compute only fills in column-level deltas — added/removed FKs come
+	// from the diff caller's caller. Inject them so we can verify the
+	// retarget paths for AddedForeignKeys / RemovedForeignKeys too.
+	d.ChangedTables[0].AddedForeignKeys = []driver.ForeignKey{addedFK}
+	d.ChangedTables[0].RemovedForeignKeys = []driver.ForeignKey{removedFK}
+
+	d = d.WithTargetSchema("dbo")
+
+	check := func(label, got string) {
+		t.Helper()
+		if got != "dbo" {
+			t.Errorf("%s ref_schema: got %q, want %q", label, got, "dbo")
+		}
+	}
+
+	if len(d.AddedTables) != 1 || len(d.AddedTables[0].ForeignKeys) != 1 {
+		t.Fatalf("expected 1 added table with 1 FK, got %+v", d.AddedTables)
+	}
+	check("AddedTables[0].ForeignKeys[0].RefSchema", d.AddedTables[0].ForeignKeys[0].RefSchema)
+
+	if len(d.ChangedTables) != 1 {
+		t.Fatalf("expected 1 changed table, got %+v", d.ChangedTables)
+	}
+	td := d.ChangedTables[0]
+	if len(td.Curr.ForeignKeys) != 1 {
+		t.Fatalf("expected Curr.ForeignKeys to be preserved, got %+v", td.Curr.ForeignKeys)
+	}
+	check("ChangedTables[0].Curr.ForeignKeys[0].RefSchema", td.Curr.ForeignKeys[0].RefSchema)
+
+	if len(td.AddedForeignKeys) != 1 {
+		t.Fatalf("expected 1 added FK, got %+v", td.AddedForeignKeys)
+	}
+	check("ChangedTables[0].AddedForeignKeys[0].RefSchema", td.AddedForeignKeys[0].RefSchema)
+
+	if len(td.RemovedForeignKeys) != 1 {
+		t.Fatalf("expected 1 removed FK, got %+v", td.RemovedForeignKeys)
+	}
+	check("ChangedTables[0].RemovedForeignKeys[0].RefSchema", td.RemovedForeignKeys[0].RefSchema)
+}
+
 func TestPlan_FilterByRisk(t *testing.T) {
 	plan := Plan{Statements: []Statement{
 		{SQL: "ALTER 1", Risk: RiskSafe},


### PR DESCRIPTION
## Summary

Fixes #4. The 9-direction sync test matrix surfaced a single failing combination: **MySQL → MSSQL**. The AI emitted `ALTER TABLE [smt_src_test].[Posts]` — using the source schema name (the MySQL database) instead of the target schema (`dbo`). MSSQL responded "Cannot find the object 'smt_src_test.Posts'".

This is the same class of bug as #1 (which was about source-vs-target identifier *case*). The diff payload carries source-side metadata in `driver.Table.Schema`, the AI sees it in the JSON prompt, and trusts it for the qualified ALTER even though the prompt also says `targetSchema = "dbo"`.

`Diff.Normalize` (added in PR #3) rewrites identifier *names* via the target dialect's normalizer, but does not touch the `Schema` field on the Table struct.

## Why most directions passed by accident

| | → MSSQL | → PG | → MySQL |
|---|---|---|---|
| **MSSQL →** | ✅ same `dbo`/`dbo` | ✅ AI picked `public` | ✅ AI picked `smt_tgt_test` |
| **PG →** | ✅ AI picked `dbo` | ✅ same `public`/`public` | ✅ AI picked `smt_tgt_test` |
| **MySQL →** | ❌ AI used source `smt_src_test` instead of target `dbo` | ✅ AI picked `public` | ✅ same DB pattern |

Same-engine self-loops share schema names, and most cross-engine pairs got the AI to override the source-schema hint. MySQL → MSSQL is where the AI doesn't.

## Fix

New `schemadiff.Diff.WithTargetSchema(name string) Diff`. Walks `AddedTables` / `RemovedTables` / `ChangedTables` (plus `ChangedTables[i].Curr`) and rewrites `Table.Schema` to the supplied name. Parallels `Diff.Normalize`: structural-only, leaves data types and other fields alone.

`cmd/smt/sync.go` now calls it right after `Normalize` and before `Render`:

```go
diff = diff.Normalize(func(name string) string { return driver.NormalizeIdentifier(cfg.Target.Type, name) })
diff = diff.WithTargetSchema(cfg.Target.Schema)
```

## Tests

- New `TestDiff_WithTargetSchemaRewritesTableSchema` covers `AddedTables`, `RemovedTables`, `ChangedTables`, and `ChangedTables[].Curr`.
- All existing tests still pass: `go test -short ./...` clean across 17 packages.

## Live verification

Re-ran the full 9-direction sync permutation matrix: each direction does `create → snapshot → mutate source → sync --apply → verify columns landed on target`. Same script, same data, same AI provider (haiku 4.5).

```
[mssql->mssql] PASS
[mssql->postgres] PASS
[mssql->mysql] PASS
[postgres->mssql] PASS
[postgres->postgres] PASS
[postgres->mysql] PASS
[mysql->mssql] PASS   ← previously failing
[mysql->postgres] PASS
[mysql->mysql] PASS
```

**9/9 PASS** vs. 8/9 before.

## Test plan

- [x] `go test -short ./...` (17 packages)
- [x] `gofmt -l .` clean
- [x] Live 9-direction sync matrix
- [ ] Reviewer eyeballs WithTargetSchema's coverage of TableDiff.Curr