### PR TITLE
Delegate type mapping to the AI; default to Sonnet 4.6

### DIFF
--- a/internal/driver/ai_typemapper.go
+++ b/internal/driver/ai_typemapper.go
@@ -1562,6 +1562,12 @@ func (m *AITypeMapper) writeMigrationRules(sb *strings.Builder, req TableDDLRequ
 	if (srcType == "postgres" || srcType == "mysql") && tgtType == "mssql" {
 		sb.WriteString("- MANDATORY: Every VARCHAR column MUST be NVARCHAR, every CHAR column MUST be NCHAR — using VARCHAR will corrupt multi-byte data because VARCHAR uses byte lengths while the source uses character lengths\n")
 	}
+	if srcType == "mssql" && tgtType == "postgres" {
+		sb.WriteString("- MANDATORY: PostgreSQL has no NVARCHAR/NCHAR/NTEXT types. Convert MSSQL national-character types: NVARCHAR(n) -> VARCHAR(n), NCHAR(n) -> CHAR(n), NTEXT -> TEXT, NVARCHAR(MAX) -> TEXT. Emitting NVARCHAR fails with 'type \"nvarchar\" does not exist'.\n")
+	}
+	if srcType == "mssql" && tgtType == "mysql" {
+		sb.WriteString("- MANDATORY: Convert MSSQL national-character types to MySQL standard types: NVARCHAR(n) -> VARCHAR(n), NCHAR(n) -> CHAR(n), NTEXT -> TEXT, NVARCHAR(MAX) -> LONGTEXT. The MySQL table charset (e.g. utf8mb4) already provides Unicode storage.\n")
+	}
 
 	// Reserved words note
 	sb.WriteString("\nReserved words: If any column name is a SQL reserved word, quote it appropriately for the target database.\n")

--- a/internal/driver/ai_typemapper.go
+++ b/internal/driver/ai_typemapper.go
@@ -1556,17 +1556,13 @@ func (m *AITypeMapper) writeMigrationRules(sb *strings.Builder, req TableDDLRequ
 	sb.WriteString("\nConversion guidance:\n")
 	m.writeConversionGuidance(sb, req.SourceContext, req.TargetContext)
 
-	// NVARCHAR guidance based on DB types — fires even when SourceContext is nil
-	srcType := Canonicalize(req.SourceDBType)
-	tgtType := Canonicalize(req.TargetDBType)
-	if (srcType == "postgres" || srcType == "mysql") && tgtType == "mssql" {
-		sb.WriteString("- MANDATORY: Every VARCHAR column MUST be NVARCHAR, every CHAR column MUST be NCHAR — using VARCHAR will corrupt multi-byte data because VARCHAR uses byte lengths while the source uses character lengths\n")
-	}
-	if srcType == "mssql" && tgtType == "postgres" {
-		sb.WriteString("- MANDATORY: PostgreSQL has no NVARCHAR/NCHAR/NTEXT types. Convert MSSQL national-character types: NVARCHAR(n) -> VARCHAR(n), NCHAR(n) -> CHAR(n), NTEXT -> TEXT, NVARCHAR(MAX) -> TEXT. Emitting NVARCHAR fails with 'type \"nvarchar\" does not exist'.\n")
-	}
-	if srcType == "mssql" && tgtType == "mysql" {
-		sb.WriteString("- MANDATORY: Convert MSSQL national-character types to MySQL standard types: NVARCHAR(n) -> VARCHAR(n), NCHAR(n) -> CHAR(n), NTEXT -> TEXT, NVARCHAR(MAX) -> LONGTEXT. The MySQL table charset (e.g. utf8mb4) already provides Unicode storage.\n")
+	// Type validity is the AI's job — SMT does not maintain a per-pair translation
+	// table. State the invariant once: every emitted type must exist in the target.
+	if Canonicalize(req.SourceDBType) != Canonicalize(req.TargetDBType) {
+		sb.WriteString("\nType validity (MANDATORY):\n")
+		sb.WriteString("- Every column type in the output CREATE TABLE must be a real, valid type in the target database. Do not pass through a source-only keyword (e.g. MSSQL NVARCHAR/NCHAR/NTEXT/UNIQUEIDENTIFIER/DATETIMEOFFSET, MySQL ENUM/SET/MEDIUMTEXT, PostgreSQL TEXT[]/JSONB).\n")
+		sb.WriteString("- For each source type, choose the target's closest semantic equivalent in storage class, length, precision, signedness, timezone-awareness, and Unicode capability. If the target charset already provides Unicode storage, prefer the standard type over a national-character variant.\n")
+		sb.WriteString("- If unsure whether a keyword is valid in the target, pick the safest standard SQL type that preserves semantics. Never invent a type name.\n")
 	}
 
 	// Reserved words note

--- a/internal/driver/ai_typemapper_test.go
+++ b/internal/driver/ai_typemapper_test.go
@@ -88,7 +88,7 @@ func TestNewAITypeMapper_DefaultModel(t *testing.T) {
 		provider      string
 		expectedModel string
 	}{
-		{"anthropic", "claude-haiku-4-5-20251001"},
+		{"anthropic", "claude-sonnet-4-6"},
 		{"openai", "gpt-4o"},
 		{"gemini", "gemini-2.0-flash"},
 		{"ollama", "llama3"},
@@ -1373,55 +1373,21 @@ func TestBuildTableDDLPrompt_SameEngine_NoAnnotations(t *testing.T) {
 	}
 }
 
-func TestBuildTableDDLPrompt_NTypeConversionGuidance(t *testing.T) {
+func TestBuildTableDDLPrompt_TypeValidityRule(t *testing.T) {
 	mapper := testMapperWithTempCache(t, "anthropic", testProvider("test-key"))
 
 	tests := []struct {
 		name         string
 		sourceDBType string
 		targetDBType string
-		wantContains []string
-		wantAbsent   []string
+		wantValidity bool
 	}{
-		{
-			name:         "mssql to postgres mandates nvarchar removal",
-			sourceDBType: "mssql",
-			targetDBType: "postgres",
-			wantContains: []string{
-				"PostgreSQL has no NVARCHAR/NCHAR/NTEXT types",
-				"NVARCHAR(n) -> VARCHAR(n)",
-				"NTEXT -> TEXT",
-			},
-		},
-		{
-			name:         "mssql to mysql mandates nvarchar removal",
-			sourceDBType: "mssql",
-			targetDBType: "mysql",
-			wantContains: []string{
-				"NVARCHAR(n) -> VARCHAR(n)",
-				"NVARCHAR(MAX) -> LONGTEXT",
-			},
-		},
-		{
-			name:         "postgres to mssql still mandates nvarchar use",
-			sourceDBType: "postgres",
-			targetDBType: "mssql",
-			wantContains: []string{
-				"Every VARCHAR column MUST be NVARCHAR",
-			},
-			wantAbsent: []string{
-				"PostgreSQL has no NVARCHAR",
-			},
-		},
-		{
-			name:         "same engine has no nvarchar conversion guidance",
-			sourceDBType: "postgres",
-			targetDBType: "postgres",
-			wantAbsent: []string{
-				"PostgreSQL has no NVARCHAR",
-				"Every VARCHAR column MUST be NVARCHAR",
-			},
-		},
+		{"mssql to postgres includes type-validity rule", "mssql", "postgres", true},
+		{"postgres to mssql includes type-validity rule", "postgres", "mssql", true},
+		{"mssql to mysql includes type-validity rule", "mssql", "mysql", true},
+		{"mysql to postgres includes type-validity rule", "mysql", "postgres", true},
+		{"same engine omits type-validity rule", "postgres", "postgres", false},
+		{"same engine mssql omits type-validity rule", "mssql", "mssql", false},
 	}
 
 	for _, tt := range tests {
@@ -1438,17 +1404,46 @@ func TestBuildTableDDLPrompt_NTypeConversionGuidance(t *testing.T) {
 				},
 			}
 			prompt := mapper.buildTableDDLPrompt(req)
-			for _, want := range tt.wantContains {
-				if !strings.Contains(prompt, want) {
-					t.Errorf("prompt should contain %q\nprompt:\n%s", want, prompt)
-				}
-			}
-			for _, absent := range tt.wantAbsent {
-				if strings.Contains(prompt, absent) {
-					t.Errorf("prompt should NOT contain %q\nprompt:\n%s", absent, prompt)
-				}
+			marker := "Type validity (MANDATORY):"
+			has := strings.Contains(prompt, marker)
+			if has != tt.wantValidity {
+				t.Errorf("prompt contains %q = %v, want %v\nprompt:\n%s", marker, has, tt.wantValidity, prompt)
 			}
 		})
+	}
+}
+
+// Make sure the prompt does not regress into a hand-coded translation table.
+// The whole point is that SMT delegates type mapping to the AI — if a per-pair
+// "MSSQL X -> PG Y" enumeration shows up here again, it should be deleted in
+// favor of the general type-validity rule.
+func TestBuildTableDDLPrompt_NoHardcodedTypeMappings(t *testing.T) {
+	mapper := testMapperWithTempCache(t, "anthropic", testProvider("test-key"))
+
+	req := TableDDLRequest{
+		SourceDBType: "mssql",
+		TargetDBType: "postgres",
+		SourceTable: &Table{
+			Name:       "T",
+			Columns:    []Column{{Name: "id", DataType: "int", IsNullable: false}},
+			PrimaryKey: []string{"id"},
+		},
+	}
+	prompt := mapper.buildTableDDLPrompt(req)
+
+	// These are the kinds of explicit mappings we deliberately do NOT include.
+	// If you find yourself wanting to add one, fix the model or sharpen the
+	// general rule instead.
+	forbidden := []string{
+		"NVARCHAR(n) -> VARCHAR(n)",
+		"NCHAR(n) -> CHAR(n)",
+		"NTEXT -> TEXT",
+		"NVARCHAR(MAX) -> LONGTEXT",
+	}
+	for _, f := range forbidden {
+		if strings.Contains(prompt, f) {
+			t.Errorf("prompt contains hand-coded type mapping %q — delegate to the AI instead", f)
+		}
 	}
 }
 

--- a/internal/driver/ai_typemapper_test.go
+++ b/internal/driver/ai_typemapper_test.go
@@ -1373,6 +1373,85 @@ func TestBuildTableDDLPrompt_SameEngine_NoAnnotations(t *testing.T) {
 	}
 }
 
+func TestBuildTableDDLPrompt_NTypeConversionGuidance(t *testing.T) {
+	mapper := testMapperWithTempCache(t, "anthropic", testProvider("test-key"))
+
+	tests := []struct {
+		name         string
+		sourceDBType string
+		targetDBType string
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name:         "mssql to postgres mandates nvarchar removal",
+			sourceDBType: "mssql",
+			targetDBType: "postgres",
+			wantContains: []string{
+				"PostgreSQL has no NVARCHAR/NCHAR/NTEXT types",
+				"NVARCHAR(n) -> VARCHAR(n)",
+				"NTEXT -> TEXT",
+			},
+		},
+		{
+			name:         "mssql to mysql mandates nvarchar removal",
+			sourceDBType: "mssql",
+			targetDBType: "mysql",
+			wantContains: []string{
+				"NVARCHAR(n) -> VARCHAR(n)",
+				"NVARCHAR(MAX) -> LONGTEXT",
+			},
+		},
+		{
+			name:         "postgres to mssql still mandates nvarchar use",
+			sourceDBType: "postgres",
+			targetDBType: "mssql",
+			wantContains: []string{
+				"Every VARCHAR column MUST be NVARCHAR",
+			},
+			wantAbsent: []string{
+				"PostgreSQL has no NVARCHAR",
+			},
+		},
+		{
+			name:         "same engine has no nvarchar conversion guidance",
+			sourceDBType: "postgres",
+			targetDBType: "postgres",
+			wantAbsent: []string{
+				"PostgreSQL has no NVARCHAR",
+				"Every VARCHAR column MUST be NVARCHAR",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := TableDDLRequest{
+				SourceDBType: tt.sourceDBType,
+				TargetDBType: tt.targetDBType,
+				SourceTable: &Table{
+					Name: "T",
+					Columns: []Column{
+						{Name: "id", DataType: "int", IsNullable: false},
+					},
+					PrimaryKey: []string{"id"},
+				},
+			}
+			prompt := mapper.buildTableDDLPrompt(req)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(prompt, want) {
+					t.Errorf("prompt should contain %q\nprompt:\n%s", want, prompt)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(prompt, absent) {
+					t.Errorf("prompt should NOT contain %q\nprompt:\n%s", absent, prompt)
+				}
+			}
+		})
+	}
+}
+
 func TestWriteIdentifierGuidance_SameEngine(t *testing.T) {
 	mapper := testMapperWithTempCache(t, "anthropic", testProvider("test-key"))
 

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -118,9 +118,13 @@ var KnownProviders = map[string]struct {
 	"lmstudio":  {ProviderTypeLocal, "http://localhost:1234"},
 }
 
-// DefaultModels maps providers to their default models
+// DefaultModels maps providers to their default models.
+// Anthropic default is Sonnet because table-DDL generation is a multi-page,
+// judgment-heavy prompt where Haiku has been observed to translate the same
+// type inconsistently between tables. The volume is low (one call per table,
+// cached) so Sonnet's cost is not a concern.
 var DefaultModels = map[string]string{
-	"anthropic": "claude-haiku-4-5-20251001",
+	"anthropic": "claude-sonnet-4-6",
 	"openai":    "gpt-4o",
 	"gemini":    "gemini-2.0-flash",
 	"ollama":    "llama3",
@@ -545,7 +549,7 @@ ai:
     # Cloud providers (require API key)
     anthropic:
       api_key: ""  # Get from https://console.anthropic.com/
-      model: "claude-haiku-4-5-20251001"  # optional
+      model: "claude-sonnet-4-6"  # optional
 
     openai:
       api_key: ""  # Get from https://platform.openai.com/

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -136,7 +136,7 @@ func TestGetEffectiveModel(t *testing.T) {
 
 	// Should return default model when not specified
 	model := provider.GetEffectiveModel("anthropic")
-	if model != "claude-haiku-4-5-20251001" {
+	if model != "claude-sonnet-4-6" {
 		t.Errorf("Expected default Anthropic model, got %q", model)
 	}
 


### PR DESCRIPTION
## Summary
A `smt create` mssql -> postgres run on the CRM fixture failed with `type "nvarchar" does not exist`. Same source column type, same prompt, different result per table — the AI translated `Departments.name` correctly but left `Companies.name` as `nvarchar(200)`. Two problems showed up:

1. **The prompt was telling the AI how to map types.** A `postgres -> mssql` MANDATORY rule already existed; the obvious fix was to add the symmetric `mssql -> postgres` rule (and one for `mssql -> mysql`). That's what the first commit on this branch did. But this is exactly what CLAUDE.md says not to do — "if you find yourself writing SQL syntax in Go code... that's AI work" — and it only covers the types we anticipated. MSSQL `geography`, `hierarchyid`, MySQL `ENUM`/`SET`, etc. would still slip through.

2. **The model couldn't be trusted on a multi-page judgment prompt.** Inconsistency on the same trivial translation is a capability symptom, not a prompt-coverage one. Haiku 4.5 is fine for the cached single-cell `MapType` calls but not for table-DDL generation.

This PR (second commit) replaces the per-pair rules with one general invariant and bumps the default model to Sonnet 4.6.

## Changes
- `internal/driver/ai_typemapper.go`: delete the three per-pair MANDATORY blocks. Replace with one rule the AI must satisfy: every emitted type must be valid in the target dialect, mapped by closest semantic equivalence. Fires for any cross-engine pair, not an enumerated list.
- `internal/secrets/secrets.go`: `DefaultModels["anthropic"]` from `claude-haiku-4-5-20251001` -> `claude-sonnet-4-6`. Comment captures the reasoning. Updates `init-secrets` template + the test that asserts the default.
- `internal/driver/ai_typemapper_test.go`: replace the per-pair-rule test with `TestBuildTableDDLPrompt_TypeValidityRule` (covers all four cross-engine pairs + same-engine no-op) and add `TestBuildTableDDLPrompt_NoHardcodedTypeMappings` to guard against the per-pair pattern reappearing.

## Verification (mssql -> postgres CRM fixture, Sonnet 4.6, lean prompt)
- 14/14 tables, 22 FKs, all checks created. Total run 24s.
- Spot-check on the trickier mssql types — all chosen by the model, no hand-coded mapping:
  - `NVARCHAR(200)` -> `character varying`
  - `NVARCHAR(MAX)` -> `text`
  - `UNIQUEIDENTIFIER` -> `uuid`
  - `DATETIMEOFFSET` -> `timestamp with time zone`
  - `BIT` -> `boolean`

## Test plan
- [x] `go test -short ./...`
- [x] `go test -run TestBuildTableDDLPrompt ./internal/driver/`
- [x] End-to-end CRM mssql -> postgres migration on Sonnet succeeds with the leaner prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)