### PR TITLE
Cleanup: route windows provider through OpenAI-compat shim path

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -749,7 +749,11 @@ func (c *Config) applyDefaults() error {
 		secretsCfg, err := secrets.Load()
 		if err == nil && secretsCfg.AI.DefaultProvider != "" {
 			provider, provErr := secretsCfg.GetProvider(secretsCfg.AI.DefaultProvider)
-			if provErr == nil && provider.IsConfigured(secretsCfg.AI.DefaultProvider) {
+			// Accept any local provider with a base_url, not just cloud
+			// providers with an api_key. Pre-PR-#39 this only checked
+			// APIKey, which silently dropped ollama/lmstudio configured
+			// purely in secrets.
+			if provErr == nil && (provider.APIKey != "" || provider.BaseURL != "") {
 				c.AI = &AIConfig{
 					Provider: secretsCfg.AI.DefaultProvider,
 					APIKey:   provider.APIKey,
@@ -774,11 +778,11 @@ func (c *Config) applyDefaults() error {
 		}
 	}
 
-	// AI features: apply defaults when the provider has enough to dispatch
-	// (cloud needs APIKey; local-HTTP needs BaseURL via secrets; native
-	// providers like `windows` need neither — being a registered native
-	// provider is sufficient).
-	if c.AI != nil && (c.AI.APIKey != "" || secrets.IsNativeProvider(c.AI.Provider)) {
+	// AI features: apply defaults when the provider has enough to dispatch.
+	// Cloud providers need APIKey; local-HTTP providers (ollama, lmstudio,
+	// windows-via-shim) need a BaseURL — either set explicitly or populated
+	// from KnownProviders.DefaultURL during validation.
+	if c.AI != nil && (c.AI.APIKey != "" || c.AI.Provider != "" && secrets.IsLocalProvider(c.AI.Provider)) {
 		// Default provider to anthropic if not specified
 		if c.AI.Provider == "" {
 			c.AI.Provider = "anthropic"
@@ -1357,8 +1361,8 @@ func (c *Config) DebugDump() string {
 	b.WriteString("\nAI Features:\n")
 	if secretsErr == nil {
 		provider, providerName, err := secretsCfg.GetDefaultProvider()
-		// Check for valid provider: API-key-based (Anthropic, OpenAI), local with BaseURL (Ollama, LMStudio), or native (Windows)
-		if err == nil && provider != nil && provider.IsConfigured(providerName) {
+		// Check for valid provider: API-key-based (Anthropic, OpenAI) or local with BaseURL (Ollama, LMStudio, Windows)
+		if err == nil && provider != nil && (provider.APIKey != "" || provider.BaseURL != "") {
 			b.WriteString(fmt.Sprintf("  Provider: %s\n", providerName))
 			if provider.APIKey != "" {
 				b.WriteString("  APIKey: [REDACTED]\n")

--- a/internal/driver/ai_typemapper.go
+++ b/internal/driver/ai_typemapper.go
@@ -53,16 +53,11 @@ const (
 	ProviderOllama AIProvider = "ollama"
 	// ProviderLMStudio uses local LM Studio with OpenAI-compatible API.
 	ProviderLMStudio AIProvider = "lmstudio"
-	// ProviderWindows uses on-device Windows AI (Phi Silica via the Windows
-	// Copilot Runtime). The actual API call is not yet wired up; dispatch
-	// returns errWindowsAINotImplemented.
+	// ProviderWindows talks to a local OpenAI-compatible shim that fronts
+	// Phi Silica via the Windows Copilot Runtime (Copilot+ PCs). The user
+	// runs the shim separately; SMT just hits its localhost endpoint.
 	ProviderWindows AIProvider = "windows"
 )
-
-// errWindowsAINotImplemented is returned by dispatch/CallAI when the Windows
-// provider is selected. The provider is registered (so configuration and
-// validation accept it) but the WinRT integration lands in a follow-up PR.
-var errWindowsAINotImplemented = errors.New("windows AI provider is not yet implemented")
 
 // ValidAIProviders returns the list of supported AI provider names.
 func ValidAIProviders() []string {
@@ -342,7 +337,8 @@ func (m *AITypeMapper) dispatch(ctx context.Context, prompt string) (string, err
 		baseURL := m.provider.GetEffectiveBaseURL(m.providerName)
 		return m.queryOpenAICompatAPI(ctx, prompt, baseURL+"/v1/chat/completions")
 	case ProviderWindows:
-		return "", errWindowsAINotImplemented
+		baseURL := m.provider.GetEffectiveBaseURL(m.providerName)
+		return m.queryOpenAICompatAPI(ctx, prompt, baseURL+"/v1/chat/completions")
 	default:
 		// Unknown providers can ride the OpenAI-compatible endpoint if
 		// they configured a base_url (covers vLLM, llama.cpp server, etc.).
@@ -1258,7 +1254,8 @@ func (m *AITypeMapper) CallAI(ctx context.Context, prompt string) (string, error
 		baseURL := m.provider.GetEffectiveBaseURL(m.providerName)
 		result, err = m.queryOpenAICompatAPI(ctx, prompt, baseURL+"/v1/chat/completions")
 	case ProviderWindows:
-		return "", errWindowsAINotImplemented
+		baseURL := m.provider.GetEffectiveBaseURL(m.providerName)
+		result, err = m.queryOpenAICompatAPI(ctx, prompt, baseURL+"/v1/chat/completions")
 	default:
 		if m.provider.BaseURL != "" {
 			result, err = m.queryOpenAICompatAPI(ctx, prompt, m.provider.BaseURL+"/v1/chat/completions")

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -116,10 +116,10 @@ var KnownProviders = map[string]struct {
 	"gemini":    {ProviderTypeCloud, "https://generativelanguage.googleapis.com"},
 	"ollama":    {ProviderTypeLocal, "http://localhost:11434"},
 	"lmstudio":  {ProviderTypeLocal, "http://localhost:1234"},
-	// Windows AI runs on-device via the Windows Copilot Runtime (Phi Silica
-	// on Copilot+ PCs). It is a native API rather than an HTTP endpoint, so
-	// it has no DefaultURL — the dispatch path is provider-specific.
-	"windows": {ProviderTypeLocal, ""},
+	// Windows AI talks to a local OpenAI-compatible shim that fronts Phi
+	// Silica via the Windows Copilot Runtime on Copilot+ PCs. The shim is
+	// a separate process the user runs (analogous to ollama / LM Studio).
+	"windows": {ProviderTypeLocal, "http://localhost:8765"},
 }
 
 // DefaultModels maps providers to their default models.
@@ -434,8 +434,8 @@ func (c *Config) GetMigrationDefaults() *MigrationDefaults {
 	// enable it by default when an AI provider is configured
 	if defaults.AIAdjust == nil && defaults.AIAdjustInterval == "" {
 		// Neither ai_adjust nor ai_adjust_interval was set - apply default
-		if provider, name, err := c.GetDefaultProvider(); err == nil && provider != nil {
-			if provider.IsConfigured(name) {
+		if provider, _, err := c.GetDefaultProvider(); err == nil && provider != nil {
+			if provider.APIKey != "" || provider.BaseURL != "" {
 				aiAdjust := true
 				defaults.AIAdjust = &aiAdjust
 				defaults.AIAdjustInterval = "30s"
@@ -519,27 +519,6 @@ func IsLocalProvider(name string) bool {
 	return false
 }
 
-// IsNativeProvider reports whether the provider runs on-device without an
-// HTTP endpoint (e.g. `windows` via the Windows Copilot Runtime). Such
-// providers need neither an API key nor a base URL — being a registered
-// known provider is sufficient. The discriminator is a registered local
-// provider with no DefaultURL.
-func IsNativeProvider(name string) bool {
-	known, ok := KnownProviders[name]
-	return ok && known.Type == ProviderTypeLocal && known.DefaultURL == ""
-}
-
-// IsConfigured reports whether p has enough information to be used as the
-// active AI provider. HTTP-based providers (cloud, ollama, lmstudio,
-// custom OpenAI-compatible local servers) need APIKey or BaseURL set.
-// Native providers like `windows` need neither.
-func (p *Provider) IsConfigured(name string) bool {
-	if p.APIKey != "" || p.BaseURL != "" {
-		return true
-	}
-	return IsNativeProvider(name)
-}
-
 // SecretsNotFoundError is returned when the secrets file doesn't exist
 type SecretsNotFoundError struct {
 	Path string
@@ -608,10 +587,12 @@ ai:
       # context_window: 8192  # optional, configure based on your model
       # max_tokens: 16000     # optional, increase for reasoning models (e.g., Qwen3, GPT-OSS)
 
-    # Windows AI (on-device). Runs Phi Silica via the Windows Copilot Runtime
-    # on Copilot+ PCs. No API key, no base_url — uses the native WinRT API.
-    # Requires Windows 11 with the Windows AI components installed.
+    # Windows AI (on-device Phi Silica via the Windows Copilot Runtime).
+    # SMT talks to a local OpenAI-compatible shim — run it separately
+    # (analogous to ollama / LM Studio). Default port: 8765.
+    # Requires a Copilot+ PC running Windows 11 24H2 or newer.
     windows:
+      base_url: "http://localhost:8765"
       model: "phi-silica"
       # max_tokens: 16000  # optional, on-device output cap
 

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -213,55 +213,6 @@ func TestIsLocalProvider(t *testing.T) {
 	}
 }
 
-func TestIsNativeProvider(t *testing.T) {
-	tests := []struct {
-		name     string
-		expected bool
-	}{
-		{"anthropic", false},
-		{"openai", false},
-		{"ollama", false},
-		{"lmstudio", false},
-		{"windows", true},
-		{"unknown", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := IsNativeProvider(tt.name)
-			if got != tt.expected {
-				t.Errorf("IsNativeProvider(%q) = %v, want %v", tt.name, got, tt.expected)
-			}
-		})
-	}
-}
-
-func TestProvider_IsConfigured(t *testing.T) {
-	tests := []struct {
-		name         string
-		providerName string
-		provider     Provider
-		want         bool
-	}{
-		{"anthropic with key", "anthropic", Provider{APIKey: "sk-..."}, true},
-		{"anthropic without key", "anthropic", Provider{}, false},
-		{"ollama with base url", "ollama", Provider{BaseURL: "http://localhost:11434"}, true},
-		{"ollama without base url", "ollama", Provider{}, false},
-		{"windows with nothing set", "windows", Provider{}, true},
-		{"windows with model only", "windows", Provider{Model: "phi-silica"}, true},
-		{"unknown provider with nothing", "unknown", Provider{}, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.provider.IsConfigured(tt.providerName)
-			if got != tt.want {
-				t.Errorf("IsConfigured(%q) = %v, want %v", tt.providerName, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestSecretsNotFoundError(t *testing.T) {
 	tmpDir := t.TempDir()
 	secretsFile := filepath.Join(tmpDir, "nonexistent.yaml")

--- a/internal/setup/actions.go
+++ b/internal/setup/actions.go
@@ -11,12 +11,9 @@ import (
 // It uses secrets.Save() which merges into any existing secrets config.
 func (s *State) WriteSecretsFile() error {
 	provider := &secrets.Provider{}
-	switch {
-	case secrets.IsNativeProvider(s.AIProvider):
-		// Native providers (e.g. windows) need neither key nor URL.
-	case secrets.IsLocalProvider(s.AIProvider):
+	if secrets.IsLocalProvider(s.AIProvider) {
 		provider.BaseURL = s.AIKey
-	default:
+	} else {
 		provider.APIKey = s.AIKey
 	}
 	if model, ok := secrets.DefaultModels[s.AIProvider]; ok {
@@ -60,7 +57,7 @@ func CheckExistingSecrets() string {
 	}
 
 	p, ok := cfg.AI.Providers[cfg.AI.DefaultProvider]
-	if !ok || !p.IsConfigured(cfg.AI.DefaultProvider) {
+	if !ok || (p.APIKey == "" && p.BaseURL == "") {
 		return "no_ai"
 	}
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -127,12 +127,6 @@ func (s *State) Prompt() PromptInfo {
 			Choices: providers,
 		}
 	case StepAIKey:
-		if secrets.IsNativeProvider(s.AIProvider) {
-			return PromptInfo{
-				Text:         "On-device provider — no key or URL needed.",
-				IsAutoAction: true,
-			}
-		}
 		if secrets.IsLocalProvider(s.AIProvider) {
 			known := secrets.KnownProviders[s.AIProvider]
 			return PromptInfo{
@@ -362,16 +356,13 @@ func (s *State) Process(input string) string {
 		s.CurrentStep = StepAIKey
 
 	case StepAIKey:
-		switch {
-		case secrets.IsNativeProvider(s.AIProvider):
-			s.AIKey = ""
-		case secrets.IsLocalProvider(s.AIProvider):
+		if secrets.IsLocalProvider(s.AIProvider) {
 			if input == "" {
 				known := secrets.KnownProviders[s.AIProvider]
 				input = known.DefaultURL
 			}
 			s.AIKey = input
-		default:
+		} else {
 			if input == "" {
 				return "API key is required for cloud providers"
 			}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -215,25 +215,21 @@ func TestCloudProviderRequiresKey(t *testing.T) {
 	}
 }
 
-func TestNativeProviderNoInput(t *testing.T) {
+func TestWindowsProviderDefaultURL(t *testing.T) {
 	s := NewState()
 	s.Process("no_ai")
 	s.Process("y")
 	s.Process("windows")
 
-	// StepAIKey for a native provider must be auto-action — the wizard
-	// must not prompt for a key or URL, since windows has neither.
-	info := s.Prompt()
-	if !info.IsAutoAction {
-		t.Fatal("StepAIKey should be IsAutoAction for windows")
-	}
-
+	// Windows now goes through the local-HTTP wizard branch, same as
+	// ollama / lmstudio — accept the default base URL pointing at the
+	// shim port.
 	s.Process("")
 	if s.CurrentStep != StepWriteSecrets {
 		t.Fatalf("expected StepWriteSecrets, got %d", s.CurrentStep)
 	}
-	if s.AIKey != "" {
-		t.Fatalf("expected empty AIKey for native provider, got %q", s.AIKey)
+	if s.AIKey != "http://localhost:8765" {
+		t.Fatalf("expected default windows shim URL, got %s", s.AIKey)
 	}
 	if !s.AIConfigured {
 		t.Fatal("expected AIConfigured")


### PR DESCRIPTION
## Summary

Cleanup follow-up to #39. The windows-provider scaffold there was sized for a path we ultimately didn't take. After we chose a user-run OpenAI-compatible shim (fronting Phi Silica via the Windows Copilot Runtime) over direct WinRT-from-Go, `windows` becomes functionally identical to `ollama` / `lmstudio`: a local HTTP provider with a default `base_url` pointing at the shim's port.

This PR collapses the over-engineering and wires `windows` to the existing local-HTTP dispatch path.

## Changes

**Drop the no-key/no-URL plumbing** (was needed only for direct-native integration):

- `internal/secrets/secrets.go` — delete `IsNativeProvider()` and `(*Provider).IsConfigured()`. `GetMigrationDefaults` reverts to the inline `APIKey-or-BaseURL` check.
- `internal/secrets/secrets_test.go` — delete `TestIsNativeProvider` and `TestProvider_IsConfigured`. `TestIsLocalProvider` already covers windows.
- `internal/setup/setup.go` — drop the `IsNativeProvider` branches in `StepAIKey`'s `Prompt` and `Process`. Windows now flows through the local-URL prompt like ollama.
- `internal/setup/actions.go` — drop the `IsNativeProvider` arm in `WriteSecretsFile`. `CheckExistingSecrets` reverts to inline `APIKey-or-BaseURL`.
- `internal/setup/setup_test.go` — replace `TestNativeProviderNoInput` with `TestWindowsProviderDefaultURL` (same wizard flow, asserts the shim base URL).

**Wire `windows` to the existing local-HTTP path:**

- `internal/secrets/secrets.go` — `KnownProviders["windows"]` `DefaultURL`: `""` → `"http://localhost:8765"`. `GenerateTemplate` `windows:` block updated to show `base_url` and describe the external shim.
- `internal/driver/ai_typemapper.go` — replace the dispatch stub `case ProviderWindows` (in both `dispatch` and `CallAI` switches) with the same `queryOpenAICompatAPI` pattern as `ollama`/`lmstudio`. Delete the `errWindowsAINotImplemented` sentinel.

**Three call sites of `IsConfigured` in `config.go`** are replaced with inline `APIKey != "" || BaseURL != ""`. **Important: the OR-form is kept** (rather than reverting to bare `APIKey != ""`). PR #39 incidentally fixed a pre-existing bug — pre-#39 the AI-from-secrets loader silently skipped any local provider configured purely in secrets (ollama / lmstudio). The inline form preserves the fix without the helper.

The AI-defaults block at `config.go:778` is also broadened to recognize any local provider via `secrets.IsLocalProvider`, not just providers with an APIKey. Same incidental fix for `ollama` / `lmstudio` configured purely in secrets.

## Functional impact

Selecting `default_provider: windows` now reaches the OpenAI-compat dispatch instead of returning the `errWindowsAINotImplemented` stub. If the user hasn't started their Phi Silica shim, they get connection-refused — same UX as `ollama` / `lmstudio` without the server running.

The shim itself is a separate sibling project (`smt-phi-silica-shim`) being built alongside this cleanup.

## Verification

- `go build ./...` clean
- `gofmt -l` clean on touched files
- Targeted tests green: `TestIsLocalProvider`, `TestNormalizeAIProvider`, `TestWindowsProviderDefaultURL`, `TestLocalProviderDefaultURL`, `TestCloudProviderRequiresKey`, `TestSecretsExistWithValidAI`, `TestSecretsExistNoAI`.
- Full short-test sweep: only failures are pre-existing on `main` — three Windows-host POSIX-permission casualties (`TestLoadSecretsFile`, `TestLocalProviderNoAPIKeyRequired`, `TestNewFromSecrets/secrets_with_webhook_returns_enabled_notifier`). Verified by running on `main` directly.

## Net diff

7 files, **+41 / -124** (net −83 lines).

## Lesson logged

For future provider/integration work: lock the integration approach (HTTP shim vs direct native vs subprocess) **before** designing the codebase surface. Different strategies need very different scaffolding. `windows` would have been ~20 lines of registration shaped this way from day one if the shim path had been chosen first.
