### PR TITLE
Tighten MySQL EXTRA generated-column detection to real markers (closes #18)

### DIFF
--- a/internal/driver/mysql/reader.go
+++ b/internal/driver/mysql/reader.go
@@ -193,6 +193,31 @@ func (r *Reader) applyActualRowSizes(ctx context.Context, dbName string, tables 
 	}
 }
 
+// parseGeneratedColumnExtra inspects the value of information_schema.COLUMNS.EXTRA
+// and reports whether the column is a true generated/computed column (and, if so,
+// whether it is STORED).
+//
+// MySQL 8.0.13+ writes a few different markers to EXTRA:
+//
+//   - "VIRTUAL GENERATED"   — generated column, computed on read
+//   - "STORED GENERATED"    — generated column, materialized on write
+//   - "DEFAULT_GENERATED"   — *not* a generated column; just a marker that the
+//     column has an expression default (e.g. "DEFAULT CURRENT_TIMESTAMP" or
+//     any function default introduced in 8.0.13). Easy to misread because it
+//     also contains the substring "GENERATED".
+//
+// A naïve substring check on "GENERATED" misclassifies the third case as a
+// generated column and wipes its real default — see issue #18.
+func parseGeneratedColumnExtra(extra string) (computed, persisted bool) {
+	switch {
+	case strings.Contains(extra, "STORED GENERATED"):
+		return true, true
+	case strings.Contains(extra, "VIRTUAL GENERATED"):
+		return true, false
+	}
+	return false, false
+}
+
 func (r *Reader) loadColumns(ctx context.Context, t *driver.Table) error {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT
@@ -224,12 +249,13 @@ func (r *Reader) loadColumns(ctx context.Context, t *driver.Table) error {
 			&c.DefaultExpression, &extra, &generationExpr); err != nil {
 			return fmt.Errorf("scanning column: %w", err)
 		}
-		// MySQL signals generated columns via EXTRA: "VIRTUAL GENERATED" or "STORED GENERATED".
-		if strings.Contains(extra, "GENERATED") {
+		if computed, persisted := parseGeneratedColumnExtra(extra); computed {
 			c.IsComputed = true
 			c.ComputedExpression = generationExpr
-			c.ComputedPersisted = strings.Contains(extra, "STORED")
-			// generated columns can't have a regular DEFAULT
+			c.ComputedPersisted = persisted
+			// Generated columns don't carry a regular DEFAULT clause; clear
+			// any value information_schema reports here so the downstream
+			// prompt doesn't double-emit.
 			c.DefaultExpression = ""
 		}
 		t.Columns = append(t.Columns, c)

--- a/internal/driver/mysql/reader_test.go
+++ b/internal/driver/mysql/reader_test.go
@@ -1,0 +1,45 @@
+package mysql
+
+import "testing"
+
+// TestParseGeneratedColumnExtra is the regression test for issue #18.
+// MySQL 8.0.13+ writes "DEFAULT_GENERATED" into information_schema.COLUMNS.EXTRA
+// for any column with an expression default (e.g. "DEFAULT CURRENT_TIMESTAMP"),
+// and that string contains the substring "GENERATED". The pre-fix code
+// substring-matched "GENERATED" and misclassified every such column as a true
+// generated/computed column — wiping its real default in the process and
+// breaking every mysql-source migration on the first table with an audit
+// timestamp column.
+func TestParseGeneratedColumnExtra(t *testing.T) {
+	tests := []struct {
+		extra         string
+		wantComputed  bool
+		wantPersisted bool
+	}{
+		// Real generated columns
+		{"VIRTUAL GENERATED", true, false},
+		{"STORED GENERATED", true, true},
+
+		// The bug case: expression default, NOT a generated column
+		{"DEFAULT_GENERATED", false, false},
+
+		// Expression default combined with auto-update (common on TIMESTAMP)
+		{"DEFAULT_GENERATED on update CURRENT_TIMESTAMP", false, false},
+
+		// Other EXTRA values that must not match
+		{"", false, false},
+		{"auto_increment", false, false},
+		{"on update CURRENT_TIMESTAMP", false, false},
+		{"INVISIBLE", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.extra, func(t *testing.T) {
+			gotComputed, gotPersisted := parseGeneratedColumnExtra(tt.extra)
+			if gotComputed != tt.wantComputed || gotPersisted != tt.wantPersisted {
+				t.Errorf("parseGeneratedColumnExtra(%q) = (computed=%v, persisted=%v), want (%v, %v)",
+					tt.extra, gotComputed, gotPersisted, tt.wantComputed, tt.wantPersisted)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #18.

`information_schema.COLUMNS.EXTRA` returns multiple values containing the substring `"GENERATED"` in MySQL 8.0.13+:

- `"VIRTUAL GENERATED"` — generated column, computed on read
- `"STORED GENERATED"` — generated column, materialized on write
- `"DEFAULT_GENERATED"` — **not** a generated column; just a marker that the column has an expression default (e.g. `DEFAULT CURRENT_TIMESTAMP` or any function default introduced in 8.0.13)

The pre-fix code substring-matched `"GENERATED"` and misclassified the third case as a true generated column, wiping its `DefaultExpression`. The AI then saw `computed: true, computed_expression: "", computed_storage: VIRTUAL` and translated as a generated column on the target — wrong on every dialect because the expression is empty.

Effect on the matrix: every mysql-source migration on the CRM fixture failed at the first table containing an audit timestamp column (essentially every real OLTP table). All three `mysql → *` pairs were blocked by this one substring-match bug.

## Fix

Extract the EXTRA-parsing into a small helper `parseGeneratedColumnExtra(extra) (computed, persisted bool)` and match the actual markers explicitly. The behavior collapses cleanly to two `strings.Contains` calls for the real markers; everything else (including the load-bearing `DEFAULT_GENERATED` case) returns `(false, false)` and the column keeps its real `DefaultExpression`.

## Tests

`TestParseGeneratedColumnExtra` (new, 8 cases):
- `"VIRTUAL GENERATED"` → `(true, false)` ✓
- `"STORED GENERATED"` → `(true, true)` ✓
- `"DEFAULT_GENERATED"` → `(false, false)` ← **the bug case**
- `"DEFAULT_GENERATED on update CURRENT_TIMESTAMP"` → `(false, false)`
- `""` / `"auto_increment"` / `"on update CURRENT_TIMESTAMP"` / `"INVISIBLE"` → all `(false, false)`

Full suite still green (`go test -short -race ./...`).

## End-to-end verification (Sonnet 4.6, mysql → pg)

Loaded `testdata/crm/crm_mysql.sql` → migrated to PG → counts match source exactly:

| metric | source (mysql) | target (pg) | status |
|--------|----------------|-------------|--------|
| tables | 14 | 14 | ✅ |
| FKs | 22 | 22 | ✅ |
| CHECK constraints | 36 | 36 | ✅ |
| auto_inc / IDENTITY | 12 | 12 | ✅ |
| true generated columns | 3 | 3 | ✅ |
| NOT NULL | 106 | 106 | ✅ |
| defaults | 45 | 45 | ✅ |

Wall time: 23s. Key columns verified post-migration:

```
table_name    | column_name | data_type | nullable | default           | is_generated
customer_tags | tagged_at   | timestamp | NO       | CURRENT_TIMESTAMP | NEVER     ✅
employees     | hire_date   | timestamp | NO       | CURRENT_TIMESTAMP | NEVER     ✅
employees     | full_name   | varchar   | YES      | (none)            | ALWAYS    ✅
```

Note on Haiku: end-to-end runs on Haiku also progress well past pre-fix behavior (12 of 14 tables vs failing at table 1) but exhibit non-deterministic AI translation flakes on `DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6)` columns. This is variance in the AI, not a code bug, and Sonnet (the project default per #16) handles it correctly. Keeping that note here as context, not as a follow-up.

## Test plan

- [x] `make build` clean
- [x] `gofmt -l internal/` clean
- [x] `go test -short -race ./...` all pass
- [x] New `TestParseGeneratedColumnExtra` 8/8 pass
- [x] Live mysql → pg run with Sonnet completes 14/14 with exact-match column counts
- [ ] Reviewer: optionally test against your own MySQL 8.0.13+ database with `DEFAULT CURRENT_TIMESTAMP` columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)