### PR TITLE
Tighten retry-corrective prompt to forbid prose responses (closes #34)

### DIFF
--- a/internal/driver/ai_typemapper.go
+++ b/internal/driver/ai_typemapper.go
@@ -2056,10 +2056,19 @@ func writeFinalizationPriorAttempt(sb *strings.Builder, req FinalizationDDLReque
 // allowlists and rely on the model to recognize cases where retry is futile.
 // Phrasing examples come from real cases that surfaced in matrix runs:
 // PG 42883 (uuid()), MySQL 1213 (deadlock), MSSQL 2714 (already exists).
+//
+// The strict-output paragraph at the end is the #34 fix: smaller / chattier
+// models (haiku 4.5 in particular) sometimes interpret the corrective context
+// as inviting analysis and respond in natural language, which the parser
+// rejects as malformed and surfaces as a hard run-killer. The asymmetric old
+// wording strictly enforced "no prose" only on the bail branch; this version
+// applies the same strictness to the fix branch too. See issue #34 for the
+// observed haiku case (concat() not immutable on PG generated column).
 func writeRetryClassificationInstruction(sb *strings.Builder) {
 	sb.WriteString("\nIMPORTANT — RETRY CLASSIFICATION:\n")
 	sb.WriteString("If, after reading the database error, you determine that retrying will NOT help — for example: the object already exists in the target, an FK references a missing parent, the user lacks permission, the error is a real data-integrity violation, the operation deadlocked, or the connection failed — respond with ONLY the literal text NOT_RETRYABLE on the first line, optionally followed by ': ' and a one-sentence reason. Emit no DDL, no code fences, no other text in that case.\n")
 	sb.WriteString("Otherwise (the error indicates a fixable defect in the DDL — wrong syntax, unknown type, undeclared function, malformed clause, etc.), return the corrected DDL as instructed above.\n")
+	sb.WriteString("\nSTRICT OUTPUT REQUIREMENT: your entire response must be EITHER a complete DDL statement OR the NOT_RETRYABLE marker (with optional reason). Do not include explanations, analysis, commentary, code fences, markdown, or any prose outside SQL syntax. If you would otherwise discuss the problem in words, write the corrected DDL instead — or, if no DDL can fix it, write NOT_RETRYABLE: <reason>. Output the SQL statement (or the marker) directly with no preamble.\n")
 }
 
 // buildIndexDDLPrompt creates the AI prompt for index DDL generation.

--- a/internal/driver/ai_typemapper_test.go
+++ b/internal/driver/ai_typemapper_test.go
@@ -1329,6 +1329,10 @@ func TestBuildFinalizationDDLPrompt_PreviousAttempt(t *testing.T) {
 				// prompts also invite NOT_RETRYABLE bailout on non-fixable errors.
 				"NOT_RETRYABLE",
 				"RETRY CLASSIFICATION",
+				// #34 fix: strict-output requirement to stop chatty models
+				// (haiku 4.5) from returning prose instead of DDL/marker.
+				"STRICT OUTPUT REQUIREMENT",
+				"Do not include explanations",
 			} {
 				if !strings.Contains(prompt, p) {
 					t.Errorf("prompt missing required phrase %q\n--- prompt tail ---\n%s",
@@ -1969,6 +1973,10 @@ func TestBuildTableDDLPrompt_PreviousAttempt(t *testing.T) {
 				// must invite the model to bail with NOT_RETRYABLE on non-fixable errors.
 				"NOT_RETRYABLE",
 				"RETRY CLASSIFICATION",
+				// #34 fix: strict-output requirement to stop chatty models
+				// (haiku 4.5) from returning prose instead of DDL/marker.
+				"STRICT OUTPUT REQUIREMENT",
+				"Do not include explanations",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Closes #34. The retry-corrective prompt instruction had asymmetric output strictness — the bail branch enforced "no prose, only the marker" but the fix branch only said "return the corrected DDL as instructed above," which let chattier models (haiku 4.5) interpret the corrective context as inviting analysis. Their explanatory response then got rejected by the strict parser, killing the run.

## Fix

Appended a unified STRICT OUTPUT REQUIREMENT paragraph applying to both branches:

> Your entire response must be EITHER a complete DDL statement OR the NOT_RETRYABLE marker (with optional reason). Do not include explanations, analysis, commentary, code fences, markdown, or any prose outside SQL syntax. If you would otherwise discuss the problem in words, write the corrected DDL instead — or, if no DDL can fix it, write NOT_RETRYABLE: <reason>. Output the SQL statement (or the marker) directly with no preamble.

Two-line touch in \`writeRetryClassificationInstruction\`; existing prompt-builder tests updated to assert the new phrases are present when PreviousAttempt is set.

## Test plan

- [x] \`TestBuildTableDDLPrompt_PreviousAttempt\` and \`TestBuildFinalizationDDLPrompt_PreviousAttempt\` — assert "STRICT OUTPUT REQUIREMENT" + "Do not include explanations" appear in retry prompts
- [x] \`go test -short ./...\` green
- [x] **E2E with haiku 4.5 on the exact case from #34**: \`mysql → pg\` employees table, PG's \`generation expression is not immutable\` (SQLSTATE 42P17)
  - Pre-fix (yesterday's matrix run): retry attempt 1/3 returned prose → parser rejected → run died at exit 3
  - Post-fix (this commit): retry attempt 1/3 returned valid corrected DDL → succeeded on retry → schema build complete in 15.8s

🤖 Generated with [Claude Code](https://claude.com/claude-code)