### PR TITLE
Make model_temperature configurable per provider

### DIFF
--- a/internal/driver/ai_typemapper.go
+++ b/internal/driver/ai_typemapper.go
@@ -834,7 +834,7 @@ func (m *AITypeMapper) queryOpenAIAPIWithTokens(ctx context.Context, prompt stri
 			{Role: "user", Content: prompt},
 		},
 		MaxCompletionTokens: maxTokens,
-		Temperature:         0,
+		Temperature:         m.provider.GetEffectiveModelTemperature(),
 	}
 
 	jsonBody, err := json.Marshal(reqBody)
@@ -914,7 +914,7 @@ func (m *AITypeMapper) queryOpenAICompatAPIWithTokens(ctx context.Context, promp
 			{Role: "user", Content: prompt},
 		},
 		MaxCompletionTokens: maxTokens,
-		Temperature:         0,
+		Temperature:         m.provider.GetEffectiveModelTemperature(),
 	}
 
 	// For local providers (Ollama/LMStudio), use max_tokens (older OpenAI-compatible API)
@@ -1034,7 +1034,7 @@ func (m *AITypeMapper) queryGeminiAPI(ctx context.Context, prompt string) (strin
 		},
 		GenerationConfig: geminiGenConfig{
 			MaxOutputTokens: maxTokens,
-			Temperature:     0,
+			Temperature:     m.provider.GetEffectiveModelTemperature(),
 		},
 	}
 

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -550,10 +550,13 @@ ai:
     openai:
       api_key: ""  # Get from https://platform.openai.com/
       model: "gpt-4o"  # optional
+      # model_temperature: 1  # required when model is an OpenAI reasoning family
+      #                       # (o-series, gpt-5.x) — they reject the default 0
 
     gemini:
       api_key: ""  # Get from https://makersuite.google.com/
       model: "gemini-2.0-flash"  # optional
+      # model_temperature: 0  # optional sampling temperature (default 0 = deterministic)
 
     # Local providers (no API key needed)
     ollama:

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -74,12 +74,13 @@ type AIConfig struct {
 
 // Provider represents an AI provider configuration
 type Provider struct {
-	APIKey         string `yaml:"api_key,omitempty"`         // Required for cloud providers
-	BaseURL        string `yaml:"base_url,omitempty"`        // Required for local providers, optional for cloud
-	Model          string `yaml:"model,omitempty"`           // Optional, uses smart defaults
-	ContextWindow  int    `yaml:"context_window,omitempty"`  // Optional, context window size in tokens (for Ollama/local providers)
-	MaxTokens      int    `yaml:"max_tokens,omitempty"`      // Optional, max output tokens (default: 16000 for local, 4000 for cloud)
-	TimeoutSeconds int    `yaml:"timeout_seconds,omitempty"` // Optional, API timeout in seconds (default: 30 for cloud, 120 for local)
+	APIKey           string   `yaml:"api_key,omitempty"`           // Required for cloud providers
+	BaseURL          string   `yaml:"base_url,omitempty"`          // Required for local providers, optional for cloud
+	Model            string   `yaml:"model,omitempty"`             // Optional, uses smart defaults
+	ContextWindow    int      `yaml:"context_window,omitempty"`    // Optional, context window size in tokens (for Ollama/local providers)
+	MaxTokens        int      `yaml:"max_tokens,omitempty"`        // Optional, max output tokens (default: 16000 for local, 4000 for cloud)
+	TimeoutSeconds   int      `yaml:"timeout_seconds,omitempty"`   // Optional, API timeout in seconds (default: 30 for cloud, 120 for local)
+	ModelTemperature *float64 `yaml:"model_temperature,omitempty"` // Optional sampling temperature for the model. Defaults to 0 (deterministic). Some providers reject 0 for certain models — e.g. OpenAI reasoning models (o-series, gpt-5.x) require model_temperature: 1.
 }
 
 // EncryptionConfig holds encryption-related secrets
@@ -485,6 +486,18 @@ func (p *Provider) GetEffectiveMaxTokens(providerName string) int {
 		return 16000
 	}
 	return 4000
+}
+
+// GetEffectiveModelTemperature returns the sampling temperature for a provider's
+// model. Returns the configured value if set, otherwise 0 (deterministic).
+// Some providers reject 0 for certain models (e.g. OpenAI reasoning models
+// require model_temperature: 1) — set ModelTemperature explicitly in the
+// secrets file for those.
+func (p *Provider) GetEffectiveModelTemperature() float64 {
+	if p.ModelTemperature != nil {
+		return *p.ModelTemperature
+	}
+	return 0
 }
 
 // IsLocalProvider returns true if the provider is a local provider (no API key needed)

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -268,3 +268,25 @@ func containsHelper(s, substr string) bool {
 	}
 	return false
 }
