### PR TITLE
Optional per-provider reasoning_effort hint for OpenAI-compat APIs

### DIFF
--- a/internal/driver/ai_typemapper.go
+++ b/internal/driver/ai_typemapper.go
@@ -755,7 +755,13 @@ type openAIRequest struct {
 	MaxCompletionTokens int                    `json:"max_completion_tokens,omitempty"`
 	MaxTokens           int                    `json:"max_tokens,omitempty"`
 	Temperature         float64                `json:"temperature"`
-	Options             map[string]interface{} `json:"options,omitempty"` // Provider-specific options (e.g., Ollama's num_ctx for context window size)
+	// ReasoningEffort is sent only when non-empty (`,omitempty` — empty string
+	// drops the field). Maps to Provider.ReasoningEffort in the secrets file:
+	// "low" / "medium" / "high" hint the server toward less or more reasoning.
+	// gpt-oss / OpenAI o-series / gpt-5.x honor it; non-reasoning models
+	// silently ignore it. Omit to use the model's built-in default.
+	ReasoningEffort string                 `json:"reasoning_effort,omitempty"`
+	Options         map[string]interface{} `json:"options,omitempty"` // Provider-specific options (e.g., Ollama's num_ctx for context window size)
 }
 
 type openAIMessage struct {
@@ -835,6 +841,7 @@ func (m *AITypeMapper) queryOpenAIAPIWithTokens(ctx context.Context, prompt stri
 		},
 		MaxCompletionTokens: maxTokens,
 		Temperature:         m.provider.GetEffectiveModelTemperature(),
+		ReasoningEffort:     m.provider.ReasoningEffort,
 	}
 
 	jsonBody, err := json.Marshal(reqBody)
@@ -915,6 +922,7 @@ func (m *AITypeMapper) queryOpenAICompatAPIWithTokens(ctx context.Context, promp
 		},
 		MaxCompletionTokens: maxTokens,
 		Temperature:         m.provider.GetEffectiveModelTemperature(),
+		ReasoningEffort:     m.provider.ReasoningEffort,
 	}
 
 	// For local providers (Ollama/LMStudio), use max_tokens (older OpenAI-compatible API)

--- a/internal/driver/ai_typemapper_test.go
+++ b/internal/driver/ai_typemapper_test.go
@@ -2148,6 +2148,54 @@ func TestGenerateTableDDL_FailedFirstTryDoesNotPoison_Issue32(t *testing.T) {
 	}
 }
 
