### PR TITLE
Move table-DDL cache write from mapper to writer post-exec (closes #32)

### DIFF
--- a/internal/driver/ai_typemapper.go
+++ b/internal/driver/ai_typemapper.go
@@ -1325,18 +1325,13 @@ func (m *AITypeMapper) GenerateTableDDL(ctx context.Context, req TableDDLRequest
 			req.SourceTable.Schema, req.SourceTable.Name, err)
 	}
 
-	// Cache the DDL result on first-try only. Retry results are cached by the
-	// writer via CacheTableDDL after the database confirms the DDL is valid —
-	// don't cache here because we haven't yet validated the result.
-	if !isRetry {
-		m.cacheMu.Lock()
-		m.cache.Set(cacheKey, response.CreateTableDDL)
-		m.cacheMu.Unlock()
-
-		if err := m.saveCache(); err != nil {
-			logging.Warn("Failed to save AI table DDL cache: %v", err)
-		}
-	}
+	// Cache writes are deferred to the writer's CacheTableDDL call after the
+	// database confirms the DDL executes — see #32. Caching here would persist
+	// AI output that hasn't been validated against the target DB; if the DDL
+	// then fails (and the AI-classifier can't fix it on retry), the bad DDL
+	// would stay cached and poison every subsequent run for the same table
+	// shape with no chance to re-call the AI. Mapper is now read-only on the
+	// cache; only validated DDL ever gets stored.
 
 	logging.Debug("AI generated DDL for %s.%s (%d columns mapped, retry=%v)",
 		req.SourceTable.Schema, req.SourceTable.Name, len(response.ColumnTypes), isRetry)
@@ -1345,11 +1340,12 @@ func (m *AITypeMapper) GenerateTableDDL(ctx context.Context, req TableDDLRequest
 }
 
 // CacheTableDDL stores a known-good DDL for the request, replacing any prior
