### PR TITLE
Cache finalization DDL + idempotent re-runs

### DIFF
--- a/internal/driver/ai_finalization_cache_test.go
+++ b/internal/driver/ai_finalization_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -493,5 +494,40 @@ func TestGenerateDropTableDDL_FailedFirstTryDoesNotPoison(t *testing.T) {
 	}
 	if got := calls.Load(); got != 2 {
 		t.Errorf("BUG: second GenerateDropTableDDL hit cache; got %d AI calls, want 2", got)
+	}
+}
+
+// TestGenerateDropTableDDL_RejectsNonIdempotent guards the validator: AI
+// output without IF EXISTS must not be returned (and therefore must not be
+// cached). All dialect prompts mandate IF EXISTS, but the cache replays the
+// exact AI output — a model that ignores the prompt would otherwise produce
+// a non-idempotent DDL that succeeds once and fails on every subsequent run.
+func TestGenerateDropTableDDL_RejectsNonIdempotent(t *testing.T) {
+	var calls atomic.Int32
+	// AI returns a bare "DROP TABLE" with no IF EXISTS.
+	server := finalizationDDLServer(t, "DROP TABLE public.foo;", &calls)
+	defer server.Close()
+
+	mapper := testMapperWithTempCache(t, "lmstudio", &secrets.Provider{
+		APIKey: "", Model: "test-model", BaseURL: server.URL,
+	})
+	mapper.client = server.Client()
+
+	req := DropTableDDLRequest{TargetDBType: "postgres", TargetSchema: "public", TableName: "foo"}
+	_, err := mapper.GenerateDropTableDDL(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error for non-idempotent DROP, got nil")
+	}
+	if !strings.Contains(err.Error(), "IF EXISTS") {
+		t.Errorf("expected error to mention IF EXISTS, got: %v", err)
+	}
+
+	// And nothing should have been cached as a side effect.
+	cacheKey := mapper.dropTableCacheKey(req)
+	mapper.cacheMu.RLock()
+	_, hit := mapper.cache.Get(cacheKey)
+	mapper.cacheMu.RUnlock()
+	if hit {
+		t.Error("non-idempotent DROP must not populate cache")
 	}
 }