+
+func TestGetEffectiveModelTemperature(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider Provider
+		want     float64
+	}{
+		{"unset returns 0 (deterministic default)", Provider{}, 0},
+		{"explicit 0 returns 0", Provider{ModelTemperature: floatPtr(0)}, 0},
+		{"explicit 1 returns 1 (for OpenAI reasoning models)", Provider{ModelTemperature: floatPtr(1)}, 1},
+		{"explicit 0.7 returns 0.7", Provider{ModelTemperature: floatPtr(0.7)}, 0.7},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.provider.GetEffectiveModelTemperature(); got != tt.want {
+				t.Errorf("GetEffectiveModelTemperature() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func floatPtr(f float64) *float64 { return &f }


### PR DESCRIPTION
## Summary

SMT hardcoded `temperature: 0` in every OpenAI and Gemini request body. OpenAI's reasoning-family models (o-series, gpt-5.x) reject any non-default temperature with HTTP 400, so SMT could not be pointed at gpt-5.5 or any o-series model — every CREATE TABLE call failed before reaching the model with:

> Unsupported value: 'temperature' does not support 0 with this model. Only the default (1) value is supported.

## Approach

Configuration, not code-level model detection. `Provider` gains an optional `ModelTemperature *float64` field (`yaml: model_temperature`). If set, the value is sent verbatim; if unset, defaults to 0 (preserves current behavior).

Users picking a reasoning model add one line to that provider's secrets block:

```yaml
openai:
  api_key: "sk-proj-..."
  model: "gpt-5.5"
  model_temperature: 1   # gpt-5.x and o-series require 1; default 0 won't work
```

**No model-name lists in code.** SMT doesn't try to predict which models need which value — the user knows their model better than we do, and a hardcoded list would rot the moment OpenAI ships the next family.

## Changes

- `Provider.ModelTemperature *float64` (yaml `model_temperature`, omitempty)
- `Provider.GetEffectiveModelTemperature()` returns the configured value or 0
- Both OpenAI request paths (`queryOpenAIAPIWithTokens` for cloud OpenAI; `queryOpenAICompatAPIWithTokens` for Ollama / LM Studio / generic OpenAI-compatible endpoints) and the Gemini path (`queryGeminiAPI`) now read from the helper instead of hardcoding `0`.
- Anthropic's request struct doesn't include `temperature` at all, so its server default is preserved (no change there).
- New `TestGetEffectiveModelTemperature` covering unset / explicit 0 / 1 / 0.7 cases.

## Verified

End-to-end smoke test: with `model_temperature: 1` on the openai provider block and `model: gpt-5.5`, `smt create` successfully built a test table with NOT NULL, IDENTITY, and `DEFAULT CURRENT_TIMESTAMP` column metadata preserved. ~12s wall for one table — slower than Haiku as expected for a reasoning model that spends tokens thinking.

```
=== gpt-5.5 smoke test (Tags table) ===
2026-05-02 20:34:18 [INFO]   ✓ [1/1] dbo.Tags
                                          Table "public.tags"
   Column   |              Type              | Nullable |             Default
------------+--------------------------------+----------+----------------------------------
 id         | integer                        | not null | generated by default as identity
 company_id | integer                        | not null |
 name       | character varying(50)          | not null |
 color      | character(7)                   |          |
 created_at | timestamp(6) without time zone | not null | CURRENT_TIMESTAMP
```

## Test plan

- [x] `make build` clean
- [x] `gofmt -l internal/` clean
- [x] `go test -short -race ./...` all pass
- [x] `TestGetEffectiveModelTemperature` covers unset/0/1/0.7
- [x] Live smoke test against gpt-5.5 succeeds with `model_temperature: 1`
- [ ] Reviewer: confirm no other code paths read provider temperature directly (only `GetEffectiveModelTemperature` should)
- [ ] Reviewer: regression-check Haiku and gpt-4o-mini still work with implicit default of 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)