### PR TITLE
Fix create-FK source-schema leak across all drivers

### DIFF
--- a/internal/driver/mssql/writer.go
+++ b/internal/driver/mssql/writer.go
@@ -541,12 +541,20 @@ func (w *Writer) CreateForeignKey(ctx context.Context, t *driver.Table, fk *driv
 		return fmt.Errorf("finalization mapper not available for foreign key creation")
 	}
 
+	// Override RefSchema with the target schema. The source FK metadata
+	// carries the source's schema name (e.g. "public" from PG), and the
+	// AI honors that field when emitting the REFERENCES clause —
+	// producing FKs that reference a schema that does not exist on the
+	// target. Same root cause as #4 / PR #5, applied to the create path.
+	fkForTarget := *fk
+	fkForTarget.RefSchema = targetSchema
+
 	ddl, err := w.finalizationMapper.GenerateFinalizationDDL(ctx, driver.FinalizationDDLRequest{
 		Type:          driver.DDLTypeForeignKey,
 		SourceDBType:  w.sourceType,
 		TargetDBType:  "mssql",
 		Table:         t,
-		ForeignKey:    fk,
+		ForeignKey:    &fkForTarget,
 		TargetSchema:  targetSchema,
 		TargetContext: w.dbContext,
 	})

--- a/internal/driver/mysql/writer.go
+++ b/internal/driver/mysql/writer.go
@@ -517,12 +517,21 @@ func (w *Writer) CreateForeignKey(ctx context.Context, t *driver.Table, fk *driv
 		return fmt.Errorf("finalization mapper not available for foreign key creation")
 	}
 
+	// Override RefSchema with the target schema. The source FK metadata
+	// carries the source's schema name (e.g. "public" from PG, "dbo"
+	// from MSSQL), and the AI honors that field when emitting the
+	// REFERENCES clause — producing FKs that reference a schema that
+	// does not exist on the MySQL target (where schema = database name).
+	// Same root cause as #4 / PR #5, applied to the create path.
+	fkForTarget := *fk
+	fkForTarget.RefSchema = targetSchema
+
 	ddl, err := w.finalizationMapper.GenerateFinalizationDDL(ctx, driver.FinalizationDDLRequest{
 		Type:          driver.DDLTypeForeignKey,
 		SourceDBType:  w.sourceType,
 		TargetDBType:  "mysql",
 		Table:         t,
-		ForeignKey:    fk,
+		ForeignKey:    &fkForTarget,
 		TargetSchema:  targetSchema,
 		TargetContext: w.dbContext,
 	})

--- a/internal/driver/postgres/writer.go
+++ b/internal/driver/postgres/writer.go
@@ -502,13 +502,21 @@ func (w *Writer) CreateForeignKey(ctx context.Context, t *driver.Table, fk *driv
 		return fmt.Errorf("finalization mapper not available for foreign key creation")
 	}
 
-	// Create copies with sanitized (lowercase) names for PostgreSQL
+	// Create copies with sanitized (lowercase) names for PostgreSQL.
+	// RefSchema is overridden to the target schema rather than copied from
+	// the source FK metadata: SMT migrates source.X to target.Y, so every
+	// schema reference in the generated DDL must resolve to the target.
+	// Without this override, the AI emits `REFERENCES dbo.SomeTable` (the
+	// source schema) on a PG target where the actual schema is `public`,
+	// causing CREATE FOREIGN KEY to fail with `schema "dbo" does not exist`.
+	// Same root cause as #4 / PR #5, applied to the create path instead
+	// of the sync path.
 	sanitizedTableName := sanitizePGIdentifier(t.Name)
 	sanitizedTable := &driver.Table{Name: sanitizedTableName}
 	sanitizedFK := &driver.ForeignKey{
 		Name:       sanitizePGIdentifier(fk.Name),
 		Columns:    make([]string, len(fk.Columns)),
-		RefSchema:  fk.RefSchema,
+		RefSchema:  targetSchema,
 		RefTable:   sanitizePGIdentifier(fk.RefTable),
 		RefColumns: make([]string, len(fk.RefColumns)),
 		OnDelete:   fk.OnDelete,


### PR DESCRIPTION
## Summary

Cross-engine `smt create` was emitting FOREIGN KEY DDL whose `REFERENCES` clause used the **source** schema name instead of the target's, causing the target DB to reject with errors like:

```
ERROR: schema "dbo" does not exist (SQLSTATE 3F000)
```

This is the same bug class as #4 (the source-schema leak in the sync path that PR #5 fixed) — but in a different code path (the per-FK create flow, not the sync diff renderer).

## Surfaced by CRM stress test

The simpler 9-table StackOverflow source/target test never tripped this because Haiku happened to guess the right schema. A larger 18-table CRM schema with 36 FKs reliably reproduces with Haiku:

```
Error: creating FK FK_Notes_Account: ERROR: schema "dbo" does not exist
```

Cloud Sonnet 4.6 doesn't trip it (probably picks up target context from elsewhere in the prompt). But Haiku is cheaper and faster, so it's worth fixing the underlying issue rather than recommending only Sonnet — and the fix is deterministic (override metadata before sending to AI), not a model-specific workaround.

## Fix

Each per-driver `CreateForeignKey` now builds a copy of the source FK with `RefSchema` overridden to the target schema before passing to the AI. SMT migrates source.X to target.Y; every schema reference in generated DDL must resolve to the target.

Three drivers, ~10 lines each:

- `internal/driver/postgres/writer.go:CreateForeignKey` — line 511 was the actual leak. Already built a `sanitizedFK` but copied `RefSchema: fk.RefSchema` unchanged. Changed to `RefSchema: targetSchema`.
- `internal/driver/mssql/writer.go:CreateForeignKey` — added `fkForTarget := *fk; fkForTarget.RefSchema = targetSchema`, passed to the AI request.
- `internal/driver/mysql/writer.go:CreateForeignKey` — same shape as mssql.

Same architectural pattern as PR #5's `Diff.WithTargetSchema` for the sync path — applied to the create path's per-FK code instead.

## Live verification

**CRM build with Haiku 4.5** (the failing path before the fix):

| | Before fix | After fix |
|---|---|---|
| Result | ❌ failed at first FK | ✅ complete |
| Time | 43s (failed) | 62s (success) |
| Tables | 18/18 ✓ | 18/18 ✓ |
| FKs | 0/36 (failed) | **36/36 ✓** |
| Checks | not reached | 14/14 ✓ |
| Identity cols | 16/16 ✓ | 16/16 ✓ |

Sample FK after fix: `FOREIGN KEY (accountid) REFERENCES accounts(id)` — clean, unqualified, no schema leak.

**Sync regression** (9-direction sync permutation matrix with Haiku):

```
[mssql->mssql]    PASS  (9s)
[mssql->postgres] PASS  (11s)
[mssql->mysql]    PASS  (12s)
[postgres->mssql] PASS  (11s)
[postgres->postgres] PASS  (3s)
[postgres->mysql] PASS  (11s)
[mysql->mssql]    PASS  (10s)
[mysql->postgres] PASS  (10s)
[mysql->mysql]    PASS  (11s)
```

**9/9 PASS** — sync path unaffected.

## Test plan

- [x] `go test -short ./...` (17 packages pass)
- [x] `gofmt -l .` clean
- [x] CRM build (MSSQL → PG, 18 tables / 36 FKs / 14 checks) with Haiku now completes
- [x] Sync 9-direction matrix with Haiku still 9/9
- [ ] Reviewer eyeballs all three drivers for consistency