-// cached value. The writer calls this after a successful CREATE TABLE
-// execution against the target database, including after a retry that
-// corrected a previously-cached bad DDL — see TableTypeMapper for the full
-// rationale on why the AI mapper can't safely cache on its own when retry is
-// involved.
+// cached value. This is the ONLY entry point that writes to the AI table-DDL
+// cache (#32) — the mapper itself never caches because it only sees AI output,
+// not validated DDL. The writer calls this after every successful CREATE TABLE
+// execution (first-try success and retry success alike); a failed exec leaves
+// the cache untouched so the next call gets a fresh AI invocation rather than
+// a poisoned hit.
 func (m *AITypeMapper) CacheTableDDL(req TableDDLRequest, ddl string) {
 	cacheKey := m.tableCacheKey(req)
 	m.cacheMu.Lock()

--- a/internal/driver/ai_typemapper_test.go
+++ b/internal/driver/ai_typemapper_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2085,9 +2086,11 @@ func TestGenerateTableDDL_DoesNotAutoCache_Issue32(t *testing.T) {
 // (the writer never called it because exec failed) leaves the cache empty —
 // so the next GenerateTableDDL invokes the AI again with a fresh chance.
 func TestGenerateTableDDL_FailedFirstTryDoesNotPoison_Issue32(t *testing.T) {
-	callCount := 0
+	// callCount is touched by both the test goroutine (assertions) and the
+	// httptest handler goroutine (increment). Use atomic to keep -race quiet.
+	var callCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
+		callCount.Add(1)
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(openAIResponse{
 			Choices: []struct {
@@ -2130,8 +2133,8 @@ func TestGenerateTableDDL_FailedFirstTryDoesNotPoison_Issue32(t *testing.T) {
 	if _, err := mapper.GenerateTableDDL(context.Background(), req); err != nil {
 		t.Fatalf("first GenerateTableDDL: %v", err)
 	}
-	if callCount != 1 {
-		t.Fatalf("expected 1 AI call, got %d", callCount)
+	if got := callCount.Load(); got != 1 {
+		t.Fatalf("expected 1 AI call, got %d", got)
 	}
 
 	// Second call with identical req: must invoke the AI again because the
@@ -2140,8 +2143,8 @@ func TestGenerateTableDDL_FailedFirstTryDoesNotPoison_Issue32(t *testing.T) {
 	if _, err := mapper.GenerateTableDDL(context.Background(), req); err != nil {
 		t.Fatalf("second GenerateTableDDL: %v", err)
 	}
-	if callCount != 2 {
-		t.Errorf("BUG (#32): second GenerateTableDDL hit cache instead of re-calling AI; got %d total calls, want 2", callCount)
+	if got := callCount.Load(); got != 2 {
+		t.Errorf("BUG (#32): second GenerateTableDDL hit cache instead of re-calling AI; got %d total calls, want 2", got)
 	}
 }
 

--- a/internal/driver/ai_typemapper_test.go
+++ b/internal/driver/ai_typemapper_test.go
@@ -1990,6 +1990,161 @@ func TestBuildTableDDLPrompt_PreviousAttempt(t *testing.T) {
 	}
 }
 
+// TestGenerateTableDDL_DoesNotAutoCache_Issue32 is the regression test for #32:
+// the mapper must NOT write to its own cache after GenerateTableDDL, because
+// at that point the AI's output hasn't been validated against the target
+// database. The writer's CacheTableDDL is now the only path that populates
+// the cache, and it's only called after a successful exec — so a failed DDL
+// can no longer poison the cache for subsequent runs.
+//
+// History: this used to be the failure mode that caused mysql→pg with gpt-oss
+// to fail in 0 seconds on every re-run after the first attempt cached bad
+// uuid()/42883 DDL. Required `rm ~/.smt/type-cache.json` to recover. See PR
+// thread on issue #32.
+func TestGenerateTableDDL_DoesNotAutoCache_Issue32(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return a syntactically-valid CREATE TABLE — what matters here is what
+		// the mapper does AFTER successfully parsing the AI response, not the
+		// content of the DDL.
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(openAIResponse{
+			Choices: []struct {
+				Message struct {
+					Content          string `json:"content"`
+					ReasoningContent string `json:"reasoning_content"`
+				} `json:"message"`
+				FinishReason string `json:"finish_reason"`
+			}{
+				{
+					Message: struct {
+						Content          string `json:"content"`
+						ReasoningContent string `json:"reasoning_content"`
+					}{Content: "CREATE TABLE public.foo (id integer NOT NULL);"},
+					FinishReason: "stop",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	mapper := testMapperWithTempCache(t, "lmstudio", &secrets.Provider{
+		APIKey:  "",
+		Model:   "test-model",
+		BaseURL: server.URL,
+	})
+	mapper.client = server.Client()
+
+	req := TableDDLRequest{
+		SourceDBType: "mysql", TargetDBType: "postgres",
+		SourceTable: &Table{
+			Schema:     "src",
+			Name:       "foo",
+			PrimaryKey: []string{"id"},
+			Columns:    []Column{{Name: "id", DataType: "int"}},
+		},
+		TargetSchema: "public",
+	}
+
+	resp, err := mapper.GenerateTableDDL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GenerateTableDDL: %v", err)
+	}
+	if resp == nil || resp.CreateTableDDL == "" {
+		t.Fatal("expected a non-empty DDL response from the mock")
+	}
+
+	// THE FIX FOR #32: the mapper must not have written to its own cache
+	// during GenerateTableDDL. Until the writer calls CacheTableDDL after a
+	// successful exec, the cache is empty for this key.
+	cacheKey := mapper.tableCacheKey(req)
+	mapper.cacheMu.RLock()
+	_, hit := mapper.cache.Get(cacheKey)
+	mapper.cacheMu.RUnlock()
+	if hit {
+		t.Errorf("BUG (#32): mapper auto-cached AI output before exec validation; cache must remain empty until CacheTableDDL is called")
+	}
+
+	// Sanity: the existing CacheTableDDL path still works as the writer's
+	// post-exec entry point.
+	mapper.CacheTableDDL(req, resp.CreateTableDDL)
+	mapper.cacheMu.RLock()
+	cached, _ := mapper.cache.Get(cacheKey)
+	mapper.cacheMu.RUnlock()
+	if cached != resp.CreateTableDDL {
+		t.Errorf("explicit CacheTableDDL didn't populate cache:\n  got:  %q\n  want: %q", cached, resp.CreateTableDDL)
+	}
+}
+
+// TestGenerateTableDDL_FailedFirstTryDoesNotPoison_Issue32 simulates the
+// pathological case the old behavior introduced: AI generated a DDL, mapper
+// auto-cached it, exec failed (and the AI-classifier or retry budget couldn't
+// fix it). The next run for the same source table would hit the cache
+// instantly and fail with the same error in 0 seconds.
+//
+// Under the #32 fix, a GenerateTableDDL call followed by NO CacheTableDDL
+// (the writer never called it because exec failed) leaves the cache empty —
+// so the next GenerateTableDDL invokes the AI again with a fresh chance.
+func TestGenerateTableDDL_FailedFirstTryDoesNotPoison_Issue32(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(openAIResponse{
+			Choices: []struct {
+				Message struct {
+					Content          string `json:"content"`
+					ReasoningContent string `json:"reasoning_content"`
+				} `json:"message"`
+				FinishReason string `json:"finish_reason"`
+			}{
+				{
+					Message: struct {
+						Content          string `json:"content"`
+						ReasoningContent string `json:"reasoning_content"`
+					}{Content: "CREATE TABLE public.foo (id integer);"},
+					FinishReason: "stop",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	mapper := testMapperWithTempCache(t, "lmstudio", &secrets.Provider{
+		APIKey: "", Model: "test-model", BaseURL: server.URL,
+	})
+	mapper.client = server.Client()
+
+	req := TableDDLRequest{
+		SourceDBType: "mysql", TargetDBType: "postgres",
+		SourceTable: &Table{
+			Schema:     "src",
+			Name:       "foo",
+			PrimaryKey: []string{"id"},
+			Columns:    []Column{{Name: "id", DataType: "int"}},
+		},
+		TargetSchema: "public",
+	}
+
+	// First call: simulates the writer calling GenerateTableDDL but then NOT
+	// calling CacheTableDDL because the subsequent exec failed.
+	if _, err := mapper.GenerateTableDDL(context.Background(), req); err != nil {
+		t.Fatalf("first GenerateTableDDL: %v", err)
+	}
+	if callCount != 1 {
+		t.Fatalf("expected 1 AI call, got %d", callCount)
+	}
+
+	// Second call with identical req: must invoke the AI again because the
+	// cache is empty (no CacheTableDDL between calls). Pre-#32 this would
+	// have hit the cache and skipped the AI entirely.
+	if _, err := mapper.GenerateTableDDL(context.Background(), req); err != nil {
+		t.Fatalf("second GenerateTableDDL: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("BUG (#32): second GenerateTableDDL hit cache instead of re-calling AI; got %d total calls, want 2", callCount)
+	}
+}
+
 // TestCacheTableDDL is a regression guard for the cache-replacement behavior
 // the writer relies on after a successful retry. Without this, a first-try
 // call that produced bad DDL would leave the bad DDL cached, and a future

--- a/internal/driver/mssql/writer.go
+++ b/internal/driver/mssql/writer.go
@@ -342,8 +342,9 @@ func (w *Writer) CreateTableWithOptions(ctx context.Context, t *driver.Table, ta
 		}
 
 		if _, err = w.db.ExecContext(ctx, ddl); err == nil {
+			// Cache validated DDL after exec confirms it works (#32).
+			w.tableMapper.CacheTableDDL(req, ddl)
 			if attempt > 0 {
-				w.tableMapper.CacheTableDDL(req, ddl)
 				logging.Info("table %s succeeded on retry attempt %d/%d", t.FullName(), attempt, opts.MaxRetries)
 			}
 			return nil

--- a/internal/driver/mysql/writer.go
+++ b/internal/driver/mysql/writer.go
@@ -347,8 +347,9 @@ func (w *Writer) CreateTableWithOptions(ctx context.Context, t *driver.Table, ta
 		}
 
 		if _, err = w.db.ExecContext(ctx, ddl); err == nil {
+			// Cache validated DDL after exec confirms it works (#32).
+			w.tableMapper.CacheTableDDL(req, ddl)
 			if attempt > 0 {
-				w.tableMapper.CacheTableDDL(req, ddl)
 				logging.Info("table %s succeeded on retry attempt %d/%d", t.FullName(), attempt, opts.MaxRetries)
 			}
 			return nil

--- a/internal/driver/postgres/writer.go
+++ b/internal/driver/postgres/writer.go
@@ -337,12 +337,13 @@ func (w *Writer) CreateTableWithOptions(ctx context.Context, t *driver.Table, ta
 		}
 
 		if _, err = w.pool.Exec(ctx, execDDL); err == nil {
-			// Success. If this was a retry, re-prime the AI cache so future
-			// first-try calls for this table-shape get the validated DDL
-			// instead of whatever bad DDL the first attempt cached. Cache
-			// the AI-returned form (aiDDL), not the Unlogged-rewritten form.
+			// Success — cache the validated DDL (#32). Mapper no longer caches
+			// AI output on its own, so this is the only path that populates
+			// the cache. Cache the AI-returned form (aiDDL), not the
+			// Unlogged-rewritten form, because tableCacheKey doesn't carry
+			// opts.Unlogged and the writer reapplies the rewrite per-call.
+			w.tableMapper.CacheTableDDL(req, aiDDL)
 			if attempt > 0 {
-				w.tableMapper.CacheTableDDL(req, aiDDL)
 				logging.Info("table %s succeeded on retry attempt %d/%d", t.FullName(), attempt, opts.MaxRetries)
 			}
 			return nil

--- a/internal/driver/typemapper.go
+++ b/internal/driver/typemapper.go
@@ -33,16 +33,20 @@ type TableTypeMapper interface {
 	CanMap(sourceDBType, targetDBType string) bool
 
 	// CacheTableDDL stores a known-good DDL for the request, replacing any prior
-	// cached value. Called by the writer after a CREATE TABLE has successfully
-	// executed against the target database — turns a runtime-validated DDL into
-	// the entry future GenerateTableDDL calls (without PreviousAttempt) will hit.
+	// cached value. This is the ONLY cache-write entry point — the mapper
+	// itself never writes the cache because it only sees AI output, not
+	// validated DDL (see #32). The writer calls this after every successful
+	// CREATE TABLE execution (first-try and retry alike); a failed exec leaves
+	// the cache untouched so the next call gets a fresh AI invocation rather
+	// than a poisoned hit.
 	//
-	// Without this method, a first-try call that produces bad DDL caches the bad
-	// DDL; a subsequent retry with PreviousAttempt produces good DDL but bypasses
-	// the cache for both lookup and store, so the bad cached DDL remains and a
-	// future migration of the same table-shape would fail again. CacheTableDDL
-	// closes that loop by letting the writer re-prime the cache once the database
-	// has confirmed the DDL is correct.
+	// History: an earlier shape cached AI output inside the mapper, with the
+	// writer additionally calling CacheTableDDL on retry success to overwrite
+	// any bad-DDL cache poisoning. That worked when retries succeeded but left
+	// stale bad DDL cached when retries didn't fire (allowlist false negative)
+	// or didn't succeed (model couldn't converge), causing 0-second failures
+	// on subsequent runs against the same source-table shape. Moving the cache
+	// write to post-exec eliminates the entire failure mode.
 	CacheTableDDL(req TableDDLRequest, ddl string)
 }
 


### PR DESCRIPTION
## Summary

Closes #32. The mapper used to cache AI output before the writer ever exec'd it — so a structurally-valid-but-semantically-wrong DDL would cache and persist across runs even if every retry failed. The fix moves cache writes to be exclusively the writer's responsibility, post-exec; the mapper became read-only on the cache.

- \`AITypeMapper.GenerateTableDDL\` no longer writes to its own cache after parsing the AI response. The lookup at the top remains; only the WRITE moved.
- All three drivers' \`CreateTableWithOptions\` call \`CacheTableDDL\` on every successful exec, not just on retry success.
- Updated \`CacheTableDDL\` docstring + \`TableTypeMapper\` interface comment to reflect "this is the only cache-write entry point."

## Cache lifecycle is now

- Successful first-try: writer caches after exec
- Successful Nth-try retry: writer caches after exec (unchanged)
- **Failed first-try: NOTHING gets cached → next call invokes AI fresh** (the failure mode #32 was about)
- Failed retry: nothing gets cached for the bad DDL

## Test plan

- [x] \`TestGenerateTableDDL_DoesNotAutoCache_Issue32\` — mock LM Studio, call \`GenerateTableDDL\`, assert mapper cache empty until explicit \`CacheTableDDL\`, then assert it populates
- [x] \`TestGenerateTableDDL_FailedFirstTryDoesNotPoison_Issue32\` — two consecutive \`GenerateTableDDL\` calls without an intervening \`CacheTableDDL\` must each invoke the AI (callCount == 2); pre-#32 the second would have hit the cache
- [x] Existing \`TestCacheTableDDL\` still passes — direct \`CacheTableDDL\` path is unchanged
- [x] \`go test -short ./...\` green
- [x] **E2E with gpt-oss-20b mysql→pg** (the case that motivated #32):
  - Run 1 (cache cleared): 2m2s, 14 tables generated, cache populated to 14 entries
  - Run 2 (cache populated): 1m18s — table phase instant from cache, only finalize phases re-ran. Confirms cache is functioning AND populated correctly by the writer after first-try success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)