--- a/internal/driver/ai_finalization_cache_test.go
+++ b/internal/driver/ai_finalization_cache_test.go
@@ -1,0 +1,497 @@
+package driver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"smt/internal/secrets"
+)
+
+// finalizationDDLServer returns an httptest server that responds to every
+// OpenAI-compatible chat completion request with the supplied DDL string,
+// and atomically increments the supplied counter on each call.
+func finalizationDDLServer(t *testing.T, ddl string, calls *atomic.Int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(openAIResponse{
+			Choices: []struct {
+				Message struct {
+					Content          string `json:"content"`
+					ReasoningContent string `json:"reasoning_content"`
+				} `json:"message"`
+				FinishReason string `json:"finish_reason"`
+			}{
+				{
+					Message: struct {
+						Content          string `json:"content"`
+						ReasoningContent string `json:"reasoning_content"`
+					}{Content: ddl},
+					FinishReason: "stop",
+				},
+			},
+		})
+	}))
+}
+
+// TestFinalizationCacheKey_SensitivityAndStability is the structural
+// counterpart of TestTableCacheKey_IncludesNewFields: the cache key must
+// change whenever a field that affects DDL changes, and stay stable
+// otherwise. Without this guard, a future code edit could silently make the
+// cache return stale DDL after a meaningful metadata change (e.g. flipping
+// IsUnique on an index, changing FK OnDelete, or rewriting a CHECK
+// definition).
+func TestFinalizationCacheKey_SensitivityAndStability(t *testing.T) {
+	m := &AITypeMapper{}
+
+	baseIdx := FinalizationDDLRequest{
+		Type:         DDLTypeIndex,
+		SourceDBType: "mssql", TargetDBType: "postgres",
+		TargetSchema: "public",
+		Table:        &Table{Name: "orders"},
+		Index: &Index{
+			Name:        "idx_customer",
+			Columns:     []string{"customer_id"},
+			IsUnique:    false,
+			IncludeCols: []string{},
+			Filter:      "",
+		},
+	}
+
+	baseFK := FinalizationDDLRequest{
+		Type:         DDLTypeForeignKey,
+		SourceDBType: "mssql", TargetDBType: "postgres",
+		TargetSchema: "public",
+		Table:        &Table{Name: "orders"},
+		ForeignKey: &ForeignKey{
+			Name:       "fk_customer",
+			Columns:    []string{"customer_id"},
+			RefSchema:  "public",
+			RefTable:   "customers",
+			RefColumns: []string{"id"},
+			OnDelete:   "NO ACTION",
+			OnUpdate:   "NO ACTION",
+		},
+	}
+
+	baseCheck := FinalizationDDLRequest{
+		Type:         DDLTypeCheckConstraint,
+		SourceDBType: "mssql", TargetDBType: "postgres",
+		TargetSchema: "public",
+		Table:        &Table{Name: "orders"},
+		CheckConstraint: &CheckConstraint{
+			Name:       "chk_total_positive",
+			Definition: "total >= 0",
+		},
+	}
+
+	t.Run("stable_under_repeat_call", func(t *testing.T) {
+		// Same input twice → same key.
+		for _, req := range []FinalizationDDLRequest{baseIdx, baseFK, baseCheck} {
+			a := m.finalizationCacheKey(req)
+			b := m.finalizationCacheKey(req)
+			if a != b {
+				t.Errorf("non-deterministic key for %s: %q vs %q", req.Type, a, b)
+			}
+			if a == "" {
+				t.Errorf("empty key for valid %s req", req.Type)
+			}
+		}
+	})
+
+	t.Run("disambiguates_ddl_types", func(t *testing.T) {
+		// Different DDL types must never collide even with shared metadata.
+		seen := map[string]DDLType{}
+		for _, req := range []FinalizationDDLRequest{baseIdx, baseFK, baseCheck} {
+			k := m.finalizationCacheKey(req)
+			if other, dup := seen[k]; dup {
+				t.Errorf("%s and %s produced same key %q", req.Type, other, k)
+			}
+			seen[k] = req.Type
+		}
+	})
+
+	idxCases := []struct {
+		name string
+		mut  func(r *FinalizationDDLRequest)
+	}{
+		{"unique_flipped", func(r *FinalizationDDLRequest) { r.Index.IsUnique = true }},
+		{"columns_changed", func(r *FinalizationDDLRequest) { r.Index.Columns = []string{"order_id"} }},
+		{"include_cols_added", func(r *FinalizationDDLRequest) { r.Index.IncludeCols = []string{"total"} }},
+		{"filter_added", func(r *FinalizationDDLRequest) { r.Index.Filter = "active = 1" }},
+		{"name_changed", func(r *FinalizationDDLRequest) { r.Index.Name = "idx_other" }},
+		{"target_schema_changed", func(r *FinalizationDDLRequest) { r.TargetSchema = "audit" }},
+		{"table_changed", func(r *FinalizationDDLRequest) { r.Table = &Table{Name: "shipments"} }},
+		{"target_db_changed", func(r *FinalizationDDLRequest) { r.TargetDBType = "mysql" }},
+		{"source_db_changed", func(r *FinalizationDDLRequest) { r.SourceDBType = "mysql" }},
+	}
+	for _, tc := range idxCases {
+		t.Run("index_"+tc.name, func(t *testing.T) {
+			req := baseIdx
+			req.Index = &Index{
+				Name: baseIdx.Index.Name, Columns: append([]string{}, baseIdx.Index.Columns...),
+				IsUnique: baseIdx.Index.IsUnique, IncludeCols: append([]string{}, baseIdx.Index.IncludeCols...), Filter: baseIdx.Index.Filter,
+			}
+			tc.mut(&req)
+			if a, b := m.finalizationCacheKey(baseIdx), m.finalizationCacheKey(req); a == b {
+				t.Errorf("index key did not change after %s\nbase: %s\ngot:  %s", tc.name, a, b)
+			}
+		})
+	}
+
+	fkCases := []struct {
+		name string
+		mut  func(r *FinalizationDDLRequest)
+	}{
+		{"name_changed", func(r *FinalizationDDLRequest) { r.ForeignKey.Name = "fk_other" }},
+		{"columns_changed", func(r *FinalizationDDLRequest) { r.ForeignKey.Columns = []string{"order_id"} }},
+		{"ref_table_changed", func(r *FinalizationDDLRequest) { r.ForeignKey.RefTable = "users" }},
+		{"ref_columns_changed", func(r *FinalizationDDLRequest) { r.ForeignKey.RefColumns = []string{"user_id"} }},
+		{"ref_schema_changed", func(r *FinalizationDDLRequest) { r.ForeignKey.RefSchema = "audit" }},
+		{"on_delete_changed", func(r *FinalizationDDLRequest) { r.ForeignKey.OnDelete = "CASCADE" }},
+		{"on_update_changed", func(r *FinalizationDDLRequest) { r.ForeignKey.OnUpdate = "SET NULL" }},
+	}
+	for _, tc := range fkCases {
+		t.Run("fk_"+tc.name, func(t *testing.T) {
+			req := baseFK
+			req.ForeignKey = &ForeignKey{
+				Name: baseFK.ForeignKey.Name, Columns: append([]string{}, baseFK.ForeignKey.Columns...),
+				RefSchema: baseFK.ForeignKey.RefSchema, RefTable: baseFK.ForeignKey.RefTable,
+				RefColumns: append([]string{}, baseFK.ForeignKey.RefColumns...),
+				OnDelete:   baseFK.ForeignKey.OnDelete, OnUpdate: baseFK.ForeignKey.OnUpdate,
+			}
+			tc.mut(&req)
+			if a, b := m.finalizationCacheKey(baseFK), m.finalizationCacheKey(req); a == b {
+				t.Errorf("fk key did not change after %s\nbase: %s\ngot:  %s", tc.name, a, b)
+			}
+		})
+	}
+
+	chkCases := []struct {
+		name string
+		mut  func(r *FinalizationDDLRequest)
+	}{
+		{"name_changed", func(r *FinalizationDDLRequest) { r.CheckConstraint.Name = "chk_other" }},
+		{"definition_changed", func(r *FinalizationDDLRequest) { r.CheckConstraint.Definition = "total > 0" }},
+	}
+	for _, tc := range chkCases {
+		t.Run("check_"+tc.name, func(t *testing.T) {
+			req := baseCheck
+			req.CheckConstraint = &CheckConstraint{
+				Name: baseCheck.CheckConstraint.Name, Definition: baseCheck.CheckConstraint.Definition,
+			}
+			tc.mut(&req)
+			if a, b := m.finalizationCacheKey(baseCheck), m.finalizationCacheKey(req); a == b {
+				t.Errorf("check key did not change after %s\nbase: %s\ngot:  %s", tc.name, a, b)
+			}
+		})
+	}
+
+	t.Run("target_table_ddl_does_not_change_key", func(t *testing.T) {
+		// TargetTableDDL is prompt context, not part of the constraint
+		// fingerprint. If it changed the key, every FK/index/check would
+		// re-invalidate any time an unrelated column on the parent table
+		// changed — defeating the cache on incremental re-runs.
+		req := baseFK
+		req.TargetTableDDL = "CREATE TABLE orders (...);"
+		baseKey := m.finalizationCacheKey(baseFK)
+		ctxKey := m.finalizationCacheKey(req)
+		if baseKey != ctxKey {
+			t.Errorf("TargetTableDDL must not affect cache key:\n  base: %s\n  ctx:  %s", baseKey, ctxKey)
+		}
+	})
+
+	t.Run("unknown_type_returns_empty", func(t *testing.T) {
+		// Defensive: bogus DDLType returns empty key, which CacheFinalizationDDL
+		// treats as a no-op (avoids polluting the cache file with garbage).
+		req := FinalizationDDLRequest{Type: DDLType("nope"), Table: &Table{Name: "x"}}
+		if k := m.finalizationCacheKey(req); k != "" {
+			t.Errorf("expected empty key for unknown type, got %q", k)
+		}
+	})
+}
+
+// TestGenerateFinalizationDDL_DoesNotAutoCache mirrors the table-DDL #32
+// regression test: GenerateFinalizationDDL must NOT write to the cache,
+// because at that point the AI's output hasn't been validated against the
+// target database. The writer's CacheFinalizationDDL is the only path that
+// populates the cache, and it's only called after a successful exec — so a
+// failed DDL can't poison the cache for subsequent runs.
+func TestGenerateFinalizationDDL_DoesNotAutoCache(t *testing.T) {
+	cases := []struct {
+		name string
+		ddl  string
+		req  FinalizationDDLRequest
+	}{
+		{
+			name: "index",
+			ddl:  "CREATE INDEX idx_foo ON public.t (a);",
+			req: FinalizationDDLRequest{
+				Type:         DDLTypeIndex,
+				SourceDBType: "mssql", TargetDBType: "postgres",
+				TargetSchema: "public", Table: &Table{Name: "t"},
+				Index: &Index{Name: "idx_foo", Columns: []string{"a"}},
+			},
+		},
+		{
+			name: "fk",
+			ddl:  "ALTER TABLE public.t ADD CONSTRAINT fk_foo FOREIGN KEY (a) REFERENCES public.p (id);",
+			req: FinalizationDDLRequest{
+				Type:         DDLTypeForeignKey,
+				SourceDBType: "mssql", TargetDBType: "postgres",
+				TargetSchema: "public", Table: &Table{Name: "t"},
+				ForeignKey: &ForeignKey{
+					Name: "fk_foo", Columns: []string{"a"},
+					RefSchema: "public", RefTable: "p", RefColumns: []string{"id"},
+				},
+			},
+		},
+		{
+			name: "check",
+			ddl:  "ALTER TABLE public.t ADD CONSTRAINT chk_foo CHECK (a >= 0);",
+			req: FinalizationDDLRequest{
+				Type:         DDLTypeCheckConstraint,
+				SourceDBType: "mssql", TargetDBType: "postgres",
+				TargetSchema: "public", Table: &Table{Name: "t"},
+				CheckConstraint: &CheckConstraint{Name: "chk_foo", Definition: "a >= 0"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			server := finalizationDDLServer(t, tc.ddl, &calls)
+			defer server.Close()
+
+			mapper := testMapperWithTempCache(t, "lmstudio", &secrets.Provider{
+				APIKey: "", Model: "test-model", BaseURL: server.URL,
+			})
+			mapper.client = server.Client()
+
+			if _, err := mapper.GenerateFinalizationDDL(context.Background(), tc.req); err != nil {
+				t.Fatalf("GenerateFinalizationDDL: %v", err)
+			}
+
+			// Cache must remain empty until CacheFinalizationDDL is called.
+			cacheKey := mapper.finalizationCacheKey(tc.req)
+			mapper.cacheMu.RLock()
+			_, hit := mapper.cache.Get(cacheKey)
+			mapper.cacheMu.RUnlock()
+			if hit {
+				t.Errorf("BUG: mapper auto-cached AI output before exec validation; cache must remain empty until CacheFinalizationDDL is called")
+			}
+
+			// Sanity: explicit CacheFinalizationDDL populates the cache.
+			mapper.CacheFinalizationDDL(tc.req, tc.ddl)
+			mapper.cacheMu.RLock()
+			cached, _ := mapper.cache.Get(cacheKey)
+			mapper.cacheMu.RUnlock()
+			if cached != tc.ddl {
+				t.Errorf("explicit CacheFinalizationDDL didn't populate cache:\n  got:  %q\n  want: %q", cached, tc.ddl)
+			}
+		})
+	}
+}
+
+// TestGenerateFinalizationDDL_FailedFirstTryDoesNotPoison: two successive
+// GenerateFinalizationDDL calls without an intervening CacheFinalizationDDL
+// must each invoke the AI. Without this property, a first call that
+// generated bad DDL would cache it and every subsequent run would fail in
+// the same way without ever giving the AI another chance.
+func TestGenerateFinalizationDDL_FailedFirstTryDoesNotPoison(t *testing.T) {
+	var calls atomic.Int32
+	server := finalizationDDLServer(t, "CREATE INDEX idx_foo ON public.t (a);", &calls)
+	defer server.Close()
+
+	mapper := testMapperWithTempCache(t, "lmstudio", &secrets.Provider{
+		APIKey: "", Model: "test-model", BaseURL: server.URL,
+	})
+	mapper.client = server.Client()
+
+	req := FinalizationDDLRequest{
+		Type:         DDLTypeIndex,
+		SourceDBType: "mssql", TargetDBType: "postgres",
+		TargetSchema: "public", Table: &Table{Name: "t"},
+		Index: &Index{Name: "idx_foo", Columns: []string{"a"}},
+	}
+
+	// Simulate writer calling GenerateFinalizationDDL but exec subsequently
+	// failing — so CacheFinalizationDDL is never invoked.
+	if _, err := mapper.GenerateFinalizationDDL(context.Background(), req); err != nil {
+		t.Fatalf("first GenerateFinalizationDDL: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected 1 AI call, got %d", got)
+	}
+	if _, err := mapper.GenerateFinalizationDDL(context.Background(), req); err != nil {
+		t.Fatalf("second GenerateFinalizationDDL: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("BUG: second GenerateFinalizationDDL hit cache instead of re-calling AI; got %d total calls, want 2", got)
+	}
+}
+
+// TestGenerateFinalizationDDL_RetrySkipsCache covers the retry path: a call
+// with PreviousAttempt set must bypass any cached value. Otherwise the
+// retry would return the stale (just-failed) DDL instead of giving the AI
+// the corrective context.
+func TestGenerateFinalizationDDL_RetrySkipsCache(t *testing.T) {
+	var calls atomic.Int32
+	server := finalizationDDLServer(t, "CREATE INDEX idx_foo ON public.t (a);", &calls)
+	defer server.Close()
+
+	mapper := testMapperWithTempCache(t, "lmstudio", &secrets.Provider{
+		APIKey: "", Model: "test-model", BaseURL: server.URL,
+	})
+	mapper.client = server.Client()
+
+	req := FinalizationDDLRequest{
+		Type:         DDLTypeIndex,
+		SourceDBType: "mssql", TargetDBType: "postgres",
+		TargetSchema: "public", Table: &Table{Name: "t"},
+		Index: &Index{Name: "idx_foo", Columns: []string{"a"}},
+	}
+	// Pre-populate the cache to verify retry bypasses it.
+	mapper.CacheFinalizationDDL(req, "CACHED-BAD-DDL-MUST-NOT-RETURN")
+
+	// First call: no PreviousAttempt → cache hit, no AI call.
+	if _, err := mapper.GenerateFinalizationDDL(context.Background(), req); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if got := calls.Load(); got != 0 {
+		t.Errorf("first-try call should have hit cache (no AI call), got %d AI calls", got)
+	}
+
+	// Retry call: PreviousAttempt set → must skip cache and call AI.
+	retryReq := req
+	retryReq.PreviousAttempt = &FinalizationDDLAttempt{DDL: "bad", Error: "syntax"}
+	if _, err := mapper.GenerateFinalizationDDL(context.Background(), retryReq); err != nil {
+		t.Fatalf("retry call: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("retry call should have invoked AI (cache skipped); got %d AI calls", got)
+	}
+}
+
+// TestCacheFinalizationDDL exercises the writer's post-exec cache-write
+// entry point. After CacheFinalizationDDL stores validated DDL, a
+// subsequent first-try GenerateFinalizationDDL call hits the cache and
+// makes zero AI calls. Replace-not-append behavior is also asserted: a
+// second CacheFinalizationDDL with different DDL overwrites the prior
+// value — without that, a successful retry couldn't fully clean up a
+// previously-cached bad DDL.
+func TestCacheFinalizationDDL(t *testing.T) {
+	var calls atomic.Int32
+	server := finalizationDDLServer(t, "AI-RESPONSE-MUST-NOT-BE-NEEDED", &calls)
+	defer server.Close()
+
+	mapper := testMapperWithTempCache(t, "lmstudio", &secrets.Provider{
+		APIKey: "", Model: "test-model", BaseURL: server.URL,
+	})
+	mapper.client = server.Client()
+
+	req := FinalizationDDLRequest{
+		Type:         DDLTypeForeignKey,
+		SourceDBType: "mssql", TargetDBType: "postgres",
+		TargetSchema: "public", Table: &Table{Name: "orders"},
+		ForeignKey: &ForeignKey{
+			Name: "fk_customer", Columns: []string{"customer_id"},
+			RefSchema: "public", RefTable: "customers", RefColumns: []string{"id"},
+		},
+	}
+
+	const validatedDDL = "ALTER TABLE public.orders ADD CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES public.customers (id);"
+	mapper.CacheFinalizationDDL(req, validatedDDL)
+
+	got, err := mapper.GenerateFinalizationDDL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GenerateFinalizationDDL after cache prime: %v", err)
+	}
+	if got != validatedDDL {
+		t.Errorf("cache-hit path returned wrong DDL:\n  got:  %q\n  want: %q", got, validatedDDL)
+	}
+	if c := calls.Load(); c != 0 {
+		t.Errorf("cache hit should not invoke AI; got %d AI calls", c)
+	}
+
+	// Replace-not-append.
+	const replacementDDL = "ALTER TABLE public.orders ADD CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES public.customers (id) ON DELETE CASCADE;"
+	mapper.CacheFinalizationDDL(req, replacementDDL)
+	got, err = mapper.GenerateFinalizationDDL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GenerateFinalizationDDL after replacement: %v", err)
+	}
+	if got != replacementDDL {
+		t.Errorf("CacheFinalizationDDL did not replace prior value:\n  got:  %q\n  want: %q", got, replacementDDL)
+	}
+}
+
+// TestGenerateDropTableDDL_DoesNotAutoCache mirrors #32 for DROP TABLE: the
+// mapper must not write to its own cache. Pre-#32 the DROP path auto-cached
+// AI output; this test guards against regressions to that behavior.
+func TestGenerateDropTableDDL_DoesNotAutoCache(t *testing.T) {
+	var calls atomic.Int32
+	server := finalizationDDLServer(t, "DROP TABLE IF EXISTS public.foo CASCADE;", &calls)
+	defer server.Close()
+
+	mapper := testMapperWithTempCache(t, "lmstudio", &secrets.Provider{
+		APIKey: "", Model: "test-model", BaseURL: server.URL,
+	})
+	mapper.client = server.Client()
+
+	req := DropTableDDLRequest{
+		TargetDBType: "postgres", TargetSchema: "public", TableName: "foo",
+	}
+	if _, err := mapper.GenerateDropTableDDL(context.Background(), req); err != nil {
+		t.Fatalf("GenerateDropTableDDL: %v", err)
+	}
+
+	cacheKey := mapper.dropTableCacheKey(req)
+	mapper.cacheMu.RLock()
+	_, hit := mapper.cache.Get(cacheKey)
+	mapper.cacheMu.RUnlock()
+	if hit {
+		t.Errorf("BUG: GenerateDropTableDDL auto-cached AI output; cache must remain empty until CacheDropTableDDL is called")
+	}
+
+	// Sanity: CacheDropTableDDL populates the cache, and a subsequent
+	// Generate call hits it without calling AI.
+	mapper.CacheDropTableDDL(req, "DROP TABLE IF EXISTS public.foo CASCADE;")
+	calls.Store(0)
+	if _, err := mapper.GenerateDropTableDDL(context.Background(), req); err != nil {
+		t.Fatalf("second GenerateDropTableDDL: %v", err)
+	}
+	if c := calls.Load(); c != 0 {
+		t.Errorf("post-CacheDropTableDDL Generate should hit cache, got %d AI calls", c)
+	}
+}
+
+// TestGenerateDropTableDDL_FailedFirstTryDoesNotPoison: two Generate calls
+// without intervening CacheDropTableDDL must each invoke the AI.
+func TestGenerateDropTableDDL_FailedFirstTryDoesNotPoison(t *testing.T) {
+	var calls atomic.Int32
+	server := finalizationDDLServer(t, "DROP TABLE IF EXISTS public.foo CASCADE;", &calls)
+	defer server.Close()
+
+	mapper := testMapperWithTempCache(t, "lmstudio", &secrets.Provider{
+		APIKey: "", Model: "test-model", BaseURL: server.URL,
+	})
+	mapper.client = server.Client()
+
+	req := DropTableDDLRequest{TargetDBType: "postgres", TargetSchema: "public", TableName: "foo"}
+	if _, err := mapper.GenerateDropTableDDL(context.Background(), req); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if _, err := mapper.GenerateDropTableDDL(context.Background(), req); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("BUG: second GenerateDropTableDDL hit cache; got %d AI calls, want 2", got)
+	}
+}

