### PR TITLE
Trim auto-generated identifier rules from AI prompt

### DIFF
--- a/internal/driver/ai_typemapper.go
+++ b/internal/driver/ai_typemapper.go
@@ -1541,11 +1541,11 @@ func (m *AITypeMapper) writeMigrationRules(sb *strings.Builder, req TableDDLRequ
 
 	sb.WriteString("\n")
 
-	// Target database rules - derived from TargetContext.
-	// Identifier rules deliberately omitted: target column names are pre-resolved
-	// in REQUIRED TARGET COLUMN NAMES, the target table name is given in OUTPUT
-	// REQUIRED, and the target dialect's AIPromptAugmentation supplies any
-	// dialect-specific case-folding rules.
+	// Target database rules - derived from TargetContext. Identifier rules
+	// deliberately omitted: target column names are pre-resolved in
+	// REQUIRED TARGET COLUMN NAMES, the target table name is given in
+	// OUTPUT REQUIREMENTS, and each target dialect's AIPromptAugmentation
+	// supplies any dialect-specific case-folding rules.
 	sb.WriteString("Target database rules:\n")
 	if req.TargetContext != nil {
 		m.writeVarcharGuidance(sb, req.TargetContext, "target")

--- a/internal/driver/ai_typemapper.go
+++ b/internal/driver/ai_typemapper.go
@@ -1541,12 +1541,15 @@ func (m *AITypeMapper) writeMigrationRules(sb *strings.Builder, req TableDDLRequ
 
 	sb.WriteString("\n")
 
-	// Target database rules - derived from TargetContext
+	// Target database rules - derived from TargetContext.
+	// Identifier rules deliberately omitted: target column names are pre-resolved
+	// in REQUIRED TARGET COLUMN NAMES, the target table name is given in OUTPUT
+	// REQUIRED, and the target dialect's AIPromptAugmentation supplies any
+	// dialect-specific case-folding rules.
 	sb.WriteString("Target database rules:\n")
 	if req.TargetContext != nil {
 		m.writeVarcharGuidance(sb, req.TargetContext, "target")
 		m.writeEncodingGuidance(sb, req.TargetContext, "target")
-		m.writeIdentifierGuidance(sb, req.TargetContext, req.SourceDBType, req.TargetDBType)
 		m.writeLimitsGuidance(sb, req.TargetContext)
 	} else {
 		sb.WriteString("- No target context available, use standard type mappings\n")
@@ -1621,36 +1624,6 @@ func (m *AITypeMapper) writeEncodingGuidance(sb *strings.Builder, ctx *DatabaseC
 	}
 	if ctx.Encoding != "" && ctx.Encoding != ctx.Charset {
 		sb.WriteString(fmt.Sprintf("- Encoding: %s\n", ctx.Encoding))
-	}
-}
-
-// writeIdentifierGuidance writes identifier handling guidance based on context.
-func (m *AITypeMapper) writeIdentifierGuidance(sb *strings.Builder, ctx *DatabaseContext, sourceDBType, targetDBType string) {
-	if ctx.IdentifierCase != "" {
-		switch strings.ToLower(ctx.IdentifierCase) {
-		case "upper":
-			sb.WriteString("- CRITICAL: Unquoted identifiers are folded to UPPERCASE\n")
-			sb.WriteString("- Use UPPERCASE for all unquoted table and column names\n")
-			sb.WriteString("- Only quote identifiers that are reserved words\n")
-		case "lower":
-			if Canonicalize(sourceDBType) == Canonicalize(targetDBType) {
-				sb.WriteString("- CRITICAL: Source and target are the same database engine\n")
-				sb.WriteString("- Preserve ALL source column and table names EXACTLY as-is, including underscores\n")
-				sb.WriteString("- Do NOT remove, add, or modify any characters in identifier names\n")
-				sb.WriteString("- Example: user_id -> user_id (NOT userid)\n")
-				sb.WriteString("- Example: created_at -> created_at (NOT createdat)\n")
-			} else {
-				sb.WriteString("- CRITICAL: Unquoted identifiers are folded to lowercase\n")
-				sb.WriteString("- Use lowercase for all table and column names (e.g., UserId -> userid, not user_id)\n")
-				sb.WriteString("- Do NOT convert to snake_case - just lowercase the original name directly\n")
-			}
-		case "preserve":
-			sb.WriteString("- Identifier case is preserved as written\n")
-		}
-	}
-
-	if ctx.CaseSensitiveIdentifiers {
-		sb.WriteString("- Identifiers are case-sensitive when quoted\n")
 	}
 }
 

--- a/internal/driver/ai_typemapper_test.go
+++ b/internal/driver/ai_typemapper_test.go
@@ -1447,71 +1447,47 @@ func TestBuildTableDDLPrompt_NoHardcodedTypeMappings(t *testing.T) {
 	}
 }
 
-func TestWriteIdentifierGuidance_SameEngine(t *testing.T) {
+// The auto-generated identifier guidance was removed because target identifier
+// rules are already covered by:
+//   - REQUIRED TARGET COLUMN NAMES (explicit per-column mapping)
+//   - OUTPUT REQUIREMENTS (explicit fully-qualified target table name)
+//   - Each target dialect's AIPromptAugmentation (case-folding rules)
+// Guard against the auto-generated guidance creeping back in.
+func TestBuildTableDDLPrompt_NoAutoIdentifierRules(t *testing.T) {
 	mapper := testMapperWithTempCache(t, "anthropic", testProvider("test-key"))
 
-	tests := []struct {
-		name         string
-		sourceDBType string
-		targetDBType string
-		wantContains []string
-		wantAbsent   []string
-	}{
-		{
-			name:         "same engine preserves identifiers",
-			sourceDBType: "postgres",
-			targetDBType: "postgres",
-			wantContains: []string{
-				"Source and target are the same database engine",
-				"Preserve ALL source column and table names EXACTLY as-is",
-				"user_id -> user_id (NOT userid)",
-				"created_at -> created_at (NOT createdat)",
-			},
-			wantAbsent: []string{
-				"UserId -> userid",
-			},
-		},
-		{
-			name:         "same engine mssql",
-			sourceDBType: "mssql",
-			targetDBType: "mssql",
-			wantContains: []string{
-				"Source and target are the same database engine",
-				"Preserve ALL source column and table names EXACTLY as-is",
-			},
-			wantAbsent: []string{
-				"UserId -> userid",
-			},
-		},
-		{
-			name:         "cross engine uses lowercase guidance",
-			sourceDBType: "mssql",
-			targetDBType: "postgres",
-			wantContains: []string{
-				"Unquoted identifiers are folded to lowercase",
-				"UserId -> userid",
-			},
-			wantAbsent: []string{
-				"Source and target are the same database engine",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var sb strings.Builder
-			ctx := &DatabaseContext{IdentifierCase: "lower"}
-			mapper.writeIdentifierGuidance(&sb, ctx, tt.sourceDBType, tt.targetDBType)
-			result := sb.String()
-
-			for _, want := range tt.wantContains {
-				if !strings.Contains(result, want) {
-					t.Errorf("expected guidance to contain %q, got:\n%s", want, result)
-				}
+	for _, pair := range []struct{ src, tgt string }{
+		{"mssql", "postgres"},
+		{"postgres", "mssql"},
+		{"mysql", "postgres"},
+		{"postgres", "postgres"},
+		{"mssql", "mssql"},
+	} {
+		t.Run(pair.src+"_to_"+pair.tgt, func(t *testing.T) {
+			req := TableDDLRequest{
+				SourceDBType: pair.src,
+				TargetDBType: pair.tgt,
+				TargetContext: &DatabaseContext{
+					IdentifierCase: "lower", // would have triggered the deleted block
+				},
+				SourceTable: &Table{
+					Name:       "T",
+					Columns:    []Column{{Name: "id", DataType: "int", IsNullable: false}},
+					PrimaryKey: []string{"id"},
+				},
 			}
-			for _, absent := range tt.wantAbsent {
-				if strings.Contains(result, absent) {
-					t.Errorf("expected guidance NOT to contain %q, got:\n%s", absent, result)
+			prompt := mapper.buildTableDDLPrompt(req)
+
+			forbidden := []string{
+				"Unquoted identifiers are folded to lowercase",
+				"Use lowercase for all table and column names",
+				"Do NOT convert to snake_case",
+				"Source and target are the same database engine",
+				"Preserve ALL source column and table names EXACTLY as-is",
+			}
+			for _, f := range forbidden {
+				if strings.Contains(prompt, f) {
+					t.Errorf("prompt contains auto-generated identifier rule %q — let the dialect or REQUIRED TARGET COLUMN NAMES be the voice on identifiers", f)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary
Captured a real production prompt under `--verbosity debug` and noticed the MIGRATION RULES section emits identifier guidance that's already covered three other ways in the same prompt:

- **REQUIRED TARGET COLUMN NAMES** — SMT pre-resolves every target column name via `targetIdentifier()` and tells the AI "you MUST use exactly these column names". The AI literally cannot make a column-name case error if it follows this section.
- **OUTPUT REQUIREMENTS** — gives the exact fully-qualified target table name (`Use fully qualified table name: public.tags`).
- **Target dialect's `AIPromptAugmentation`** — for postgres, covers lowercase folding, underscore preservation, CamelCase rules, examples, and double-quote semantics in more detail than the auto-generated guidance ever did.

Despite this, `writeIdentifierGuidance` was emitting a fourth source of identifier rules into the MIGRATION RULES section, derived from `TargetContext.IdentifierCase`:

```
- CRITICAL: Unquoted identifiers are folded to lowercase
- Use lowercase for all table and column names (e.g., UserId -> userid, not user_id)
- Do NOT convert to snake_case - just lowercase the original name directly
- Identifiers are case-sensitive when quoted
```

Delete `writeIdentifierGuidance` and its call site. The prompt loses 4 lines on a typical mssql -> postgres run; nothing else moves.

## Verification
- `go test -short ./...` — green
- End-to-end CRM mssql -> postgres on Sonnet 4.6 with cleared cache: 14 tables, 22 FKs, 135 checks. Identical schema to before this PR.

## Test changes
- Delete `TestWriteIdentifierGuidance_SameEngine` (it tested the now-removed function directly).
- Add `TestBuildTableDDLPrompt_NoAutoIdentifierRules` covering all 5 source/target combos that previously triggered the function. It asserts the auto-generated strings stay out of the prompt — a guard against the function quietly coming back.

## Test plan
- [x] `go test -short ./...`
- [x] `go test -run TestBuildTableDDLPrompt ./internal/driver/`
- [x] CRM mssql -> postgres end-to-end migration produces identical schema

## Related
- Issue #13 (separate concern: SourceContext is never populated, so the source half of the prompt is empty regardless of this trim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)