+// TestOpenAIRequest_ReasoningEffort_Optional confirms the contract that the
+// reasoning_effort field is sent only when the user explicitly set
+// Provider.ReasoningEffort. Empty (omitted in YAML) → field absent from the
+// request body, so the server uses the model's built-in default. Set →
+// field present with the configured value.
+//
+// Reasoning-capable models (gpt-oss, OpenAI o-series, gpt-5.x) honor the
+// hint; non-reasoning models silently ignore it. The optional/empty default
+// preserves prior behavior for users who haven't touched the setting.
+func TestOpenAIRequest_ReasoningEffort_Optional(t *testing.T) {
+	tests := []struct {
+		name        string
+		effort      string
+		wantPresent bool
+		wantValue   string
+	}{
+		{"empty effort → field absent", "", false, ""},
+		{"low effort", "low", true, "low"},
+		{"medium effort", "medium", true, "medium"},
+		{"high effort", "high", true, "high"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := openAIRequest{
+				Model:           "test-model",
+				Messages:        []openAIMessage{{Role: "user", Content: "x"}},
+				ReasoningEffort: tt.effort,
+			}
+			body, err := json.Marshal(req)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal(body, &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			got, present := decoded["reasoning_effort"]
+			if present != tt.wantPresent {
+				t.Errorf("reasoning_effort present=%v, want %v\nbody: %s", present, tt.wantPresent, body)
+			}
+			if tt.wantPresent && got != tt.wantValue {
+				t.Errorf("reasoning_effort=%v, want %q", got, tt.wantValue)
+			}
+		})
+	}
+}
+
 // TestCacheTableDDL is a regression guard for the cache-replacement behavior
 // the writer relies on after a successful retry. Without this, a first-try
 // call that produced bad DDL would leave the bad DDL cached, and a future

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -81,6 +81,7 @@ type Provider struct {
 	MaxTokens        int      `yaml:"max_tokens,omitempty"`        // Optional, max output tokens (default: 16000 for local, 4000 for cloud)
 	TimeoutSeconds   int      `yaml:"timeout_seconds,omitempty"`   // Optional, API timeout in seconds (default: 30 for cloud, 120 for local)
 	ModelTemperature *float64 `yaml:"model_temperature,omitempty"` // Optional sampling temperature for the model. Defaults to 0 (deterministic). Some providers reject 0 for certain models — e.g. OpenAI reasoning models (o-series, gpt-5.x) require model_temperature: 1.
+	ReasoningEffort  string   `yaml:"reasoning_effort,omitempty"`  // Optional reasoning_effort hint for reasoning-capable models (gpt-oss, OpenAI o-series, gpt-5.x). Allowed values: "low", "medium", "high". Empty (omitted) means don't send the field — the server uses the model's built-in default (typically "medium" for gpt-oss). Set to "low" to trade reliability for ~2-3× speed; set to "high" to trade speed for fewer retries.
 }
 
 // EncryptionConfig holds encryption-related secrets

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"gopkg.in/yaml.v3"
@@ -81,7 +82,7 @@ type Provider struct {
 	MaxTokens        int      `yaml:"max_tokens,omitempty"`        // Optional, max output tokens (default: 16000 for local, 4000 for cloud)
 	TimeoutSeconds   int      `yaml:"timeout_seconds,omitempty"`   // Optional, API timeout in seconds (default: 30 for cloud, 120 for local)
 	ModelTemperature *float64 `yaml:"model_temperature,omitempty"` // Optional sampling temperature for the model. Defaults to 0 (deterministic). Some providers reject 0 for certain models — e.g. OpenAI reasoning models (o-series, gpt-5.x) require model_temperature: 1.
-	ReasoningEffort  string   `yaml:"reasoning_effort,omitempty"`  // Optional reasoning_effort hint for reasoning-capable models (gpt-oss, OpenAI o-series, gpt-5.x). Allowed values: "low", "medium", "high". Empty (omitted) means don't send the field — the server uses the model's built-in default (typically "medium" for gpt-oss). Set to "low" to trade reliability for ~2-3× speed; set to "high" to trade speed for fewer retries.
+	ReasoningEffort  string   `yaml:"reasoning_effort,omitempty"`  // Optional reasoning_effort hint for reasoning-capable models (gpt-oss, OpenAI o-series, gpt-5.x). Allowed values: "low", "medium", "high" (case-insensitive, whitespace trimmed; normalized to lowercase by the config loader). Empty (omitted) means don't send the field — the server uses the model's built-in default (typically "medium" for gpt-oss). Set to "low" to trade reliability for ~2-3× speed; set to "high" to trade speed for fewer retries. Anything else fails Config.Validate() with a clear error message rather than getting silently ignored by the upstream API.
 }
 
 // EncryptionConfig holds encryption-related secrets
@@ -389,6 +390,22 @@ func validateProvider(name string, p *Provider) error {
 		}
 	}
 
+	// Normalize and validate reasoning_effort. Trim+lowercase first so
+	// stray whitespace and case variations don't reject input the user
+	// clearly meant to be valid; treat pure-whitespace as empty (don't
+	// send the field). Reject anything outside the allowed set so the
+	// config-load step catches typos like "lo" or "Hi" before they
+	// reach the upstream API as silently-ignored garbage.
+	normalized := strings.ToLower(strings.TrimSpace(p.ReasoningEffort))
+	switch normalized {
+	case "":
+		p.ReasoningEffort = "" // pure-whitespace input collapses to empty
+	case "low", "medium", "high":
+		p.ReasoningEffort = normalized
+	default:
+		return fmt.Errorf("provider %q has invalid reasoning_effort %q (allowed: \"low\", \"medium\", \"high\", or omit)", name, p.ReasoningEffort)
+	}
+
 	return nil
 }
 
@@ -559,6 +576,9 @@ ai:
       model: "gpt-4o"  # optional
       # model_temperature: 1  # required when model is an OpenAI reasoning family
       #                       # (o-series, gpt-5.x) — they reject the default 0
+      # reasoning_effort: "medium"  # optional: "low" | "medium" | "high"
+      #                             # Honored by reasoning models (o-series, gpt-5.x);
+      #                             # ignored by others. Omit to use the model default.
 
     gemini:
       api_key: ""  # Get from https://makersuite.google.com/
@@ -582,6 +602,10 @@ ai:
       model: "local-model"
       # context_window: 8192  # optional, configure based on your model
       # max_tokens: 16000     # optional, increase for reasoning models (e.g., Qwen3, GPT-OSS)