--- a/internal/driver/ai_typemapper.go
+++ b/internal/driver/ai_typemapper.go
@@ -1947,6 +1947,12 @@ func truncateString(s string, maxLen int) string {
 }
 
 // GenerateFinalizationDDL generates DDL for indexes, foreign keys, or check constraints using AI.
+//
+// Caching mirrors GenerateTableDDL (#32): cache is consulted only on first-try
+// calls; retry calls (PreviousAttempt != nil) bypass the cache so the model
+// gets a fresh chance with the corrective context. Cache writes happen
+// post-exec via CacheFinalizationDDL — never inside the mapper — so a DDL the
+// AI emits but the database rejects can't poison future runs.
 func (m *AITypeMapper) GenerateFinalizationDDL(ctx context.Context, req FinalizationDDLRequest) (string, error) {
 	if req.Table == nil {
 		return "", fmt.Errorf("Table is required")
@@ -1994,6 +2000,19 @@ func (m *AITypeMapper) GenerateFinalizationDDL(ctx context.Context, req Finaliza
 		return "", fmt.Errorf("unknown DDL type: %s", req.Type)
 	}
 
+	cacheKey := m.finalizationCacheKey(req)
+	isRetry := req.PreviousAttempt != nil
+	if !isRetry {
+		m.cacheMu.RLock()
+		if cached, ok := m.cache.Get(cacheKey); ok {
+			m.cacheMu.RUnlock()
+			logging.Debug("AI finalization DDL cache hit: %s on %s.%s",
+				entityName, req.TargetSchema, req.Table.Name)
+			return cached, nil
+		}
+		m.cacheMu.RUnlock()
+	}
+
 	result, err := m.CallAI(ctx, prompt)
 	if err != nil {
 		return "", fmt.Errorf("AI DDL generation failed for %s.%s: %w",
@@ -2022,6 +2041,78 @@ func (m *AITypeMapper) GenerateFinalizationDDL(ctx context.Context, req Finaliza
 	logging.Debug("AI generated DDL:\n%s", ddl)
 
 	return ddl, nil
+}
+
+// finalizationCacheKey builds a cache key for finalization DDL (index / FK /
+// CHECK). Mirrors tableCacheKey: deterministic, prefixed by DDL type to
+// disambiguate from table:/drop: keys in the same shared cache file.
+//
+// The key intentionally excludes TargetTableDDL — that's prompt context, not
+// a fingerprint of the constraint being created. Including it would
+// re-invalidate every FK whenever any unrelated column on the parent table
+// changed, defeating the cache's purpose on incremental re-runs.
+//
+// SourceDBType is included even though current FK/index/check prompts don't
+// use it: defensive against future prompt changes that would leak via stale
+// cache. Same shape as tableCacheKey.
+func (m *AITypeMapper) finalizationCacheKey(req FinalizationDDLRequest) string {
+	switch req.Type {
+	case DDLTypeIndex:
+		idx := req.Index
+		if idx == nil {
+			return ""
+		}
+		return fmt.Sprintf("index:%s:%s:%s.%s:%s:unique=%v:cols=[%s]:incl=[%s]:filter=%s",
+			req.SourceDBType, req.TargetDBType, req.TargetSchema, req.Table.Name,
+			idx.Name, idx.IsUnique,
+			strings.Join(idx.Columns, ","),
+			strings.Join(idx.IncludeCols, ","),
+			idx.Filter)
+	case DDLTypeForeignKey:
+		fk := req.ForeignKey
+		if fk == nil {
+			return ""
+		}
+		return fmt.Sprintf("fk:%s:%s:%s.%s:%s:cols=[%s]:ref=%s.%s:refcols=[%s]:onDel=%s:onUpd=%s",
+			req.SourceDBType, req.TargetDBType, req.TargetSchema, req.Table.Name,
+			fk.Name,
+			strings.Join(fk.Columns, ","),
+			fk.RefSchema, fk.RefTable,
+			strings.Join(fk.RefColumns, ","),
+			fk.OnDelete, fk.OnUpdate)
+	case DDLTypeCheckConstraint:
+		chk := req.CheckConstraint
+		if chk == nil {
+			return ""
+		}
+		return fmt.Sprintf("check:%s:%s:%s.%s:%s:def=%s",
+			req.SourceDBType, req.TargetDBType, req.TargetSchema, req.Table.Name,
+			chk.Name, chk.Definition)
+	default:
+		return ""
+	}
+}
+
+// CacheFinalizationDDL stores a known-good DDL for the request, replacing any
+// prior cached value. This is the ONLY entry point that writes to the
+// finalization-DDL cache — the mapper itself is read-only on the cache
+// (see #32). Writers call this after every successful exec (first-try and
+// retry alike); a failed exec leaves the cache untouched.
+func (m *AITypeMapper) CacheFinalizationDDL(req FinalizationDDLRequest, ddl string) {
+	cacheKey := m.finalizationCacheKey(req)
+	if cacheKey == "" {
+		// Unknown DDL type or missing required entity — silently no-op rather
+		// than persist garbage. The Generate path already errors on these
+		// cases so this branch is defensive against direct CacheFinalizationDDL
+		// callers in tests.
+		return
+	}
+	m.cacheMu.Lock()
+	m.cache.Set(cacheKey, ddl)
+	m.cacheMu.Unlock()
+	if err := m.saveCache(); err != nil {
+		logging.Warn("Failed to save AI finalization DDL cache: %v", err)
+	}
 }
 
 // writeFinalizationPriorAttempt appends a "PRIOR ATTEMPT FAILED" section to a
@@ -2273,13 +2364,15 @@ func (m *AITypeMapper) GenerateDropTableDDL(ctx context.Context, req DropTableDD
 		return "", fmt.Errorf("TargetDBType is required")
 	}
 
-	// Build cache key
-	cacheKey := fmt.Sprintf("drop:%s:%s.%s", req.TargetDBType, req.TargetSchema, req.TableName)
+	cacheKey := m.dropTableCacheKey(req)
 
-	// Check cache first
+	// Check cache first (read-only on this path; cache writes happen in
+	// CacheDropTableDDL after the writer confirms exec succeeded — same
+	// post-exec pattern as CacheTableDDL / CacheFinalizationDDL, see #32).
 	m.cacheMu.RLock()
 	if cached, ok := m.cache.Get(cacheKey); ok {
 		m.cacheMu.RUnlock()
+		logging.Debug("AI drop table DDL cache hit: %s.%s", req.TargetSchema, req.TableName)
 		return cached, nil
 	}
 	m.cacheMu.RUnlock()
@@ -2304,19 +2397,29 @@ func (m *AITypeMapper) GenerateDropTableDDL(ctx context.Context, req DropTableDD
 		return "", fmt.Errorf("response does not contain valid DROP statement: %s", truncateString(ddl, 100))
 	}
 
-	// Cache the result
-	m.cacheMu.Lock()
-	m.cache.Set(cacheKey, ddl)
-	m.cacheMu.Unlock()
-
-	// Persist cache
-	if err := m.saveCache(); err != nil {
-		logging.Warn("Failed to save AI drop table DDL cache: %v", err)
-	}
-
+	// Cache writes are deferred to CacheDropTableDDL post-exec — see #32.
 	logging.Debug("AI generated DROP DDL:\n%s", ddl)
 
 	return ddl, nil
+}
+
+// dropTableCacheKey builds the cache key for DROP TABLE DDL. Includes target
+// db type so a re-target doesn't reuse a sibling-engine DDL.
+func (m *AITypeMapper) dropTableCacheKey(req DropTableDDLRequest) string {
+	return fmt.Sprintf("drop:%s:%s.%s", req.TargetDBType, req.TargetSchema, req.TableName)
+}
+
+// CacheDropTableDDL stores a known-good DROP TABLE DDL post-exec. Mirrors
+// CacheTableDDL / CacheFinalizationDDL — only validated DDL ever reaches the
+// cache, so a failed exec can't poison subsequent runs (#32).
+func (m *AITypeMapper) CacheDropTableDDL(req DropTableDDLRequest, ddl string) {
+	cacheKey := m.dropTableCacheKey(req)
+	m.cacheMu.Lock()
+	m.cache.Set(cacheKey, ddl)
+	m.cacheMu.Unlock()
+	if err := m.saveCache(); err != nil {
+		logging.Warn("Failed to save AI drop table DDL cache: %v", err)
+	}
 }
 
 // buildDropTableDDLPrompt creates the AI prompt for DROP TABLE DDL generation.

--- a/internal/driver/ai_typemapper.go
+++ b/internal/driver/ai_typemapper.go
@@ -2391,10 +2391,18 @@ func (m *AITypeMapper) GenerateDropTableDDL(ctx context.Context, req DropTableDD
 
 	ddl := strings.TrimSpace(result)
 
-	// Basic validation - should contain DROP
+	// Validate: must contain DROP and must be idempotent (IF EXISTS).
+	// All three target dialects' AIDropTablePromptAugmentation already mandate
+	// IF EXISTS, but the cache replays the exact AI output — so a model that
+	// disregards the prompt and emits a bare "DROP TABLE foo" would succeed
+	// once, get cached, and fail every subsequent run with "table not found".
+	// Rejecting non-idempotent DDL here keeps the cache contract honest.
 	upperDDL := strings.ToUpper(ddl)
 	if !strings.Contains(upperDDL, "DROP") {
 		return "", fmt.Errorf("response does not contain valid DROP statement: %s", truncateString(ddl, 100))
+	}
+	if !strings.Contains(upperDDL, "IF EXISTS") {
+		return "", fmt.Errorf("response does not contain idempotent DROP (missing IF EXISTS): %s", truncateString(ddl, 100))
 	}
 
 	// Cache writes are deferred to CacheDropTableDDL post-exec — see #32.

--- a/internal/driver/mssql/retry.go
+++ b/internal/driver/mssql/retry.go
@@ -5,9 +5,33 @@ import (
 	"errors"
 	"fmt"
 
+	mssql "github.com/microsoft/go-mssqldb"
+
 	"smt/internal/driver"
 	"smt/internal/logging"
 )
+
+// isAlreadyExists reports whether err is a SQL Server "object already exists"
+// error class. See postgres equivalent for the rationale; this is a small,
+// focused detection by error number, not a return to the broad allowlist
+// removed in #29 PR B follow-up.
+//
+//	2714 = There is already an object named '...' in the database.
+//	1779 = Table 'X' already has a primary key defined on it.
+//	1781 = Column 'X' is already constrained.
+//	1913 = There is already an object named 'idx' (creating same-name index).
+//	2705 = Column names in each table must be unique.
+func isAlreadyExists(err error) bool {
+	var mErr mssql.Error
+	if !errors.As(err, &mErr) {
+		return false
+	}
+	switch mErr.Number {
+	case 2714, 1779, 1781, 1913, 2705:
+		return true
+	}
+	return false
+}
 
 // retryFinalize generates DDL via the finalization mapper and executes it,
 // retrying up to maxRetries times. Each retry feeds the prior failed DDL plus
@@ -52,6 +76,10 @@ func (w *Writer) retryFinalize(ctx context.Context, req driver.FinalizationDDLRe
 			if attempt > 0 {
 				logging.Info("%s succeeded on retry attempt %d/%d", label, attempt, maxRetries)
 			}
+			return nil
+		} else if isAlreadyExists(execErr) {
+			// See postgres equivalent.
+			logging.Info("  ✓ %s already exists (post-exec catch); treating as no-op", label)
 			return nil
 		} else {
 			// Short-circuit on cancellation — see postgres equivalent for rationale.

--- a/internal/driver/mssql/retry.go
+++ b/internal/driver/mssql/retry.go
@@ -47,6 +47,8 @@ func (w *Writer) retryFinalize(ctx context.Context, req driver.FinalizationDDLRe
 		}
 
 		if _, execErr := w.db.ExecContext(ctx, ddl); execErr == nil {
+			// Cache the validated DDL post-exec — see postgres equivalent / #32.
+			w.finalizationMapper.CacheFinalizationDDL(req, ddl)
 			if attempt > 0 {
 				logging.Info("%s succeeded on retry attempt %d/%d", label, attempt, maxRetries)
 			}

--- a/internal/driver/mssql/retry_test.go
+++ b/internal/driver/mssql/retry_test.go
@@ -1,0 +1,43 @@
+package mssql
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	mssql "github.com/microsoft/go-mssqldb"
+)
+
+// TestIsAlreadyExists exercises the error-number-class detection that the
+// create paths use to swallow re-run idempotency failures. See postgres
+// equivalent.
+func TestIsAlreadyExists(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"plain error", errors.New("boom"), false},
+		{"2714 already an object", mssql.Error{Number: 2714, Message: "There is already an object named 'foo'"}, true},
+		{"1779 PK already", mssql.Error{Number: 1779}, true},
+		{"1781 column already constrained", mssql.Error{Number: 1781}, true},
+		{"1913 index already", mssql.Error{Number: 1913}, true},
+		{"2705 column names duplicate", mssql.Error{Number: 2705}, true},
+
+		// Negatives — adjacent error classes that must NOT trigger.
+		{"547 FK violation", mssql.Error{Number: 547}, false},
+		{"208 invalid object name", mssql.Error{Number: 208}, false},
+		{"229 permission denied", mssql.Error{Number: 229}, false},
+
+		{"wrapped mssql error", fmt.Errorf("exec failed: %w", mssql.Error{Number: 2714}), true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAlreadyExists(tc.err); got != tc.want {
+				t.Errorf("isAlreadyExists(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/driver/mssql/writer.go
+++ b/internal/driver/mssql/writer.go
@@ -299,6 +299,16 @@ func (w *Writer) CreateTable(ctx context.Context, t *driver.Table, targetSchema 
 // On retryable errors, regenerates with the prior failed DDL + error fed back
 // into the prompt up to opts.MaxRetries times. See #29 / postgres equivalent.
 func (w *Writer) CreateTableWithOptions(ctx context.Context, t *driver.Table, targetSchema string, opts driver.TableOptions) error {
+	// Skip if the target table already exists. Idempotent re-runs land here
+	// instead of failing on "There is already an object named ...". See
+	// postgres equivalent.
+	if exists, err := w.TableExists(ctx, targetSchema, t.Name); err != nil {
+		return fmt.Errorf("checking table existence for %s: %w", t.FullName(), err)
+	} else if exists {
+		logging.Info("  ✓ table %s already exists, skipping", t.FullName())
+		return nil
+	}
+
 	req := driver.TableDDLRequest{
 		SourceDBType:  w.sourceType,
 		TargetDBType:  "mssql",
@@ -408,6 +418,52 @@ func (w *Writer) HasPrimaryKey(ctx context.Context, schema, table string) (bool,
 			AND TABLE_NAME = @table
 		) THEN 1 ELSE 0 END
 	`, sql.Named("schema", schema), sql.Named("table", table)).Scan(&exists)
+	return exists == 1, err
+}
+
+// IndexExists reports whether an index with the given name exists on the
+// given table. SQL Server scopes index names per table, so both schema
+// and table are required to disambiguate.
+func (w *Writer) IndexExists(ctx context.Context, schema, table, indexName string) (bool, error) {
+	var exists int
+	err := w.db.QueryRowContext(ctx, `
+		SELECT CASE WHEN EXISTS (
+			SELECT 1 FROM sys.indexes i
+			JOIN sys.tables t ON i.object_id = t.object_id
+			JOIN sys.schemas s ON t.schema_id = s.schema_id
+			WHERE s.name = @schema AND t.name = @table AND i.name = @name
+		) THEN 1 ELSE 0 END
+	`, sql.Named("schema", schema), sql.Named("table", table), sql.Named("name", indexName)).Scan(&exists)
+	return exists == 1, err
+}
+
+// ForeignKeyExists reports whether an FK constraint with the given name
+// exists on the given table.
+func (w *Writer) ForeignKeyExists(ctx context.Context, schema, table, fkName string) (bool, error) {
+	var exists int
+	err := w.db.QueryRowContext(ctx, `
+		SELECT CASE WHEN EXISTS (
+			SELECT 1 FROM sys.foreign_keys fk
+			JOIN sys.tables t ON fk.parent_object_id = t.object_id
+			JOIN sys.schemas s ON t.schema_id = s.schema_id
+			WHERE s.name = @schema AND t.name = @table AND fk.name = @name
+		) THEN 1 ELSE 0 END
+	`, sql.Named("schema", schema), sql.Named("table", table), sql.Named("name", fkName)).Scan(&exists)
+	return exists == 1, err
+}
+
+// CheckConstraintExists reports whether a CHECK constraint with the given
+// name exists on the given table.
+func (w *Writer) CheckConstraintExists(ctx context.Context, schema, table, checkName string) (bool, error) {
+	var exists int
+	err := w.db.QueryRowContext(ctx, `
+		SELECT CASE WHEN EXISTS (
+			SELECT 1 FROM sys.check_constraints cc
+			JOIN sys.tables t ON cc.parent_object_id = t.object_id
+			JOIN sys.schemas s ON t.schema_id = s.schema_id
+			WHERE s.name = @schema AND t.name = @table AND cc.name = @name
+		) THEN 1 ELSE 0 END
+	`, sql.Named("schema", schema), sql.Named("table", table), sql.Named("name", checkName)).Scan(&exists)
 	return exists == 1, err
 }
 
@@ -573,6 +629,13 @@ func (w *Writer) CreateIndexWithOptions(ctx context.Context, t *driver.Table, id
 		return fmt.Errorf("finalization mapper not available for index creation")
 	}
 
+	if exists, err := w.IndexExists(ctx, targetSchema, t.Name, idx.Name); err != nil {
+		return fmt.Errorf("checking index existence for %s.%s: %w", t.Name, idx.Name, err)
+	} else if exists {
+		logging.Info("  ✓ index %s.%s already exists, skipping", t.Name, idx.Name)
+		return nil
+	}
+
 	req := driver.FinalizationDDLRequest{
 		Type:          driver.DDLTypeIndex,
 		SourceDBType:  w.sourceType,
@@ -595,6 +658,13 @@ func (w *Writer) CreateForeignKey(ctx context.Context, t *driver.Table, fk *driv
 func (w *Writer) CreateForeignKeyWithOptions(ctx context.Context, t *driver.Table, fk *driver.ForeignKey, targetSchema string, opts driver.FinalizeOptions) error {
 	if w.finalizationMapper == nil {
 		return fmt.Errorf("finalization mapper not available for foreign key creation")
+	}
+
+	if exists, err := w.ForeignKeyExists(ctx, targetSchema, t.Name, fk.Name); err != nil {
+		return fmt.Errorf("checking FK existence for %s.%s: %w", t.Name, fk.Name, err)
+	} else if exists {
+		logging.Info("  ✓ FK %s.%s already exists, skipping", t.Name, fk.Name)
+		return nil
 	}
 
 	// Override RefSchema with the target schema. The source FK metadata
@@ -627,6 +697,13 @@ func (w *Writer) CreateCheckConstraint(ctx context.Context, t *driver.Table, chk
 func (w *Writer) CreateCheckConstraintWithOptions(ctx context.Context, t *driver.Table, chk *driver.CheckConstraint, targetSchema string, opts driver.FinalizeOptions) error {
 	if w.finalizationMapper == nil {
 		return fmt.Errorf("finalization mapper not available for check constraint creation")
+	}
+
+	if exists, err := w.CheckConstraintExists(ctx, targetSchema, t.Name, chk.Name); err != nil {
+		return fmt.Errorf("checking CHECK existence for %s.%s: %w", t.Name, chk.Name, err)
+	} else if exists {
+		logging.Info("  ✓ CHECK %s.%s already exists, skipping", t.Name, chk.Name)
+		return nil
 	}
 
 	req := driver.FinalizationDDLRequest{

--- a/internal/driver/mssql/writer.go
+++ b/internal/driver/mssql/writer.go
@@ -358,11 +358,9 @@ func (w *Writer) CreateTableWithOptions(ctx context.Context, t *driver.Table, ta
 				logging.Info("table %s succeeded on retry attempt %d/%d", t.FullName(), attempt, opts.MaxRetries)
 			}
 			return nil
-		} else if isAlreadyExists(err) {
-			// Pre-exec TableExists catches most re-run cases — belt-and-braces.
-			logging.Info("  ✓ table %s already exists (post-exec catch); treating as no-op", t.FullName())
-			return nil
 		}
+		// No post-exec already-exists catch on the CREATE TABLE path —
+		// see postgres equivalent for rationale.
 
 		// Short-circuit on cancellation — see postgres equivalent for rationale.
 		if driver.IsCanceled(ctx, err) {

--- a/internal/driver/mssql/writer.go
+++ b/internal/driver/mssql/writer.go
@@ -358,6 +358,10 @@ func (w *Writer) CreateTableWithOptions(ctx context.Context, t *driver.Table, ta
 				logging.Info("table %s succeeded on retry attempt %d/%d", t.FullName(), attempt, opts.MaxRetries)
 			}
 			return nil
+		} else if isAlreadyExists(err) {
+			// Pre-exec TableExists catches most re-run cases — belt-and-braces.
+			logging.Info("  ✓ table %s already exists (post-exec catch); treating as no-op", t.FullName())
+			return nil
 		}
 
 		// Short-circuit on cancellation — see postgres equivalent for rationale.

--- a/internal/driver/mysql/retry.go
+++ b/internal/driver/mysql/retry.go
@@ -5,9 +5,31 @@ import (
 	"errors"
 	"fmt"
 
+	mysqldrv "github.com/go-sql-driver/mysql"
+
 	"smt/internal/driver"
 	"smt/internal/logging"
 )
+
+// isAlreadyExists reports whether err is a MySQL "object already exists"
+// error class. See postgres equivalent for the rationale.
+//
+//	1050 = Table '...' already exists.
+//	1061 = Duplicate key name (CREATE INDEX with existing name).
+//	1826 = Duplicate foreign key constraint name.
+//	1068 = Multiple primary key defined.
+//	1022 = Can't write; duplicate key in table.
+func isAlreadyExists(err error) bool {
+	var mErr *mysqldrv.MySQLError
+	if !errors.As(err, &mErr) {
+		return false
+	}
+	switch mErr.Number {
+	case 1050, 1061, 1826, 1068, 1022:
+		return true
+	}
+	return false
+}
 
 // retryFinalize generates DDL via the finalization mapper and executes it,
 // retrying up to maxRetries times. Each retry feeds the prior failed DDL plus
@@ -52,6 +74,10 @@ func (w *Writer) retryFinalize(ctx context.Context, req driver.FinalizationDDLRe
 			if attempt > 0 {
 				logging.Info("%s succeeded on retry attempt %d/%d", label, attempt, maxRetries)
 			}
+			return nil
+		} else if isAlreadyExists(execErr) {
+			// See postgres equivalent.
+			logging.Info("  ✓ %s already exists (post-exec catch); treating as no-op", label)
 			return nil
 		} else {
 			// Short-circuit on cancellation — see postgres equivalent for rationale.

--- a/internal/driver/mysql/retry.go
+++ b/internal/driver/mysql/retry.go
@@ -47,6 +47,8 @@ func (w *Writer) retryFinalize(ctx context.Context, req driver.FinalizationDDLRe
 		}
 
 		if _, execErr := w.db.ExecContext(ctx, ddl); execErr == nil {
+			// Cache the validated DDL post-exec — see postgres equivalent / #32.
+			w.finalizationMapper.CacheFinalizationDDL(req, ddl)
 			if attempt > 0 {
 				logging.Info("%s succeeded on retry attempt %d/%d", label, attempt, maxRetries)
 			}

--- a/internal/driver/mysql/retry_test.go
+++ b/internal/driver/mysql/retry_test.go
@@ -1,0 +1,44 @@
+package mysql
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	mysqldrv "github.com/go-sql-driver/mysql"
+)
+
+// TestIsAlreadyExists exercises the error-number-class detection that the
+// create paths use to swallow re-run idempotency failures. See postgres
+// equivalent.
+func TestIsAlreadyExists(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"plain error", errors.New("boom"), false},
+		{"1050 table exists", &mysqldrv.MySQLError{Number: 1050}, true},
+		{"1061 duplicate key name", &mysqldrv.MySQLError{Number: 1061}, true},
+		{"1826 duplicate FK constraint name", &mysqldrv.MySQLError{Number: 1826}, true},
+		{"1068 multiple PK", &mysqldrv.MySQLError{Number: 1068}, true},
+		{"1022 duplicate key", &mysqldrv.MySQLError{Number: 1022}, true},
+
+		// Negatives — adjacent error classes that must NOT trigger.
+		{"1452 FK violation", &mysqldrv.MySQLError{Number: 1452}, false},
+		{"1146 table doesn't exist", &mysqldrv.MySQLError{Number: 1146}, false},
+		{"1062 duplicate entry (data)", &mysqldrv.MySQLError{Number: 1062}, false},
+		{"1142 access denied", &mysqldrv.MySQLError{Number: 1142}, false},
+
+		{"wrapped mysql error", fmt.Errorf("exec failed: %w", &mysqldrv.MySQLError{Number: 1050}), true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAlreadyExists(tc.err); got != tc.want {
+				t.Errorf("isAlreadyExists(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/driver/mysql/writer.go
+++ b/internal/driver/mysql/writer.go
@@ -509,10 +509,16 @@ func (w *Writer) ForeignKeyExists(ctx context.Context, schema, table, fkName str
 }
 
 // CheckConstraintExists reports whether a CHECK constraint with the given
-// name exists on the given table. Requires MySQL 8.0.16+ (the version that
-// added CHECK enforcement and the information_schema.CHECK_CONSTRAINTS view);
-// older targets return ErrNoRows → false here, which matches the broader
-// behavior of #18 / CLAUDE.md's MySQL 8.0.16+ note for check support.
+// name exists on the given table.
+//
+// Uses information_schema.TABLE_CONSTRAINTS (available on every MySQL
+// version) rather than information_schema.CHECK_CONSTRAINTS (8.0.16+ only).
+// Older MySQL targets that lack the CHECK_CONSTRAINTS view would error out
+// of the existence check and block the create path entirely, even though
+// CHECK semantics aren't supported there at all (the AI/exec path further
+// down is already broken in the same way per CLAUDE.md). On pre-8.0.16
+// MySQL, TABLE_CONSTRAINTS simply returns no rows for CHECK — falling
+// through to the existing AI/exec path, same as before this PR.
 func (w *Writer) CheckConstraintExists(ctx context.Context, schema, table, checkName string) (bool, error) {
 	dbName := schema
 	if dbName == "" {
@@ -521,14 +527,9 @@ func (w *Writer) CheckConstraintExists(ctx context.Context, schema, table, check
 
 	var exists int
 	err := w.db.QueryRowContext(ctx, `
-		SELECT 1 FROM information_schema.CHECK_CONSTRAINTS cc
-		JOIN information_schema.TABLE_CONSTRAINTS tc
-		  ON cc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA
-		 AND cc.CONSTRAINT_NAME   = tc.CONSTRAINT_NAME
-		WHERE tc.CONSTRAINT_SCHEMA = ?
-		  AND tc.TABLE_NAME       = ?
-		  AND tc.CONSTRAINT_NAME  = ?
-		  AND tc.CONSTRAINT_TYPE  = 'CHECK'
+		SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+		WHERE CONSTRAINT_TYPE = 'CHECK'
+		AND TABLE_SCHEMA = ? AND TABLE_NAME = ? AND CONSTRAINT_NAME = ?
 	`, dbName, table, checkName).Scan(&exists)
 	if err == sql.ErrNoRows {
 		return false, nil

--- a/internal/driver/mysql/writer.go
+++ b/internal/driver/mysql/writer.go
@@ -304,6 +304,15 @@ func (w *Writer) CreateTable(ctx context.Context, t *driver.Table, targetSchema 
 // On retryable errors, regenerates with the prior failed DDL + error fed back
 // into the prompt up to opts.MaxRetries times. See #29 / postgres equivalent.
 func (w *Writer) CreateTableWithOptions(ctx context.Context, t *driver.Table, targetSchema string, opts driver.TableOptions) error {
+	// Skip if the target table already exists. Idempotent re-runs land here
+	// instead of failing on "Table ... already exists". See postgres equivalent.
+	if exists, err := w.TableExists(ctx, targetSchema, t.Name); err != nil {
+		return fmt.Errorf("checking table existence for %s: %w", t.FullName(), err)
+	} else if exists {
+		logging.Info("  ✓ table %s already exists, skipping", t.FullName())
+		return nil
+	}
+
 	req := driver.TableDDLRequest{
 		SourceDBType:  w.sourceType,
 		TargetDBType:  "mysql",
@@ -371,18 +380,26 @@ func (w *Writer) CreateTableWithOptions(ctx context.Context, t *driver.Table, ta
 func (w *Writer) DropTable(ctx context.Context, schema, table string) error {
 	// Use AI-generated DROP DDL if available
 	if w.dropDDLMapper != nil {
-		ddl, err := w.dropDDLMapper.GenerateDropTableDDL(ctx, driver.DropTableDDLRequest{
+		req := driver.DropTableDDLRequest{
 			TargetDBType:  "mysql",
 			TargetSchema:  schema,
 			TableName:     table,
 			TargetContext: w.dbContext,
-		})
+		}
+		ddl, err := w.dropDDLMapper.GenerateDropTableDDL(ctx, req)
 		if err != nil {
 			logging.Warn("AI DROP DDL generation failed, using fallback: %v", err)
 		} else {
 			logging.Debug("Executing AI-generated DROP DDL: %s", ddl)
-			_, err := w.db.ExecContext(ctx, ddl)
-			return err
+			if _, execErr := w.db.ExecContext(ctx, ddl); execErr == nil {
+				// Cache the validated DDL post-exec — same #32 pattern as
+				// CacheTableDDL / CacheFinalizationDDL. Only validated DDL
+				// reaches the cache.
+				w.dropDDLMapper.CacheDropTableDDL(req, ddl)
+				return nil
+			} else {
+				return execErr
+			}
 		}
 	}
 
@@ -445,6 +462,74 @@ func (w *Writer) HasPrimaryKey(ctx context.Context, schema, table string) (bool,
 		WHERE CONSTRAINT_TYPE = 'PRIMARY KEY'
 		AND TABLE_SCHEMA = ? AND TABLE_NAME = ?
 	`, dbName, table).Scan(&exists)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+// IndexExists reports whether an index with the given name exists on the
+// given table.
+func (w *Writer) IndexExists(ctx context.Context, schema, table, indexName string) (bool, error) {
+	dbName := schema
+	if dbName == "" {
+		dbName = w.config.Database
+	}
+
+	var exists int
+	err := w.db.QueryRowContext(ctx, `
+		SELECT 1 FROM information_schema.STATISTICS
+		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND INDEX_NAME = ?
+		LIMIT 1
+	`, dbName, table, indexName).Scan(&exists)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+// ForeignKeyExists reports whether an FK constraint with the given name
+// exists on the given table.
+func (w *Writer) ForeignKeyExists(ctx context.Context, schema, table, fkName string) (bool, error) {
+	dbName := schema
+	if dbName == "" {
+		dbName = w.config.Database
+	}
+
+	var exists int
+	err := w.db.QueryRowContext(ctx, `
+		SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+		WHERE CONSTRAINT_TYPE = 'FOREIGN KEY'
+		AND TABLE_SCHEMA = ? AND TABLE_NAME = ? AND CONSTRAINT_NAME = ?
+	`, dbName, table, fkName).Scan(&exists)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+// CheckConstraintExists reports whether a CHECK constraint with the given
+// name exists on the given table. Requires MySQL 8.0.16+ (the version that
+// added CHECK enforcement and the information_schema.CHECK_CONSTRAINTS view);
+// older targets return ErrNoRows → false here, which matches the broader
+// behavior of #18 / CLAUDE.md's MySQL 8.0.16+ note for check support.
+func (w *Writer) CheckConstraintExists(ctx context.Context, schema, table, checkName string) (bool, error) {
+	dbName := schema
+	if dbName == "" {
+		dbName = w.config.Database
+	}
+
+	var exists int
+	err := w.db.QueryRowContext(ctx, `
+		SELECT 1 FROM information_schema.CHECK_CONSTRAINTS cc
+		JOIN information_schema.TABLE_CONSTRAINTS tc
+		  ON cc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA
+		 AND cc.CONSTRAINT_NAME   = tc.CONSTRAINT_NAME
+		WHERE tc.CONSTRAINT_SCHEMA = ?
+		  AND tc.TABLE_NAME       = ?
+		  AND tc.CONSTRAINT_NAME  = ?
+		  AND tc.CONSTRAINT_TYPE  = 'CHECK'
+	`, dbName, table, checkName).Scan(&exists)
 	if err == sql.ErrNoRows {
 		return false, nil
 	}
@@ -549,6 +634,13 @@ func (w *Writer) CreateIndexWithOptions(ctx context.Context, t *driver.Table, id
 		return fmt.Errorf("finalization mapper not available for index creation")
 	}
 
+	if exists, err := w.IndexExists(ctx, targetSchema, t.Name, idx.Name); err != nil {
+		return fmt.Errorf("checking index existence for %s.%s: %w", t.Name, idx.Name, err)
+	} else if exists {
+		logging.Info("  ✓ index %s.%s already exists, skipping", t.Name, idx.Name)
+		return nil
+	}
+
 	req := driver.FinalizationDDLRequest{
 		Type:          driver.DDLTypeIndex,
 		SourceDBType:  w.sourceType,
@@ -571,6 +663,13 @@ func (w *Writer) CreateForeignKey(ctx context.Context, t *driver.Table, fk *driv
 func (w *Writer) CreateForeignKeyWithOptions(ctx context.Context, t *driver.Table, fk *driver.ForeignKey, targetSchema string, opts driver.FinalizeOptions) error {
 	if w.finalizationMapper == nil {
 		return fmt.Errorf("finalization mapper not available for foreign key creation")
+	}
+
+	if exists, err := w.ForeignKeyExists(ctx, targetSchema, t.Name, fk.Name); err != nil {
+		return fmt.Errorf("checking FK existence for %s.%s: %w", t.Name, fk.Name, err)
+	} else if exists {
+		logging.Info("  ✓ FK %s.%s already exists, skipping", t.Name, fk.Name)
+		return nil
 	}
 
 	// Override RefSchema with the target schema. The source FK metadata
@@ -605,6 +704,13 @@ func (w *Writer) CreateCheckConstraint(ctx context.Context, t *driver.Table, chk
 func (w *Writer) CreateCheckConstraintWithOptions(ctx context.Context, t *driver.Table, chk *driver.CheckConstraint, targetSchema string, opts driver.FinalizeOptions) error {
 	if w.finalizationMapper == nil {
 		return fmt.Errorf("finalization mapper not available for check constraint creation")
+	}
+
+	if exists, err := w.CheckConstraintExists(ctx, targetSchema, t.Name, chk.Name); err != nil {
+		return fmt.Errorf("checking CHECK existence for %s.%s: %w", t.Name, chk.Name, err)
+	} else if exists {
+		logging.Info("  ✓ CHECK %s.%s already exists, skipping", t.Name, chk.Name)
+		return nil
 	}
 
 	req := driver.FinalizationDDLRequest{

--- a/internal/driver/mysql/writer.go
+++ b/internal/driver/mysql/writer.go
@@ -362,6 +362,10 @@ func (w *Writer) CreateTableWithOptions(ctx context.Context, t *driver.Table, ta
 				logging.Info("table %s succeeded on retry attempt %d/%d", t.FullName(), attempt, opts.MaxRetries)
 			}
 			return nil
+		} else if isAlreadyExists(err) {
+			// Pre-exec TableExists catches most re-run cases — belt-and-braces.
+			logging.Info("  ✓ table %s already exists (post-exec catch); treating as no-op", t.FullName())
+			return nil
 		}
 
 		// Short-circuit on cancellation — see postgres equivalent for rationale.

--- a/internal/driver/mysql/writer.go
+++ b/internal/driver/mysql/writer.go
@@ -362,11 +362,9 @@ func (w *Writer) CreateTableWithOptions(ctx context.Context, t *driver.Table, ta
 				logging.Info("table %s succeeded on retry attempt %d/%d", t.FullName(), attempt, opts.MaxRetries)
 			}
 			return nil
-		} else if isAlreadyExists(err) {
-			// Pre-exec TableExists catches most re-run cases — belt-and-braces.
-			logging.Info("  ✓ table %s already exists (post-exec catch); treating as no-op", t.FullName())
-			return nil
 		}
+		// No post-exec already-exists catch on the CREATE TABLE path —
+		// see postgres equivalent for rationale.
 
 		// Short-circuit on cancellation — see postgres equivalent for rationale.
 		if driver.IsCanceled(ctx, err) {

--- a/internal/driver/postgres/retry.go
+++ b/internal/driver/postgres/retry.go
@@ -5,9 +5,39 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/jackc/pgx/v5/pgconn"
+
 	"smt/internal/driver"
 	"smt/internal/logging"
 )
+
+// isAlreadyExists reports whether err is a PostgreSQL "object already exists"
+// error class. Used by the create paths to treat re-run idempotency failures
+// as no-op success — the pre-exec existence probes catch most cases, but the
+// AI sometimes renames constraint identifiers in a way our normalizer doesn't
+// predict (e.g. CK_X → chk_x for some inputs and ck_x for others), so the
+// probe misses and we land here. Detection is by SQLSTATE so it's stable
+// across pgx versions and PG releases.
+//
+// 42710 = duplicate_object — covers indexes, foreign keys, check constraints,
+//
+//	primary keys, sequences, and most other relation-bound objects.
+//
+// 42P07 = duplicate_table.
+// 42P06 = duplicate_schema (caught for completeness; CreateSchema already
+//
+//	uses IF NOT EXISTS).
+func isAlreadyExists(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	switch pgErr.Code {
+	case "42710", "42P07", "42P06":
+		return true
+	}
+	return false
+}
 
 // retryFinalize generates DDL via the finalization mapper and executes it,
 // retrying up to maxRetries times. Each retry feeds the prior failed DDL plus
@@ -66,6 +96,16 @@ func (w *Writer) retryFinalize(ctx context.Context, req driver.FinalizationDDLRe
 			if attempt > 0 {
 				logging.Info("%s succeeded on retry attempt %d/%d", label, attempt, maxRetries)
 			}
+			return nil
+		} else if isAlreadyExists(execErr) {
+			// Pre-exec existence probes catch most re-run cases, but the AI
+			// sometimes renames identifiers in ways the normalizer doesn't
+			// predict — the probe by name then misses, and we land here. Treat
+			// as no-op success rather than letting the AI retry into the same
+			// failure. Don't cache the DDL: the catalog name diverges from
+			// what we'd compute for this request, so there's no guarantee
+			// future runs would land here for the same key.
+			logging.Info("  ✓ %s already exists (post-exec catch); treating as no-op", label)
 			return nil
 		} else {
 			// Short-circuit on cancellation — without this guard the next

--- a/internal/driver/postgres/retry.go
+++ b/internal/driver/postgres/retry.go
@@ -59,6 +59,10 @@ func (w *Writer) retryFinalize(ctx context.Context, req driver.FinalizationDDLRe
 		}
 
 		if _, execErr := w.pool.Exec(ctx, ddl); execErr == nil {
+			// Cache the validated DDL post-exec — same #32 pattern as
+			// CacheTableDDL. Only validated DDL ever reaches the cache, so a
+			// failed-but-not-corrected DDL can't poison subsequent runs.
+			w.finalizationMapper.CacheFinalizationDDL(req, ddl)
 			if attempt > 0 {
 				logging.Info("%s succeeded on retry attempt %d/%d", label, attempt, maxRetries)
 			}

--- a/internal/driver/postgres/retry_test.go
+++ b/internal/driver/postgres/retry_test.go
@@ -1,0 +1,46 @@
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// TestIsAlreadyExists exercises the SQLSTATE-class detection that the create
+// paths use to swallow re-run idempotency failures (e.g. when the AI renames
+// a constraint identifier in a way the normalizer doesn't predict, the
+// pre-exec existence probe misses, and exec then fails with 42710). The
+// matrix doubles as a guard against accidentally widening the allowlist.
+func TestIsAlreadyExists(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"plain error", errors.New("boom"), false},
+		{"42710 duplicate_object", &pgconn.PgError{Code: "42710", Message: "constraint already exists"}, true},
+		{"42P07 duplicate_table", &pgconn.PgError{Code: "42P07", Message: "relation already exists"}, true},
+		{"42P06 duplicate_schema", &pgconn.PgError{Code: "42P06", Message: "schema already exists"}, true},
+
+		// Negatives — adjacent SQLSTATEs that must NOT trigger the swallow.
+		// These are real errors users need to see (referential integrity,
+		// permission, type/name resolution).
+		{"23503 fk_violation", &pgconn.PgError{Code: "23503"}, false},
+		{"42883 undefined_function", &pgconn.PgError{Code: "42883"}, false},
+		{"42P01 undefined_table", &pgconn.PgError{Code: "42P01"}, false},
+		{"28000 invalid_authorization", &pgconn.PgError{Code: "28000"}, false},
+
+		{"wrapped pg error", fmt.Errorf("exec failed: %w", &pgconn.PgError{Code: "42710"}), true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAlreadyExists(tc.err); got != tc.want {
+				t.Errorf("isAlreadyExists(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/driver/postgres/writer.go
+++ b/internal/driver/postgres/writer.go
@@ -357,6 +357,11 @@ func (w *Writer) CreateTableWithOptions(ctx context.Context, t *driver.Table, ta
 				logging.Info("table %s succeeded on retry attempt %d/%d", t.FullName(), attempt, opts.MaxRetries)
 			}
 			return nil
+		} else if isAlreadyExists(err) {
+			// Pre-exec TableExists catches most re-run cases. Belt-and-braces
+			// for race / drift / inconsistent quoting between probe and exec.
+			logging.Info("  ✓ table %s already exists (post-exec catch); treating as no-op", t.FullName())
+			return nil
 		}
 
 		// Short-circuit on cancellation. Without this guard the AI-classifier

--- a/internal/driver/postgres/writer.go
+++ b/internal/driver/postgres/writer.go
@@ -357,12 +357,14 @@ func (w *Writer) CreateTableWithOptions(ctx context.Context, t *driver.Table, ta
 				logging.Info("table %s succeeded on retry attempt %d/%d", t.FullName(), attempt, opts.MaxRetries)
 			}
 			return nil
-		} else if isAlreadyExists(err) {
-			// Pre-exec TableExists catches most re-run cases. Belt-and-braces
-			// for race / drift / inconsistent quoting between probe and exec.
-			logging.Info("  ✓ table %s already exists (post-exec catch); treating as no-op", t.FullName())
-			return nil
 		}
+		// No post-exec already-exists catch on the CREATE TABLE path:
+		// PG SQLSTATE 42710 fires for inline constraint-name conflicts
+		// inside a CREATE TABLE, which means the table was *not* created
+		// — swallowing that error would silently skip the table and break
+		// later phases. Pre-exec TableExists is the table-level idempotency
+		// mechanism. The post-exec catch only makes semantic sense for
+		// retryFinalize where the failing object IS the constraint/index.
 
 		// Short-circuit on cancellation. Without this guard the AI-classifier
 		// path would re-prompt the model to "fix" a Ctrl-C and the user would

--- a/internal/driver/postgres/writer.go
+++ b/internal/driver/postgres/writer.go
@@ -277,6 +277,16 @@ func (w *Writer) CreateTable(ctx context.Context, t *driver.Table, targetSchema 
 // DDL is re-cached so future first-try calls for the same table-shape get
 // the good DDL instead of the cached failure. See #29 for the full design.
 func (w *Writer) CreateTableWithOptions(ctx context.Context, t *driver.Table, targetSchema string, opts driver.TableOptions) error {
+	// Skip if the target table already exists. Idempotent re-runs land here
+	// instead of failing on "relation already exists" inside the AI/exec path.
+	// Drift detection is out of scope — that's `smt sync`.
+	if exists, err := w.TableExists(ctx, targetSchema, t.Name); err != nil {
+		return fmt.Errorf("checking table existence for %s: %w", t.FullName(), err)
+	} else if exists {
+		logging.Info("  ✓ table %s already exists, skipping", t.FullName())
+		return nil
+	}
+
 	req := driver.TableDDLRequest{
 		SourceDBType:  w.sourceType,
 		TargetDBType:  "postgres",
@@ -553,6 +563,15 @@ func (w *Writer) CreateIndexWithOptions(ctx context.Context, t *driver.Table, id
 		}
 	}
 
+	// Skip if the index already exists. Re-runs hit this path; without it
+	// the cached DDL would be sent to the database and fail.
+	if exists, err := w.IndexExists(ctx, targetSchema, sanitizedTableName, sanitizedIdx.Name); err != nil {
+		return fmt.Errorf("checking index existence for %s.%s: %w", t.Name, idx.Name, err)
+	} else if exists {
+		logging.Info("  ✓ index %s.%s already exists, skipping", t.Name, idx.Name)
+		return nil
+	}
+
 	// Get target table DDL for AI context
 	targetTableDDL := w.GetTableDDL(ctx, targetSchema, sanitizedTableName)
 
@@ -608,6 +627,14 @@ func (w *Writer) CreateForeignKeyWithOptions(ctx context.Context, t *driver.Tabl
 		sanitizedFK.RefColumns[i] = sanitizePGIdentifier(col)
 	}
 
+	// Skip if the FK already exists.
+	if exists, err := w.ForeignKeyExists(ctx, targetSchema, sanitizedTableName, sanitizedFK.Name); err != nil {
+		return fmt.Errorf("checking FK existence for %s.%s: %w", t.Name, fk.Name, err)
+	} else if exists {
+		logging.Info("  ✓ FK %s.%s already exists, skipping", t.Name, fk.Name)
+		return nil
+	}
+
 	// Get target table DDL for AI context
 	targetTableDDL := w.GetTableDDL(ctx, targetSchema, sanitizedTableName)
 
@@ -644,6 +671,14 @@ func (w *Writer) CreateCheckConstraintWithOptions(ctx context.Context, t *driver
 		Definition: chk.Definition,
 	}
 
+	// Skip if the CHECK already exists.
+	if exists, err := w.CheckConstraintExists(ctx, targetSchema, sanitizedTableName, sanitizedChk.Name); err != nil {
+		return fmt.Errorf("checking CHECK existence for %s.%s: %w", t.Name, chk.Name, err)
+	} else if exists {
+		logging.Info("  ✓ CHECK %s.%s already exists, skipping", t.Name, chk.Name)
+		return nil
+	}
+
 	// Get target table DDL for AI context
 	targetTableDDL := w.GetTableDDL(ctx, targetSchema, sanitizedTableName)
 
@@ -672,6 +707,48 @@ func (w *Writer) HasPrimaryKey(ctx context.Context, schema, table string) (bool,
 			WHERE i.indisprimary AND n.nspname = $1 AND c.relname = $2
 		)
 	`, schema, sanitizedTable).Scan(&exists)
+	return exists, err
+}
+
+// IndexExists reports whether an index with the given name exists in the
+// schema. Postgres index names are unique per schema, so the table argument
+// is unused but kept to match the Writer interface across drivers.
+func (w *Writer) IndexExists(ctx context.Context, schema, table, indexName string) (bool, error) {
+	var exists bool
+	err := w.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM pg_indexes
+			WHERE schemaname = $1 AND indexname = $2
+		)
+	`, schema, sanitizePGIdentifier(indexName)).Scan(&exists)
+	return exists, err
+}
+
+// ForeignKeyExists reports whether an FK constraint with the given name
+// exists on the given table.
+func (w *Writer) ForeignKeyExists(ctx context.Context, schema, table, fkName string) (bool, error) {
+	var exists bool
+	err := w.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.table_constraints
+			WHERE table_schema = $1 AND table_name = $2 AND constraint_name = $3
+			  AND constraint_type = 'FOREIGN KEY'
+		)
+	`, schema, sanitizePGTableName(table), sanitizePGIdentifier(fkName)).Scan(&exists)
+	return exists, err
+}
+
+// CheckConstraintExists reports whether a CHECK constraint with the given
+// name exists on the given table.
+func (w *Writer) CheckConstraintExists(ctx context.Context, schema, table, checkName string) (bool, error) {
+	var exists bool
+	err := w.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.table_constraints
+			WHERE table_schema = $1 AND table_name = $2 AND constraint_name = $3
+			  AND constraint_type = 'CHECK'
+		)
+	`, schema, sanitizePGTableName(table), sanitizePGIdentifier(checkName)).Scan(&exists)
 	return exists, err
 }
 

--- a/internal/driver/typemapper.go
+++ b/internal/driver/typemapper.go
@@ -205,6 +205,16 @@ type TypeInfo struct {
 type FinalizationDDLMapper interface {
 	// GenerateFinalizationDDL generates DDL for indexes, foreign keys, or check constraints.
 	GenerateFinalizationDDL(ctx context.Context, req FinalizationDDLRequest) (string, error)
+
+	// CacheFinalizationDDL stores a known-good DDL for the request, replacing
+	// any prior cached value. This is the ONLY entry point that writes to the
+	// finalization-DDL cache — the mapper itself never caches because it only
+	// sees AI output, not validated DDL. The writer calls this after every
+	// successful CREATE INDEX / FOREIGN KEY / CHECK CONSTRAINT execution
+	// (first-try and retry alike); a failed exec leaves the cache untouched
+	// so the next call gets a fresh AI invocation rather than a poisoned hit.
+	// Mirrors TableTypeMapper.CacheTableDDL — see #32 for the rationale.
+	CacheFinalizationDDL(req FinalizationDDLRequest, ddl string)
 }
 
 // DDLType specifies the type of DDL to generate.
@@ -276,6 +286,12 @@ type TableDropDDLMapper interface {
 	// The AI will generate database-specific syntax that properly handles
 	// foreign key constraints and other database-specific requirements.
 	GenerateDropTableDDL(ctx context.Context, req DropTableDDLRequest) (string, error)
+
+	// CacheDropTableDDL stores a known-good DDL for the request, replacing any
+	// prior cached value. The DROP prompt mandates IF EXISTS so the cached DDL
+	// is naturally idempotent across re-runs; this method is the writer's
+	// post-exec hook. Mirrors TableTypeMapper.CacheTableDDL — see #32.
+	CacheDropTableDDL(req DropTableDDLRequest, ddl string)
 }
 
 // DropTableDDLRequest contains information needed to generate DROP TABLE DDL.

--- a/internal/driver/writer.go
+++ b/internal/driver/writer.go
@@ -34,6 +34,22 @@ type Writer interface {
 	CreateCheckConstraintWithOptions(ctx context.Context, t *Table, chk *CheckConstraint, targetSchema string, opts FinalizeOptions) error
 	HasPrimaryKey(ctx context.Context, schema, table string) (bool, error)
 
+	// IndexExists reports whether an index with the given name exists on the
+	// target table. Used by CreateIndexWithOptions to short-circuit re-runs
+	// without invoking the AI or executing DDL that would fail with "already
+	// exists". Catalog query, no AI involved.
+	IndexExists(ctx context.Context, schema, table, indexName string) (bool, error)
+
+	// ForeignKeyExists reports whether a foreign key with the given name
+	// exists on the target table. Used by CreateForeignKeyWithOptions for
+	// idempotent re-runs.
+	ForeignKeyExists(ctx context.Context, schema, table, fkName string) (bool, error)
+
+	// CheckConstraintExists reports whether a CHECK constraint with the given
+	// name exists on the target table. Used by CreateCheckConstraintWithOptions
+	// for idempotent re-runs.
+	CheckConstraintExists(ctx context.Context, schema, table, checkName string) (bool, error)
+
 	// DDL introspection
 	// GetTableDDL returns the CREATE TABLE DDL for an existing table.
 	// Returns empty string if DDL cannot be retrieved (non-fatal).


### PR DESCRIPTION
## Summary

- Extends post-exec DDL caching (#32 / #33) from CREATE TABLE to **CREATE INDEX / FOREIGN KEY / CHECK** and **DROP TABLE**. Mapper is read-only on cache; writers call `CacheFinalizationDDL` / `CacheDropTableDDL` after exec confirms the DDL works, so failed DDL never poisons the cache. Retries bypass the cache so corrective context isn't shadowed.
- Adds **skip-if-exists** guards on every create path so secondary runs are real no-ops, not "instant fail with already exists." New `Writer` methods `IndexExists` / `ForeignKeyExists` / `CheckConstraintExists` (deterministic catalog queries — no AI) for all three drivers, plus a `TableExists` short-circuit added to `CreateTableWithOptions`.
- Fixes a latent #32 regression in `GenerateDropTableDDL` — it still auto-cached AI output before exec validation. Moves it to the same post-exec hook pattern.

Net effect: a re-run of `smt create` against a target with no source changes makes zero AI calls and zero failed exec attempts. Drift detection stays out of scope — that's `smt sync`'s job.

## Test plan

- [x] `make check` (fmt + full -short suite) passes
- [x] New unit tests in `internal/driver/ai_finalization_cache_test.go`:
  - `TestFinalizationCacheKey_SensitivityAndStability` — cache key changes for every metadata field that affects DDL (IsUnique, columns, FK ON DELETE, CHECK definition, etc.); stable under repeat call; disambiguates DDL types; `TargetTableDDL` does **not** affect key (so unrelated parent-column changes don't invalidate FK cache); unknown DDL type yields empty key.
  - `TestGenerateFinalizationDDL_DoesNotAutoCache` — mirror of the table-DDL #32 regression test for index, FK, check.
  - `TestGenerateFinalizationDDL_FailedFirstTryDoesNotPoison` — two Generate calls without intervening Cache call → two AI calls.
  - `TestGenerateFinalizationDDL_RetrySkipsCache` — `PreviousAttempt != nil` bypasses cache lookup.
  - `TestCacheFinalizationDDL` — cache-hit path skips AI; replace-not-append.
  - `TestGenerateDropTableDDL_DoesNotAutoCache` and `…_FailedFirstTryDoesNotPoison` — same regression guards for the DROP path.
- [ ] Integration: `make test-dbs-up` then `smt create` twice against a CRM-fixture target. Run 1 makes the expected AI calls; run 2 logs `✓ table X already exists, skipping`, `✓ index Y…`, `✓ FK Z…` and makes zero AI calls during finalization phases.

## Notes / follow-ups

- Provider/model namespacing of the cache is still a pre-existing gap (also true of `tableCacheKey`). A switch from Sonnet to gpt-oss reuses Sonnet-cached DDL. Tracked as a separate concern.
- `CheckConstraintExists` on MySQL requires 8.0.16+ (information_schema.CHECK_CONSTRAINTS view). Older versions return false → fall through to the AI/exec path, which would already be broken on the same target due to the matrix gaps in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)