### PR TITLE
Populate SourceContext in the AI prompt (closes #13)

### DIFF
--- a/internal/driver/mssql/driver_test.go
+++ b/internal/driver/mssql/driver_test.go
@@ -1,11 +1,31 @@
 package mssql
 
 import (
+	"os"
 	"strings"
 	"testing"
 
 	"smt/internal/driver"
 )
+
+// TestReaderDatabaseContext_Populated is the mssql side of the issue #13
+// regression guard. Mirrors the postgres/mysql tests.
+func TestReaderDatabaseContext_Populated(t *testing.T) {
+	src, err := os.ReadFile("reader.go")
+	if err != nil {
+		t.Fatalf("read reader.go: %v", err)
+	}
+	body := string(src)
+	for _, needle := range []string{
+		"func (r *Reader) DatabaseContext()",
+		"dbContextOnce.Do",
+		"gatherDatabaseContext(",
+	} {
+		if !strings.Contains(body, needle) {
+			t.Errorf("reader.go missing required marker %q", needle)
+		}
+	}
+}
 
 func TestDriverRegistration(t *testing.T) {
 	// The driver should be registered via init()

--- a/internal/driver/mssql/driver_test.go
+++ b/internal/driver/mssql/driver_test.go
@@ -2,6 +2,8 @@ package mssql
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -11,11 +13,7 @@ import (
 // TestReaderDatabaseContext_Populated is the mssql side of the issue #13
 // regression guard. Mirrors the postgres/mysql tests.
 func TestReaderDatabaseContext_Populated(t *testing.T) {
-	src, err := os.ReadFile("reader.go")
-	if err != nil {
-		t.Fatalf("read reader.go: %v", err)
-	}
-	body := string(src)
+	body := readReaderSource(t)
 	for _, needle := range []string{
 		"func (r *Reader) DatabaseContext()",
 		"dbContextOnce.Do",
@@ -25,6 +23,22 @@ func TestReaderDatabaseContext_Populated(t *testing.T) {
 			t.Errorf("reader.go missing required marker %q", needle)
 		}
 	}
+}
+
+// readReaderSource returns the contents of reader.go as a string. Uses
+// runtime.Caller to locate the file by absolute path so the test doesn't
+// depend on the working directory.
+func readReaderSource(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed; cannot locate reader.go")
+	}
+	src, err := os.ReadFile(filepath.Join(filepath.Dir(thisFile), "reader.go"))
+	if err != nil {
+		t.Fatalf("read reader.go: %v", err)
+	}
+	return string(src)
 }
 
 func TestDriverRegistration(t *testing.T) {

--- a/internal/driver/mssql/reader.go
+++ b/internal/driver/mssql/reader.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	_ "github.com/microsoft/go-mssqldb"
@@ -17,10 +18,25 @@ import (
 
 // Reader implements driver.Reader for SQL Server.
 type Reader struct {
-	db       *sql.DB
-	config   *dbconfig.SourceConfig
-	maxConns int
-	dialect  *Dialect
+	db          *sql.DB
+	config      *dbconfig.SourceConfig
+	maxConns    int
+	dialect     *Dialect
+	compatLevel int
+
+	// dbContextOnce gates the (single) lookup of dbContext for the source side.
+	dbContextOnce sync.Once
+	dbContext     *driver.DatabaseContext
+}
+
+// DatabaseContext returns metadata about this source database for the AI prompt
+// (version, collation, code page, charset, compat-level-gated feature list).
+// Cached after first call.
+func (r *Reader) DatabaseContext() *driver.DatabaseContext {
+	r.dbContextOnce.Do(func() {
+		r.dbContext = gatherDatabaseContext(r.db, r.config.Database, r.config.Host, r.compatLevel)
+	})
+	return r.dbContext
 }
 
 // NewReader creates a new SQL Server reader.
@@ -58,10 +74,11 @@ func NewReader(cfg *dbconfig.SourceConfig, maxConns int) (*Reader, error) {
 	logging.Debug("Connected to MSSQL source: %s:%d/%s (compat level %d)", cfg.Host, cfg.Port, cfg.Database, compatLevel)
 
 	return &Reader{
-		db:       db,
-		config:   cfg,
-		maxConns: maxConns,
-		dialect:  dialect,
+		db:          db,
+		config:      cfg,
+		maxConns:    maxConns,
+		dialect:     dialect,
+		compatLevel: compatLevel,
 	}, nil
 }
 

--- a/internal/driver/mssql/writer.go
+++ b/internal/driver/mssql/writer.go
@@ -112,10 +112,23 @@ func NewWriter(cfg *dbconfig.TargetConfig, maxConns int, opts driver.WriterOptio
 }
 
 // gatherDatabaseContext collects SQL Server database metadata for AI context.
+// Thin wrapper that calls the package-level helper so the Reader and Writer
+// can share the same query logic — see issue #13.
 func (w *Writer) gatherDatabaseContext() *driver.DatabaseContext {
+	return gatherDatabaseContext(w.db, w.config.Database, w.config.Host, w.compatLevel)
+}
+
+// gatherDatabaseContext queries a live SQL Server connection for metadata the
+// AI prompt's =/== SOURCE/TARGET DATABASE ==/=/= block consumes (version,
+// collation, code page, charset, compat-level-gated feature list). Used by
+// both the Writer (target context) and the Reader (source context, plumbed
+// through TableOptions.SourceContext via the orchestrator). Failures on
+// individual queries are non-fatal — the function returns whatever it could
+// collect.
+func gatherDatabaseContext(db *sql.DB, dbName, host string, compatLevel int) *driver.DatabaseContext {
 	ctx := &driver.DatabaseContext{
-		DatabaseName:             w.config.Database,
-		ServerName:               w.config.Host,
+		DatabaseName:             dbName,
+		ServerName:               host,
 		IdentifierCase:           "insensitive",
 		CaseSensitiveIdentifiers: false,
 		MaxIdentifierLength:      128,
@@ -126,7 +139,7 @@ func (w *Writer) gatherDatabaseContext() *driver.DatabaseContext {
 
 	// Query server version
 	var version string
-	if w.db.QueryRow("SELECT @@VERSION").Scan(&version) == nil {
+	if db.QueryRow("SELECT @@VERSION").Scan(&version) == nil {
 		ctx.Version = version
 		// Parse major version using regex
 		// @@VERSION returns something like "Microsoft SQL Server 2022 (RTM) - 16.0.1000.6"
@@ -167,7 +180,7 @@ func (w *Writer) gatherDatabaseContext() *driver.DatabaseContext {
 
 	// Query database collation
 	var collation sql.NullString
-	if w.db.QueryRow("SELECT DATABASEPROPERTYEX(DB_NAME(), 'Collation')").Scan(&collation) == nil && collation.Valid {
+	if db.QueryRow("SELECT DATABASEPROPERTYEX(DB_NAME(), 'Collation')").Scan(&collation) == nil && collation.Valid {
 		ctx.Collation = collation.String
 		// Parse collation for case sensitivity
 		upperCollation := strings.ToUpper(collation.String)
@@ -184,7 +197,7 @@ func (w *Writer) gatherDatabaseContext() *driver.DatabaseContext {
 
 	// Query code page from collation
 	var codePage sql.NullInt64
-	if w.db.QueryRow(`
+	if db.QueryRow(`
 		SELECT COLLATIONPROPERTY(DATABASEPROPERTYEX(DB_NAME(), 'Collation'), 'CodePage')
 	`).Scan(&codePage) == nil && codePage.Valid {
 		ctx.CodePage = int(codePage.Int64)
@@ -212,15 +225,15 @@ func (w *Writer) gatherDatabaseContext() *driver.DatabaseContext {
 
 	// Features based on compatibility level
 	ctx.Features = []string{"NVARCHAR", "VARCHAR_MAX", "DATETIME2", "JSON"}
-	if w.compatLevel >= 130 { // SQL Server 2016+
+	if compatLevel >= 130 { // SQL Server 2016+
 		ctx.Features = append(ctx.Features, "JSON_FUNCTIONS", "TEMPORAL_TABLES")
 	}
-	if w.compatLevel >= 150 { // SQL Server 2019+
+	if compatLevel >= 150 { // SQL Server 2019+
 		ctx.Features = append(ctx.Features, "UTF8_SUPPORT")
 	}
 
 	logging.Debug("MSSQL context: collation=%s, code_page=%d, compat_level=%d",
-		ctx.Collation, ctx.CodePage, w.compatLevel)
+		ctx.Collation, ctx.CodePage, compatLevel)
 
 	return ctx
 }

--- a/internal/driver/mssql/writer.go
+++ b/internal/driver/mssql/writer.go
@@ -119,7 +119,7 @@ func (w *Writer) gatherDatabaseContext() *driver.DatabaseContext {
 }
 
 // gatherDatabaseContext queries a live SQL Server connection for metadata the
-// AI prompt's =/== SOURCE/TARGET DATABASE ==/=/= block consumes (version,
+// AI prompt's SOURCE DATABASE / TARGET DATABASE block consumes (version,
 // collation, code page, charset, compat-level-gated feature list). Used by
 // both the Writer (target context) and the Reader (source context, plumbed
 // through TableOptions.SourceContext via the orchestrator). Failures on

--- a/internal/driver/mysql/dialect_test.go
+++ b/internal/driver/mysql/dialect_test.go
@@ -2,6 +2,8 @@ package mysql
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -99,11 +101,7 @@ func TestAIPromptAugmentation_FractionalSecondPrecision(t *testing.T) {
 // TestReaderDatabaseContext_Populated is the mysql side of the issue #13
 // regression guard. Mirrors the postgres test.
 func TestReaderDatabaseContext_Populated(t *testing.T) {
-	src, err := os.ReadFile("reader.go")
-	if err != nil {
-		t.Fatalf("read reader.go: %v", err)
-	}
-	body := string(src)
+	body := readReaderSource(t)
 	for _, needle := range []string{
 		"func (r *Reader) DatabaseContext()",
 		"dbContextOnce.Do",
@@ -113,4 +111,20 @@ func TestReaderDatabaseContext_Populated(t *testing.T) {
 			t.Errorf("reader.go missing required marker %q", needle)
 		}
 	}
+}
+
+// readReaderSource returns the contents of reader.go as a string. Uses
+// runtime.Caller to locate the file by absolute path so the test doesn't
+// depend on the working directory.
+func readReaderSource(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed; cannot locate reader.go")
+	}
+	src, err := os.ReadFile(filepath.Join(filepath.Dir(thisFile), "reader.go"))
+	if err != nil {
+		t.Fatalf("read reader.go: %v", err)
+	}
+	return string(src)
 }

--- a/internal/driver/mysql/dialect_test.go
+++ b/internal/driver/mysql/dialect_test.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -91,6 +92,25 @@ func TestAIPromptAugmentation_FractionalSecondPrecision(t *testing.T) {
 	} {
 		if !strings.Contains(aug, needle) {
 			t.Errorf("prompt missing required phrase %q", needle)
+		}
+	}
+}
+
+// TestReaderDatabaseContext_Populated is the mysql side of the issue #13
+// regression guard. Mirrors the postgres test.
+func TestReaderDatabaseContext_Populated(t *testing.T) {
+	src, err := os.ReadFile("reader.go")
+	if err != nil {
+		t.Fatalf("read reader.go: %v", err)
+	}
+	body := string(src)
+	for _, needle := range []string{
+		"func (r *Reader) DatabaseContext()",
+		"dbContextOnce.Do",
+		"gatherDatabaseContext(",
+	} {
+		if !strings.Contains(body, needle) {
+			t.Errorf("reader.go missing required marker %q", needle)
 		}
 	}
 }

--- a/internal/driver/mysql/reader.go
+++ b/internal/driver/mysql/reader.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql" // MySQL driver
@@ -16,10 +17,26 @@ import (
 
 // Reader implements driver.Reader for MySQL/MariaDB.
 type Reader struct {
-	db       *sql.DB
-	config   *dbconfig.SourceConfig
-	maxConns int
-	dialect  *Dialect
+	db        *sql.DB
+	config    *dbconfig.SourceConfig
+	maxConns  int
+	dialect   *Dialect
+	version   string // raw VERSION() string from connect-time probe
+	isMariaDB bool
+
+	// dbContextOnce gates the (single) lookup of dbContext for the source side.
+	dbContextOnce sync.Once
+	dbContext     *driver.DatabaseContext
+}
+
+// DatabaseContext returns metadata about this source database for the AI prompt
+// (charset, collation, identifier case, storage engine, version-gated feature
+// list). Cached after first call.
+func (r *Reader) DatabaseContext() *driver.DatabaseContext {
+	r.dbContextOnce.Do(func() {
+		r.dbContext = gatherDatabaseContext(r.db, r.config.Database, r.config.Host, r.version, r.isMariaDB)
+	})
+	return r.dbContext
 }
 
 // NewReader creates a new MySQL reader.
@@ -47,18 +64,21 @@ func NewReader(cfg *dbconfig.SourceConfig, maxConns int) (*Reader, error) {
 	// Detect MySQL vs MariaDB
 	var version string
 	db.QueryRow("SELECT VERSION()").Scan(&version)
+	isMariaDB := strings.Contains(strings.ToLower(version), "mariadb")
 	dbType := "MySQL"
-	if strings.Contains(strings.ToLower(version), "mariadb") {
+	if isMariaDB {
 		dbType = "MariaDB"
 	}
 
 	logging.Debug("Connected to %s source: %s:%d/%s", dbType, cfg.Host, cfg.Port, cfg.Database)
 
 	return &Reader{
-		db:       db,
-		config:   cfg,
-		maxConns: maxConns,
-		dialect:  dialect,
+		db:        db,
+		config:    cfg,
+		maxConns:  maxConns,
+		dialect:   dialect,
+		version:   version,
+		isMariaDB: isMariaDB,
 	}, nil
 }
 

--- a/internal/driver/mysql/writer.go
+++ b/internal/driver/mysql/writer.go
@@ -124,7 +124,7 @@ func (w *Writer) gatherDatabaseContext(version string) *driver.DatabaseContext {
 }
 
 // gatherDatabaseContext queries a live MySQL/MariaDB connection for metadata
-// the AI prompt's =/== SOURCE/TARGET DATABASE ==/=/= block consumes (charset,
+// the AI prompt's SOURCE DATABASE / TARGET DATABASE block consumes (charset,
 // collation, identifier case, storage engine, version-gated feature list).
 // Used by both the Writer (target context) and the Reader (source context,
 // plumbed through TableOptions.SourceContext via the orchestrator). Failures

--- a/internal/driver/mysql/writer.go
+++ b/internal/driver/mysql/writer.go
@@ -117,11 +117,24 @@ func NewWriter(cfg *dbconfig.TargetConfig, maxConns int, opts driver.WriterOptio
 }
 
 // gatherDatabaseContext collects MySQL/MariaDB database metadata for AI context.
+// Thin wrapper that calls the package-level helper so the Reader and Writer
+// can share the same query logic — see issue #13.
 func (w *Writer) gatherDatabaseContext(version string) *driver.DatabaseContext {
+	return gatherDatabaseContext(w.db, w.config.Database, w.config.Host, version, w.isMariaDB)
+}
+
+// gatherDatabaseContext queries a live MySQL/MariaDB connection for metadata
+// the AI prompt's =/== SOURCE/TARGET DATABASE ==/=/= block consumes (charset,
+// collation, identifier case, storage engine, version-gated feature list).
+// Used by both the Writer (target context) and the Reader (source context,
+// plumbed through TableOptions.SourceContext via the orchestrator). Failures
+// on individual queries are non-fatal — the function returns whatever it
+// could collect.
+func gatherDatabaseContext(db *sql.DB, dbName, host, version string, isMariaDB bool) *driver.DatabaseContext {
 	dbCtx := &driver.DatabaseContext{
 		Version:                  version,
-		DatabaseName:             w.config.Database,
-		ServerName:               w.config.Host,
+		DatabaseName:             dbName,
+		ServerName:               host,
 		IdentifierCase:           "preserve",
 		CaseSensitiveIdentifiers: false, // Depends on OS/config
 		MaxIdentifierLength:      64,
@@ -138,7 +151,7 @@ func (w *Writer) gatherDatabaseContext(version string) *driver.DatabaseContext {
 		}
 	}
 
-	if w.isMariaDB {
+	if isMariaDB {
 		dbCtx.StorageEngine = "MariaDB"
 	}
 
@@ -149,7 +162,7 @@ func (w *Writer) gatherDatabaseContext(version string) *driver.DatabaseContext {
 
 	// Query character set and collation
 	var charsetVar, collationVar string
-	if w.db.QueryRow("SELECT @@character_set_database, @@collation_database").Scan(&charsetVar, &collationVar) == nil {
+	if db.QueryRow("SELECT @@character_set_database, @@collation_database").Scan(&charsetVar, &collationVar) == nil {
 		dbCtx.Charset = charsetVar
 		dbCtx.Collation = collationVar
 
@@ -181,7 +194,7 @@ func (w *Writer) gatherDatabaseContext(version string) *driver.DatabaseContext {
 	// Query lower_case_table_names for identifier case sensitivity
 	// Use -1 as sentinel to distinguish "not queried" from actual value of 0
 	lowerCaseTableNames := -1
-	if w.db.QueryRow("SELECT @@lower_case_table_names").Scan(&lowerCaseTableNames) == nil {
+	if db.QueryRow("SELECT @@lower_case_table_names").Scan(&lowerCaseTableNames) == nil {
 		switch lowerCaseTableNames {
 		case 0:
 			dbCtx.CaseSensitiveIdentifiers = true
@@ -197,7 +210,7 @@ func (w *Writer) gatherDatabaseContext(version string) *driver.DatabaseContext {
 
 	// Query default storage engine
 	var engine string
-	if w.db.QueryRow("SELECT @@default_storage_engine").Scan(&engine) == nil {
+	if db.QueryRow("SELECT @@default_storage_engine").Scan(&engine) == nil {
 		dbCtx.StorageEngine = engine
 	}
 
@@ -214,10 +227,10 @@ func (w *Writer) gatherDatabaseContext(version string) *driver.DatabaseContext {
 
 	// Standard MySQL features
 	dbCtx.Features = []string{"JSON", "SPATIAL", "FULLTEXT"}
-	if w.isMariaDB {
+	if isMariaDB {
 		dbCtx.Features = append(dbCtx.Features, "SEQUENCES", "SYSTEM_VERSIONING")
 	}
-	if dbCtx.MajorVersion >= 8 || (w.isMariaDB && dbCtx.MajorVersion >= 10) {
+	if dbCtx.MajorVersion >= 8 || (isMariaDB && dbCtx.MajorVersion >= 10) {
 		dbCtx.Features = append(dbCtx.Features, "CTE", "WINDOW_FUNCTIONS")
 	}
 

--- a/internal/driver/postgres/driver_test.go
+++ b/internal/driver/postgres/driver_test.go
@@ -238,3 +238,23 @@ func TestAIPromptAugmentation(t *testing.T) {
 		}
 	}
 }
+
+// TestReaderDatabaseContext_Populated is the regression guard for issue #13.
+// The orchestrator passes Reader.DatabaseContext() into TableOptions.SourceContext;
+// returning nil here would silently produce one-sided AI prompts (full TARGET
+// block, empty SOURCE block) and fire the "No source context available" lie in
+// MIGRATION RULES. This test asserts the symbol is present in reader.go so
+// accidental refactors that drop it surface at test time, not in a debug-prompt
+// dump weeks later.
+func TestReaderDatabaseContext_Populated(t *testing.T) {
+	body := readReaderSource(t)
+	for _, needle := range []string{
+		"func (r *Reader) DatabaseContext()",
+		"dbContextOnce.Do",
+		"gatherDatabaseContext(", // shared helper called by Reader and Writer
+	} {
+		if !strings.Contains(body, needle) {
+			t.Errorf("reader.go missing required marker %q", needle)
+		}
+	}
+}

--- a/internal/driver/postgres/reader.go
+++ b/internal/driver/postgres/reader.go
@@ -27,6 +27,21 @@ type Reader struct {
 	// serverVersionOnce gates the lazy lookup of serverVersionNum.
 	serverVersionOnce sync.Once
 	serverVersionNum  int // 0 if lookup failed; integer like 160001 (PG 16.0.1)
+
+	// dbContextOnce gates the (single) lookup of dbContext for the source side.
+	dbContextOnce sync.Once
+	dbContext     *driver.DatabaseContext
+}
+
+// DatabaseContext returns metadata about this source database for the AI prompt
+// (version, charset, collation, identifier case, varchar semantics, etc.).
+// Cached after first call so the orchestrator's per-table loop doesn't re-query
+// pg_database / SHOW server_encoding for every CREATE TABLE.
+func (r *Reader) DatabaseContext() *driver.DatabaseContext {
+	r.dbContextOnce.Do(func() {
+		r.dbContext = gatherDatabaseContext(context.Background(), r.pool, r.config.Database, r.config.Host)
+	})
+	return r.dbContext
 }
 
 // NewReader creates a new PostgreSQL reader.

--- a/internal/driver/postgres/writer.go
+++ b/internal/driver/postgres/writer.go
@@ -117,12 +117,23 @@ func NewWriter(cfg *dbconfig.TargetConfig, maxConns int, opts driver.WriterOptio
 }
 
 // gatherDatabaseContext collects PostgreSQL database metadata for AI context.
+// Thin wrapper that calls the package-level helper so the Reader and Writer
+// can share the same query logic — see issue #13.
 func (w *Writer) gatherDatabaseContext() *driver.DatabaseContext {
-	ctx := context.Background()
+	return gatherDatabaseContext(context.Background(), w.pool, w.config.Database, w.config.Host)
+}
 
+// gatherDatabaseContext queries a live PostgreSQL connection for metadata
+// the AI prompt's =/== SOURCE/TARGET DATABASE ==/=/= block consumes (version,
+// encoding, collation, identifier case, varchar semantics, version-gated
+// feature list). Used by both the Writer (for target context) and the Reader
+// (for source context, plumbed through TableOptions.SourceContext via the
+// orchestrator). Failures on individual queries are non-fatal — the function
+// returns whatever it could collect.
+func gatherDatabaseContext(ctx context.Context, pool *pgxpool.Pool, dbName, host string) *driver.DatabaseContext {
 	dbCtx := &driver.DatabaseContext{
-		DatabaseName:             w.config.Database,
-		ServerName:               w.config.Host,
+		DatabaseName:             dbName,
+		ServerName:               host,
 		IdentifierCase:           "lower",
 		CaseSensitiveIdentifiers: true, // PostgreSQL preserves case in quotes
 		CaseSensitiveData:        true, // Default is case-sensitive
@@ -134,7 +145,7 @@ func (w *Writer) gatherDatabaseContext() *driver.DatabaseContext {
 
 	// Query server version
 	var version string
-	if w.pool.QueryRow(ctx, "SELECT version()").Scan(&version) == nil {
+	if pool.QueryRow(ctx, "SELECT version()").Scan(&version) == nil {
 		dbCtx.Version = version
 		// Parse major version using regex to handle any version format
 		// Matches patterns like "PostgreSQL 16.1", "PostgreSQL 17", etc.
@@ -148,7 +159,7 @@ func (w *Writer) gatherDatabaseContext() *driver.DatabaseContext {
 
 	// Query encoding
 	var encoding string
-	if w.pool.QueryRow(ctx, "SHOW server_encoding").Scan(&encoding) == nil {
+	if pool.QueryRow(ctx, "SHOW server_encoding").Scan(&encoding) == nil {
 		dbCtx.Charset = encoding
 		dbCtx.Encoding = encoding
 		if encoding == "UTF8" {
@@ -160,7 +171,7 @@ func (w *Writer) gatherDatabaseContext() *driver.DatabaseContext {
 
 	// Query collation
 	var collation sql.NullString
-	if w.pool.QueryRow(ctx, `
+	if pool.QueryRow(ctx, `
 		SELECT datcollate FROM pg_database WHERE datname = current_database()
 	`).Scan(&collation) == nil && collation.Valid {
 		dbCtx.Collation = collation.String
@@ -168,7 +179,7 @@ func (w *Writer) gatherDatabaseContext() *driver.DatabaseContext {
 
 	// Query LC_CTYPE for character classification
 	var lcCtype sql.NullString
-	if w.pool.QueryRow(ctx, `
+	if pool.QueryRow(ctx, `
 		SELECT datctype FROM pg_database WHERE datname = current_database()
 	`).Scan(&lcCtype) == nil && lcCtype.Valid {
 		if dbCtx.Notes != "" {

--- a/internal/driver/postgres/writer.go
+++ b/internal/driver/postgres/writer.go
@@ -124,7 +124,7 @@ func (w *Writer) gatherDatabaseContext() *driver.DatabaseContext {
 }
 
 // gatherDatabaseContext queries a live PostgreSQL connection for metadata
-// the AI prompt's =/== SOURCE/TARGET DATABASE ==/=/= block consumes (version,
+// the AI prompt's SOURCE DATABASE / TARGET DATABASE block consumes (version,
 // encoding, collation, identifier case, varchar semantics, version-gated
 // feature list). Used by both the Writer (for target context) and the Reader
 // (for source context, plumbed through TableOptions.SourceContext via the

--- a/internal/driver/reader.go
+++ b/internal/driver/reader.go
@@ -39,6 +39,15 @@ type Reader interface {
 	MaxConns() int
 	DBType() string
 	PoolStats() stats.PoolStats
+
+	// DatabaseContext returns metadata about this source database for the AI
+	// prompt (version, charset, collation, identifier case, varchar semantics,
+	// etc.). The orchestrator passes the result to target.CreateTableWithOptions
+	// via TableOptions.SourceContext so the AI sees a populated SOURCE DATABASE
+	// block alongside the existing TARGET DATABASE block. Implementations should
+	// cache after first call — orchestrator may invoke this for every CREATE
+	// TABLE on a wide schema.
+	DatabaseContext() *DatabaseContext
 }
 
 // ReadOptions configures how to read data from a table.

--- a/internal/orchestrator/phases.go
+++ b/internal/orchestrator/phases.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 
+	"smt/internal/driver"
 	"smt/internal/logging"
 	"smt/internal/source"
 )
@@ -149,8 +150,14 @@ func (o *Orchestrator) CreateTables(ctx context.Context, runID string) error {
 	total := len(o.tables)
 	logging.Info("[%s] creating %d tables (concurrency=%d)", TaskCreateTables, total, o.aiConcurrency())
 	var done atomic.Int64
+	// Gather source DB context once up front (Reader caches; this primes the
+	// cache so the per-table goroutines all read the same value without racing
+	// on the sync.Once inside the Reader implementation). The result feeds the
+	// AI prompt's SOURCE DATABASE block — see issue #13.
+	sourceCtx := o.source.DatabaseContext()
 	return runParallel(ctx, o.tables, o.aiConcurrency(), func(ctx context.Context, _ int, t source.Table) error {
-		if err := o.target.CreateTable(ctx, &t, o.config.Target.Schema); err != nil {
+		opts := driver.TableOptions{SourceContext: sourceCtx}
+		if err := o.target.CreateTableWithOptions(ctx, &t, o.config.Target.Schema, opts); err != nil {
 			return fmt.Errorf("creating table %s: %w", t.Name, err)
 		}
 		n := done.Add(1)


### PR DESCRIPTION
## Summary

Closes #13. Before this change every cross-engine `smt create` produced a one-sided AI prompt — fully populated `=== TARGET DATABASE ===` block (version, charset, encoding, collation, identifier case, varchar semantics, feature list) and a single-line `=== SOURCE DATABASE === Type: <engine>` with nothing else. The MIGRATION RULES section opened with `Source database characteristics: No source context available, using standard type semantics` — admitting it had no input to reason about.

## Root cause

End-to-end plumbing rot, all three layers:

1. **`Reader` interface** had no `DatabaseContext()` accessor.
2. **Each driver's `Writer.gatherDatabaseContext`** was a private method on the writer struct — not reachable from the reader side.
3. **Orchestrator** called the no-options form `target.CreateTable(...)`, so `TableOptions{}` was the zero value and `SourceContext` was always nil regardless of plumbing.

## Fix

- Each driver's `gatherDatabaseContext` is now a package-level free function callable from both Reader and Writer. The Writer keeps a thin method wrapper so its call sites are unchanged. Body is unchanged — only the receiver moves and the connection + config become parameters.
- `Reader` interface gains `DatabaseContext() *DatabaseContext` with a comment about the orchestrator's caching expectation.
- Each Reader (mssql / postgres / mysql) implements it with a `sync.Once` cache. mssql Reader stores the compat level it already queries on connect; mysql Reader stores the version + `isMariaDB` flag it already determines on connect.
- `Orchestrator.CreateTables` now calls `target.CreateTableWithOptions(..., driver.TableOptions{SourceContext: o.source.DatabaseContext()})`, priming the source-side cache once before the per-table goroutines spin up.

## Tests

- Each driver gets a `TestReaderDatabaseContext_Populated` SQL-marker test asserting `reader.go` references the new method, the `sync.Once` cache, and the shared `gatherDatabaseContext` helper.
- `go test -short -race ./...` still green.

## End-to-end verification

`--verbosity debug` capture on mssql → pg, single-table run:

**Pre-fix:**
```
=== SOURCE DATABASE ===
Type: mssql
```

**Post-fix:**
```
=== SOURCE DATABASE ===
Type: mssql
Version: Microsoft SQL Server 2022 (RTM-CU24-GDR) ... 16.0.4250.1 (X64) ...
Database: CRM_MSSQL_TEST
Character Encoding:
  Charset: SQL_Latin1_General_CP1
  National Charset: UTF-16
  Collation: SQL_Latin1_General_CP1_CI_AS
  Max Bytes Per Char: 2
Case Sensitivity:
  Identifier Case: insensitive
  Identifiers: case-insensitive
  String Comparisons: case-insensitive (collation-dependent)
Limits:
  Max Identifier Length: 128
  Max VARCHAR Length: 8000
  Max NVARCHAR Length: 4000 characters
  VARCHAR Semantics: byte (lengths are in bytes)
Features: NVARCHAR, VARCHAR_MAX, DATETIME2, JSON, JSON_FUNCTIONS, TEMPORAL_TABLES, UTF8_SUPPORT
Notes: Accent-sensitive collation
```

Symmetric to the existing TARGET DATABASE block. The `No source context available` string is gone from MIGRATION RULES.

## Empirical follow-up: Haiku regression case

The original Haiku regression that pushed the project default to Sonnet was pg → mssql with PERSISTED computed columns — Haiku emitted invalid `<type> AS (...) PERSISTED`. With source context populated, Haiku now lands the full CRM fixture cleanly:

| metric | source | Haiku target |
|---|---|---|
| tables | 14 | 14 ✅ |
| FKs | 22 | 22 ✅ |
| CHECKs | 33 | 33 ✅ |
| computed (PERSISTED) | 3 | 3 ✅ — valid MSSQL syntax |

Wall: 13s. Source context **fixed the original Haiku regression case** for mssql ↔ pg.

Quick Haiku sweep of the broader matrix:

| pair | result |
|---|---|
| mssql → pg | ✅ 14/22/31/2 in 11s |
| **pg → mssql** | ✅ **14/22/33/3 in 13s — original regression now fixed** |
| mssql → mysql | ❌ 2/0/0 — still flaky on AI translation |
| mysql → pg | ❌ 12/0/0 — still flaky on AI translation |

Source context didn't fix everything for Haiku — mssql ↔ mysql translations are still flakier than Sonnet — but the mssql ↔ pg pair is now Haiku-viable, useful for cost-sensitive warehouse workloads where Sonnet's premium would compound. Project default stays Sonnet; users who run predominantly mssql↔pg can switch to Haiku confidently.

## Test plan

- [x] `make build` clean
- [x] `gofmt -l internal/` clean
- [x] `go test -short -race ./...` all pass
- [x] New `TestReaderDatabaseContext_Populated` passes for all three drivers
- [x] Live `--verbosity debug` capture confirms populated SOURCE DATABASE block
- [x] mssql → pg with both Sonnet (existing) and Haiku (newly viable) lands the full CRM fixture
- [ ] Reviewer: confirm no other call sites need updating — `target.CreateTable` (no-options form) is now an unused interface method on Writer; could be removed in a follow-up but kept here to keep the PR focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)