+      # reasoning_effort: "low"  # optional: "low" | "medium" | "high"
+      #                          # Honored by gpt-oss; ignored by non-reasoning models.
+      #                          # "low" trades reliability for ~2-3× speed; "high" trades
+      #                          # speed for fewer retries. Omit to use the model default.
 
 encryption:
   master_key: ""  # Used for encrypting profiles, generate with: openssl rand -base64 32

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -269,6 +269,51 @@ func containsHelper(s, substr string) bool {
 	return false
 }
 
+// TestValidateReasoningEffort pins the contract added in PR #36: empty is
+// always fine, the three allowed values pass through (case-insensitive,
+// whitespace trimmed, normalized to lowercase), pure-whitespace input
+// collapses to empty, and anything else fails Validate() with a message
+// that names both the field and the bad value. The validator catches typos
+// at config-load time so users don't silently lose the setting (some
+// upstream APIs would just ignore garbage values).
+func TestValidateReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		wantErr        bool
+		wantNormalized string
+	}{
+		{"empty is allowed (field not sent)", "", false, ""},
+		{"low passes through", "low", false, "low"},
+		{"medium passes through", "medium", false, "medium"},
+		{"high passes through", "high", false, "high"},
+		{"uppercase normalized to lowercase", "HIGH", false, "high"},
+		{"mixed case normalized", "Medium", false, "medium"},
+		{"whitespace trimmed", "  low  ", false, "low"},
+		{"pure whitespace collapses to empty", "   ", false, ""},
+		{"typo lo rejected", "lo", true, ""},
+		{"typo hihg rejected", "hihg", true, ""},
+		{"unrelated word rejected", "fast", true, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Provider{
+				BaseURL:         "http://localhost:1234", // satisfies the unknown-provider branch
+				ReasoningEffort: tt.input,
+			}
+			err := validateProvider("test-provider", p)
+			gotErr := err != nil
+			if gotErr != tt.wantErr {
+				t.Errorf("validateProvider err=%v, wantErr=%v (input=%q)", err, tt.wantErr, tt.input)
+			}
+			if !tt.wantErr && p.ReasoningEffort != tt.wantNormalized {
+				t.Errorf("normalized=%q, want %q (input=%q)", p.ReasoningEffort, tt.wantNormalized, tt.input)
+			}
+		})
+	}
+}
+
 func TestGetEffectiveModelTemperature(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

Adds an optional \`reasoning_effort\` knob to the per-provider config in \`~/.secrets/smt-config.yaml\`. Lets users hint reasoning-capable models (gpt-oss, OpenAI o-series, gpt-5.x) toward less or more reasoning per call.

\`\`\`yaml
ai:
  providers:
    lmstudio:
      base_url: \"http://localhost:1234\"
      model: \"openai/gpt-oss-20b\"
      reasoning_effort: \"low\"   # optional; \"low\" | \"medium\" | \"high\"
\`\`\`

## Behavior

- **Omitted (or empty)**: the field is NOT sent on the wire. Server uses the model's built-in default (typically \`medium\` for gpt-oss). Preserves prior behavior for everyone who hasn't touched the setting.
- **Set**: included verbatim in the OpenAI-compat request body. Non-reasoning models ignore it; reasoning-capable models honor it.

## Wire-up

- New \`Provider.ReasoningEffort string\` field with \`yaml:\"reasoning_effort,omitempty\"\` in \`internal/secrets/secrets.go\`
- New \`openAIRequest.ReasoningEffort\` field with \`json:\"reasoning_effort,omitempty\"\` so the empty case stays off the wire
- Threaded through the OpenAI cloud path (\`queryOpenAIAPI\`) and the OpenAI-compat path (\`queryOpenAICompatAPIWithTokens\` — used by lmstudio + ollama). Gemini uses a different body shape and isn't touched.

## Use case (from this session's matrix runs)

- gpt-oss-20b on M5 Pro defaulted to medium effort (~175 reasoning tokens / ~287 completion tokens per call). \`reasoning_effort: low\` would trade reliability for ~2-3× speed; \`reasoning_effort: high\` would trade speed for fewer retries on cross-dialect translations.

## Test plan

- [x] \`TestOpenAIRequest_ReasoningEffort_Optional\` covers all four cases — empty (field absent), low/medium/high (field present with the configured value)
- [x] \`go test -short ./...\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)