### PR TITLE
Fix deterministic PostgreSQL CRM DDL edge cases

### DIFF
--- a/internal/driver/postgres/deterministic.go
+++ b/internal/driver/postgres/deterministic.go
@@ -73,7 +73,7 @@ func (r deterministicDDL) createTable(t *driver.Table, targetSchema string, unlo
 	lines := make([]string, 0, len(t.Columns)+1)
 
 	for _, col := range t.Columns {
-		def, colType, err := r.columnDefinition(col)
+		def, colType, err := r.columnDefinition(col, t.Columns)
 		if err != nil {
 			return "", nil, fmt.Errorf("mapping column %s.%s: %w", t.Name, col.Name, err)
 		}
@@ -104,11 +104,15 @@ func (r deterministicDDL) createTable(t *driver.Table, targetSchema string, unlo
 	return b.String(), columnTypes, nil
 }
 
-func (r deterministicDDL) columnDefinition(col driver.Column) (string, string, error) {
+func (r deterministicDDL) columnDefinition(col driver.Column, tableColumns ...[]driver.Column) (string, string, error) {
 	colName := sanitizePGIdentifier(col.Name)
 	colType, err := r.columnType(col)
 	if err != nil {
 		return "", "", err
+	}
+	contextColumns := []driver.Column(nil)
+	if len(tableColumns) > 0 {
+		contextColumns = tableColumns[0]
 	}
 	if col.IsComputed {
 		if !col.ComputedPersisted {
@@ -124,6 +128,7 @@ func (r deterministicDDL) columnDefinition(col driver.Column) (string, string, e
 		if isTextualPGType(colType) {
 			expr = rewriteSQLServerStringConcat(expr)
 		}
+		expr = rewriteSQLServerBitComparisons(expr, contextColumns)
 		if strings.EqualFold(strings.TrimSpace(col.DataType), "bit") {
 			expr = rewriteSQLServerBooleanResultLiterals(expr)
 		}
@@ -193,6 +198,7 @@ func (r deterministicDDL) createIndex(t *driver.Table, idx *driver.Index, target
 		if err != nil {
 			return "", fmt.Errorf("mapping filter for index %s: %w", idx.Name, err)
 		}
+		expr = rewriteSQLServerBitComparisons(expr, t.Columns)
 		b.WriteString(" WHERE ")
 		b.WriteString(expr)
 	}

--- a/internal/driver/postgres/deterministic.go
+++ b/internal/driver/postgres/deterministic.go
@@ -111,7 +111,30 @@ func (r deterministicDDL) columnDefinition(col driver.Column) (string, string, e
 		return "", "", err
 	}
 	if col.IsComputed {
-		return "", "", fmt.Errorf("computed column %s is not yet supported by deterministic PostgreSQL DDL", col.Name)
+		if !col.ComputedPersisted {
+			return "", "", fmt.Errorf("computed column %s is not persisted; PostgreSQL generated columns are stored only", col.Name)
+		}
+		expr, err := r.sqlServerExpression(col.ComputedExpression)
+		if err != nil {
+			return "", "", fmt.Errorf("mapping computed column %s: %w", col.Name, err)
+		}
+		if strings.TrimSpace(expr) == "" {
+			return "", "", fmt.Errorf("computed column %s has no expression", col.Name)
+		}
+		if isTextualPGType(colType) {
+			expr = rewriteSQLServerStringConcat(expr)
+		}
+		if strings.EqualFold(strings.TrimSpace(col.DataType), "bit") {
+			expr = rewriteSQLServerBooleanResultLiterals(expr)
+		}
+		var b strings.Builder
+		b.WriteString(r.dialect.QuoteIdentifier(colName))
+		b.WriteString(" ")
+		b.WriteString(colType)
+		b.WriteString(" GENERATED ALWAYS AS (")
+		b.WriteString(expr)
+		b.WriteString(") STORED")
+		return b.String(), colType, nil
 	}
 
 	var b strings.Builder
@@ -228,6 +251,7 @@ func (r deterministicDDL) createCheckConstraint(t *driver.Table, chk *driver.Che
 	if err != nil {
 		return "", fmt.Errorf("mapping check constraint %s: %w", chk.Name, err)
 	}
+	expr = rewriteSQLServerBitComparisons(expr, t.Columns)
 
 	return fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s CHECK %s",
 		r.dialect.QualifyTable(targetSchema, tableName),
@@ -337,6 +361,13 @@ func (r deterministicDDL) defaultExpression(col driver.Column) (string, error) {
 		return "(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')", nil
 	case "sysdatetime()":
 		return "CURRENT_TIMESTAMP", nil
+	case "sysdatetimeoffset()":
+		return "CURRENT_TIMESTAMP", nil
+	case "sysutcdatetime()":
+		if strings.EqualFold(strings.TrimSpace(col.DataType), "datetimeoffset") {
+			return "CURRENT_TIMESTAMP", nil
+		}
+		return "(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')", nil
 	case "newid()":
 		return "gen_random_uuid()", nil
 	}
@@ -358,15 +389,22 @@ func (r deterministicDDL) sqlServerExpression(expr string) (string, error) {
 	out = replaceBracketIdentifiers(out, func(name string) string {
 		return r.dialect.QuoteIdentifier(sanitizePGIdentifier(name))
 	})
+	out = stripSQLServerUnicodeStringPrefixes(out)
+	out = rewriteSQLServerLikePatterns(out)
 	out = strings.ReplaceAll(out, "GETDATE()", "CURRENT_TIMESTAMP")
 	out = strings.ReplaceAll(out, "getdate()", "CURRENT_TIMESTAMP")
 	out = strings.ReplaceAll(out, "GETUTCDATE()", "(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')")
 	out = strings.ReplaceAll(out, "getutcdate()", "(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')")
+	out = strings.ReplaceAll(out, "SYSDATETIME()", "CURRENT_TIMESTAMP")
+	out = strings.ReplaceAll(out, "sysdatetime()", "CURRENT_TIMESTAMP")
+	out = strings.ReplaceAll(out, "SYSDATETIMEOFFSET()", "CURRENT_TIMESTAMP")
+	out = strings.ReplaceAll(out, "sysdatetimeoffset()", "CURRENT_TIMESTAMP")
+	out = strings.ReplaceAll(out, "SYSUTCDATETIME()", "(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')")
+	out = strings.ReplaceAll(out, "sysutcdatetime()", "(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')")
 	out = strings.ReplaceAll(out, "NEWID()", "gen_random_uuid()")
 	out = strings.ReplaceAll(out, "newid()", "gen_random_uuid()")
 	out = strings.ReplaceAll(out, "ISNULL(", "COALESCE(")
 	out = strings.ReplaceAll(out, "isnull(", "COALESCE(")
-	out = strings.ReplaceAll(out, "N'", "'")
 	if err := rejectUnsupportedSQLServerExpression(out); err != nil {
 		return "", err
 	}
@@ -383,7 +421,7 @@ func rejectUnsupportedSQLServerExpression(expr string) error {
 		}
 		name := strings.ToLower(match[1])
 		switch name {
-		case "coalesce", "gen_random_uuid", "nullif", "lower", "upper", "in", "not", "exists":
+		case "and", "or", "case", "when", "then", "else", "end", "coalesce", "gen_random_uuid", "nullif", "lower", "upper", "in", "not", "exists":
 			continue
 		default:
 			return fmt.Errorf("unsupported SQL expression function %q in %q", match[1], expr)
@@ -471,14 +509,229 @@ func balancedParens(s string) bool {
 	return depth == 0 && !inSingleQuote
 }
 
-var bracketIdentifierRE = regexp.MustCompile(`\[([^\]]+)\]`)
-
 func replaceBracketIdentifiers(s string, quote func(string) string) string {
-	return bracketIdentifierRE.ReplaceAllStringFunc(s, func(match string) string {
-		parts := bracketIdentifierRE.FindStringSubmatch(match)
-		if len(parts) != 2 {
+	var b strings.Builder
+	b.Grow(len(s))
+	inSingleQuote := false
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if ch == '\'' {
+			b.WriteByte(ch)
+			if inSingleQuote && i+1 < len(s) && s[i+1] == '\'' {
+				i++
+				b.WriteByte(s[i])
+				continue
+			}
+			inSingleQuote = !inSingleQuote
+			continue
+		}
+		if !inSingleQuote && ch == '[' {
+			if end := strings.IndexByte(s[i+1:], ']'); end >= 0 {
+				name := s[i+1 : i+1+end]
+				b.WriteString(quote(name))
+				i += end + 1
+				continue
+			}
+		}
+		b.WriteByte(ch)
+	}
+	return b.String()
+}
+
+func stripSQLServerUnicodeStringPrefixes(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	inSingleQuote := false
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if !inSingleQuote && (ch == 'N' || ch == 'n') && i+1 < len(s) && s[i+1] == '\'' && startsSQLStringPrefix(s, i) {
+			b.WriteByte('\'')
+			i++
+			inSingleQuote = true
+			continue
+		}
+		if ch == '\'' {
+			b.WriteByte(ch)
+			if inSingleQuote && i+1 < len(s) && s[i+1] == '\'' {
+				i++
+				b.WriteByte(s[i])
+				continue
+			}
+			inSingleQuote = !inSingleQuote
+			continue
+		}
+		b.WriteByte(ch)
+	}
+	return b.String()
+}
+
+func startsSQLStringPrefix(s string, idx int) bool {
+	if idx == 0 {
+		return true
+	}
+	prev := s[idx-1]
+	return !((prev >= 'a' && prev <= 'z') ||
+		(prev >= 'A' && prev <= 'Z') ||
+		(prev >= '0' && prev <= '9') ||
+		prev == '_' ||
+		prev == '"')
+}
+
+func isTextualPGType(colType string) bool {
+	colType = strings.ToLower(strings.TrimSpace(colType))
+	return strings.HasPrefix(colType, "character varying") ||
+		strings.HasPrefix(colType, "character(") ||
+		colType == "text"
+}
+
+func rewriteSQLServerStringConcat(expr string) string {
+	var b strings.Builder
+	b.Grow(len(expr))
+	inSingleQuote := false
+	for i := 0; i < len(expr); i++ {
+		ch := expr[i]
+		if ch == '\'' {
+			b.WriteByte(ch)
+			if inSingleQuote && i+1 < len(expr) && expr[i+1] == '\'' {
+				i++
+				b.WriteByte(expr[i])
+				continue
+			}
+			inSingleQuote = !inSingleQuote
+			continue
+		}
+		if !inSingleQuote && ch == '+' {
+			b.WriteString(" || ")
+			continue
+		}
+		b.WriteByte(ch)
+	}
+	return b.String()
+}
+
+func rewriteSQLServerBooleanResultLiterals(expr string) string {
+	resultLiteralRE := regexp.MustCompile(`(?i)\b(THEN|ELSE)\s+\(?([01])\)?`)
+	return resultLiteralRE.ReplaceAllStringFunc(expr, func(match string) string {
+		parts := resultLiteralRE.FindStringSubmatch(match)
+		if len(parts) != 3 {
 			return match
 		}
-		return quote(parts[1])
+		lit := "false"
+		if parts[2] == "1" {
+			lit = "true"
+		}
+		return parts[1] + " " + lit
 	})
+}
+
+func rewriteSQLServerBitComparisons(expr string, cols []driver.Column) string {
+	out := expr
+	for _, col := range cols {
+		if !strings.EqualFold(strings.TrimSpace(col.DataType), "bit") {
+			continue
+		}
+		quoted := `"` + sanitizePGIdentifier(col.Name) + `"`
+		ident := regexp.QuoteMeta(quoted)
+		leftRE := regexp.MustCompile(`(?i)(` + ident + `)\s*=\s*\(?([01])\)?\b`)
+		out = leftRE.ReplaceAllStringFunc(out, func(match string) string {
+			parts := leftRE.FindStringSubmatch(match)
+			if len(parts) != 3 {
+				return match
+			}
+			return parts[1] + " = " + bitLiteral(parts[2])
+		})
+		rightRE := regexp.MustCompile(`(?i)\(?([01])\)?\s*=\s*(` + ident + `)\b`)
+		out = rightRE.ReplaceAllStringFunc(out, func(match string) string {
+			parts := rightRE.FindStringSubmatch(match)
+			if len(parts) != 3 {
+				return match
+			}
+			return bitLiteral(parts[1]) + " = " + parts[2]
+		})
+	}
+	return out
+}
+
+func bitLiteral(v string) string {
+	if v == "1" {
+		return "true"
+	}
+	return "false"
+}
+
+var sqlServerLikeLiteralRE = regexp.MustCompile(`(?i)(("[^"]+"|[a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)?)\s+)(NOT\s+)?LIKE\s+('(?:''|[^'])*')`)
+
+func rewriteSQLServerLikePatterns(s string) string {
+	return sqlServerLikeLiteralRE.ReplaceAllStringFunc(s, func(match string) string {
+		parts := sqlServerLikeLiteralRE.FindStringSubmatch(match)
+		if len(parts) != 5 {
+			return match
+		}
+		pattern := unquoteSQLString(parts[4])
+		if !strings.Contains(pattern, "[") || !strings.Contains(pattern, "]") {
+			return match
+		}
+		re, ok := sqlServerLikePatternToRegex(pattern)
+		if !ok {
+			return match
+		}
+		op := "~"
+		if strings.TrimSpace(parts[3]) != "" {
+			op = "!~"
+		}
+		return strings.TrimSpace(parts[1]) + " " + op + " " + quoteSQLString(re)
+	})
+}
+
+func sqlServerLikePatternToRegex(pattern string) (string, bool) {
+	var b strings.Builder
+	b.Grow(len(pattern) + 2)
+	b.WriteByte('^')
+	usedBracketClass := false
+	for i := 0; i < len(pattern); i++ {
+		ch := pattern[i]
+		switch ch {
+		case '%':
+			b.WriteString(".*")
+		case '_':
+			b.WriteByte('.')
+		case '[':
+			end := strings.IndexByte(pattern[i+1:], ']')
+			if end < 0 {
+				b.WriteString(`\[`)
+				continue
+			}
+			class := pattern[i+1 : i+1+end]
+			if class == "" {
+				b.WriteString(`\[\]`)
+			} else {
+				usedBracketClass = true
+				if class[0] == '^' {
+					class = "^" + regexp.QuoteMeta(class[1:])
+				} else {
+					class = regexp.QuoteMeta(class)
+				}
+				b.WriteByte('[')
+				b.WriteString(class)
+				b.WriteByte(']')
+			}
+			i += end + 1
+		default:
+			b.WriteString(regexp.QuoteMeta(string(ch)))
+		}
+	}
+	b.WriteByte('$')
+	return b.String(), usedBracketClass
+}
+
+func unquoteSQLString(lit string) string {
+	lit = strings.TrimSpace(lit)
+	if len(lit) >= 2 && lit[0] == '\'' && lit[len(lit)-1] == '\'' {
+		lit = lit[1 : len(lit)-1]
+	}
+	return strings.ReplaceAll(lit, "''", "'")
+}
+
+func quoteSQLString(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }

--- a/internal/driver/postgres/deterministic.go
+++ b/internal/driver/postgres/deterministic.go
@@ -144,6 +144,9 @@ func (r deterministicDDL) columnDefinition(col driver.Column, tableColumns ...[]
 		b.WriteString(" GENERATED ALWAYS AS (")
 		b.WriteString(expr)
 		b.WriteString(") STORED")
+		if !col.IsNullable {
+			b.WriteString(" NOT NULL")
+		}
 		return b.String(), colType, nil
 	}
 
@@ -643,21 +646,21 @@ func rewriteSQLServerBitComparisons(expr string, cols []driver.Column) string {
 		}
 		quoted := `"` + sanitizePGIdentifier(col.Name) + `"`
 		ident := regexp.QuoteMeta(quoted)
-		leftRE := regexp.MustCompile(`(?i)(` + ident + `)\s*=\s*(?:\(([01])\)|([01])\b)`)
+		leftRE := regexp.MustCompile(`(?i)(` + ident + `)\s*(=|<>|!=)\s*(?:\(([01])\)|([01])\b)`)
 		out = leftRE.ReplaceAllStringFunc(out, func(match string) string {
 			parts := leftRE.FindStringSubmatch(match)
-			if len(parts) != 4 {
+			if len(parts) != 5 {
 				return match
 			}
-			return parts[1] + " = " + bitLiteral(firstNonEmpty(parts[2], parts[3]))
+			return parts[1] + " " + parts[2] + " " + bitLiteral(firstNonEmpty(parts[3], parts[4]))
 		})
-		rightRE := regexp.MustCompile(`(?i)(?:\(([01])\)|([01])\b)\s*=\s*(` + ident + `)`)
+		rightRE := regexp.MustCompile(`(?i)(?:\(([01])\)|([01])\b)\s*(=|<>|!=)\s*(` + ident + `)`)
 		out = rightRE.ReplaceAllStringFunc(out, func(match string) string {
 			parts := rightRE.FindStringSubmatch(match)
-			if len(parts) != 4 {
+			if len(parts) != 5 {
 				return match
 			}
-			return bitLiteral(firstNonEmpty(parts[1], parts[2])) + " = " + parts[3]
+			return bitLiteral(firstNonEmpty(parts[1], parts[2])) + " " + parts[3] + " " + parts[4]
 		})
 	}
 	return out

--- a/internal/driver/postgres/deterministic.go
+++ b/internal/driver/postgres/deterministic.go
@@ -39,6 +39,11 @@ func RenderColumnDefinitionWithPolicy(col driver.Column, unknownTypePolicy strin
 	return def, err
 }
 
+func RenderColumnDefinitionWithContextAndPolicy(col driver.Column, tableColumns []driver.Column, unknownTypePolicy string) (string, error) {
+	def, _, err := newDeterministicDDL(unknownTypePolicy).columnDefinition(col, tableColumns)
+	return def, err
+}
+
 func RenderColumnType(col driver.Column) (string, error) {
 	return RenderColumnTypeWithPolicy(col, "")
 }

--- a/internal/driver/postgres/deterministic.go
+++ b/internal/driver/postgres/deterministic.go
@@ -632,24 +632,33 @@ func rewriteSQLServerBitComparisons(expr string, cols []driver.Column) string {
 		}
 		quoted := `"` + sanitizePGIdentifier(col.Name) + `"`
 		ident := regexp.QuoteMeta(quoted)
-		leftRE := regexp.MustCompile(`(?i)(` + ident + `)\s*=\s*\(?([01])\)?\b`)
+		leftRE := regexp.MustCompile(`(?i)(` + ident + `)\s*=\s*(?:\(([01])\)|([01])\b)`)
 		out = leftRE.ReplaceAllStringFunc(out, func(match string) string {
 			parts := leftRE.FindStringSubmatch(match)
-			if len(parts) != 3 {
+			if len(parts) != 4 {
 				return match
 			}
-			return parts[1] + " = " + bitLiteral(parts[2])
+			return parts[1] + " = " + bitLiteral(firstNonEmpty(parts[2], parts[3]))
 		})
-		rightRE := regexp.MustCompile(`(?i)\(?([01])\)?\s*=\s*(` + ident + `)\b`)
+		rightRE := regexp.MustCompile(`(?i)(?:\(([01])\)|([01])\b)\s*=\s*(` + ident + `)`)
 		out = rightRE.ReplaceAllStringFunc(out, func(match string) string {
 			parts := rightRE.FindStringSubmatch(match)
-			if len(parts) != 3 {
+			if len(parts) != 4 {
 				return match
 			}
-			return bitLiteral(parts[1]) + " = " + parts[2]
+			return bitLiteral(firstNonEmpty(parts[1], parts[2])) + " = " + parts[3]
 		})
 	}
 	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func bitLiteral(v string) string {

--- a/internal/driver/postgres/deterministic_test.go
+++ b/internal/driver/postgres/deterministic_test.go
@@ -111,6 +111,129 @@ func TestDeterministicMSSQLTimestampRowversionMapsToBytea(t *testing.T) {
 	}
 }
 
+func TestDeterministicMSSQLDateTimeOffsetDefault(t *testing.T) {
+	renderer := newDeterministicDDL()
+	def, err := renderer.defaultExpression(driver.Column{
+		Name:              "PaidAt",
+		DataType:          "datetimeoffset",
+		DefaultExpression: "(sysdatetimeoffset())",
+	})
+	if err != nil {
+		t.Fatalf("defaultExpression: %v", err)
+	}
+	if def != "CURRENT_TIMESTAMP" {
+		t.Fatalf("sysdatetimeoffset maps to %q, want CURRENT_TIMESTAMP", def)
+	}
+}
+
+func TestDeterministicMSSQLDateTimeOffsetUTCDefault(t *testing.T) {
+	renderer := newDeterministicDDL()
+	def, err := renderer.defaultExpression(driver.Column{
+		Name:              "PaidAt",
+		DataType:          "datetimeoffset",
+		DefaultExpression: "(sysutcdatetime())",
+	})
+	if err != nil {
+		t.Fatalf("defaultExpression: %v", err)
+	}
+	if def != "CURRENT_TIMESTAMP" {
+		t.Fatalf("datetimeoffset sysutcdatetime maps to %q, want CURRENT_TIMESTAMP", def)
+	}
+}
+
+func TestDeterministicMSSQLComputedColumn(t *testing.T) {
+	renderer := newDeterministicDDL()
+	def, colType, err := renderer.columnDefinition(driver.Column{
+		Name:               "LineTotal",
+		DataType:           "decimal",
+		Precision:          15,
+		Scale:              2,
+		IsComputed:         true,
+		ComputedExpression: "(([quantity]*[unit_price])*((1)-[discount_pct]/(100)))",
+		ComputedPersisted:  true,
+	})
+	if err != nil {
+		t.Fatalf("columnDefinition: %v", err)
+	}
+	if colType != "numeric(15,2)" {
+		t.Fatalf("colType = %q, want numeric(15,2)", colType)
+	}
+	assertContains(t, def, `"linetotal" numeric(15,2) GENERATED ALWAYS AS (`)
+	assertContains(t, def, `"quantity"*"unit_price"`)
+	assertContains(t, def, `"discount_pct"`)
+	assertContains(t, def, `) STORED`)
+}
+
+func TestDeterministicMSSQLComputedStringConcatColumn(t *testing.T) {
+	renderer := newDeterministicDDL()
+	def, _, err := renderer.columnDefinition(driver.Column{
+		Name:               "FullName",
+		DataType:           "nvarchar",
+		MaxLength:          101,
+		IsComputed:         true,
+		ComputedExpression: "([first_name]+' '+[last_name])",
+		ComputedPersisted:  true,
+	})
+	if err != nil {
+		t.Fatalf("columnDefinition: %v", err)
+	}
+	assertContains(t, def, `"fullname" character varying(101) GENERATED ALWAYS AS (`)
+	assertContains(t, def, `"first_name" || ' ' || "last_name"`)
+	assertContains(t, def, `) STORED`)
+}
+
+func TestDeterministicMSSQLNonPersistedComputedColumnFails(t *testing.T) {
+	renderer := newDeterministicDDL()
+	_, _, err := renderer.columnDefinition(driver.Column{
+		Name:               "FullName",
+		DataType:           "nvarchar",
+		MaxLength:          101,
+		IsComputed:         true,
+		ComputedExpression: "([first_name]+' '+[last_name])",
+		ComputedPersisted:  false,
+	})
+	if err == nil {
+		t.Fatal("expected non-persisted computed column to fail")
+	}
+}
+
+func TestDeterministicMSSQLComputedCaseColumn(t *testing.T) {
+	renderer := newDeterministicDDL()
+	def, _, err := renderer.columnDefinition(driver.Column{
+		Name:               "Margin",
+		DataType:           "decimal",
+		Precision:          12,
+		Scale:              2,
+		IsComputed:         true,
+		ComputedExpression: "(case when [cost_price] IS NULL OR [cost_price]=(0) then NULL else ([unit_price]-[cost_price])/[cost_price] end)",
+		ComputedPersisted:  true,
+	})
+	if err != nil {
+		t.Fatalf("columnDefinition: %v", err)
+	}
+	assertContains(t, def, `"margin" numeric(12,2) GENERATED ALWAYS AS (`)
+	assertContains(t, def, `case when "cost_price" IS NULL`)
+	assertContains(t, def, `else ("unit_price"-"cost_price")/"cost_price" end`)
+	assertContains(t, def, `) STORED`)
+}
+
+func TestDeterministicMSSQLComputedBitCaseColumn(t *testing.T) {
+	renderer := newDeterministicDDL()
+	def, _, err := renderer.columnDefinition(driver.Column{
+		Name:               "IsPreferred",
+		DataType:           "bit",
+		IsComputed:         true,
+		ComputedExpression: "(case when [score] >= (10) then (1) else (0) end)",
+		ComputedPersisted:  true,
+	})
+	if err != nil {
+		t.Fatalf("columnDefinition: %v", err)
+	}
+	assertContains(t, def, `"ispreferred" boolean GENERATED ALWAYS AS (`)
+	assertContains(t, def, `case when "score" >= (10) then true else false end`)
+	assertContains(t, def, `) STORED`)
+}
+
 func TestDeterministicUnsafeDefaultExpressionFails(t *testing.T) {
 	renderer := newDeterministicDDL()
 	_, _, err := renderer.columnDefinition(driver.Column{
@@ -132,6 +255,66 @@ func TestDeterministicUnsafeCheckExpressionFails(t *testing.T) {
 	}, "public")
 	if err == nil {
 		t.Fatal("expected unsupported check expression error")
+	}
+}
+
+func TestDeterministicMSSQLCheckBooleanKeywords(t *testing.T) {
+	renderer := newDeterministicDDL()
+	ddl, err := renderer.createCheckConstraint(&driver.Table{Name: "Customers"}, &driver.CheckConstraint{
+		Name:       "CK_Cust_identity",
+		Definition: "([customer_type]='individual' AND [first_name] IS NOT NULL AND [last_name] IS NOT NULL OR ([customer_type]='government' OR [customer_type]='company') AND [company_name] IS NOT NULL)",
+	}, "public")
+	if err != nil {
+		t.Fatalf("createCheckConstraint: %v", err)
+	}
+	assertContains(t, ddl, `ALTER TABLE "public"."customers" ADD CONSTRAINT "ck_cust_identity" CHECK (`)
+	assertContains(t, ddl, `"customer_type"='individual' AND "first_name" IS NOT NULL`)
+	assertContains(t, ddl, `OR ("customer_type"='government' OR "customer_type"='company')`)
+}
+
+func TestDeterministicMSSQLCheckBitComparison(t *testing.T) {
+	renderer := newDeterministicDDL()
+	ddl, err := renderer.createCheckConstraint(&driver.Table{
+		Name:    "Customers",
+		Columns: []driver.Column{{Name: "IsActive", DataType: "bit"}},
+	}, &driver.CheckConstraint{
+		Name:       "CK_Cust_active",
+		Definition: "([IsActive]=(1))",
+	}, "public")
+	if err != nil {
+		t.Fatalf("createCheckConstraint: %v", err)
+	}
+	assertContains(t, ddl, `CHECK ("isactive" = true)`)
+}
+
+func TestDeterministicMSSQLCheckLikeBracketPattern(t *testing.T) {
+	renderer := newDeterministicDDL()
+	ddl, err := renderer.createCheckConstraint(&driver.Table{Name: "Tags"}, &driver.CheckConstraint{
+		Name:       "CK_Tag_color",
+		Definition: "([color] IS NULL OR [color] LIKE '#[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]')",
+	}, "public")
+	if err != nil {
+		t.Fatalf("createCheckConstraint: %v", err)
+	}
+	assertContains(t, ddl, `ALTER TABLE "public"."tags" ADD CONSTRAINT "ck_tag_color" CHECK (`)
+	assertContains(t, ddl, `"color" IS NULL OR "color" ~ '^#[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]$'`)
+	if strings.Contains(ddl, `"col_0_9a_fa_f"`) {
+		t.Fatalf("LIKE character class was rewritten as an identifier:\n%s", ddl)
+	}
+}
+
+func TestDeterministicMSSQLCheckUnicodeLikeBracketPattern(t *testing.T) {
+	renderer := newDeterministicDDL()
+	ddl, err := renderer.createCheckConstraint(&driver.Table{Name: "Tags"}, &driver.CheckConstraint{
+		Name:       "CK_Tag_color",
+		Definition: "([color] IS NULL OR [color] LIKE N'#[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]')",
+	}, "public")
+	if err != nil {
+		t.Fatalf("createCheckConstraint: %v", err)
+	}
+	assertContains(t, ddl, `"color" IS NULL OR "color" ~ '^#[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]$'`)
+	if strings.Contains(ddl, `LIKE N'`) || strings.Contains(ddl, `"col_0_9a_fa_f"`) {
+		t.Fatalf("Unicode LIKE pattern was not rewritten correctly:\n%s", ddl)
 	}
 }
 

--- a/internal/driver/postgres/deterministic_test.go
+++ b/internal/driver/postgres/deterministic_test.go
@@ -92,6 +92,26 @@ func TestDeterministicFinalizationDDL(t *testing.T) {
 	assertContains(t, checkDDL, `ALTER TABLE "public"."votes" ADD CONSTRAINT "ck_votes_bountyamount" CHECK ("bountyamount">(0))`)
 }
 
+func TestDeterministicFilteredIndexBitComparison(t *testing.T) {
+	renderer := newDeterministicDDL()
+	table := &driver.Table{
+		Name:    "Customers",
+		Columns: []driver.Column{{Name: "IsActive", DataType: "bit"}},
+	}
+	idxDDL, err := renderer.createIndex(table, &driver.Index{
+		Name:    "IX_Customers_Active",
+		Columns: []string{"Id"},
+		Filter:  "([IsActive]=(1))",
+	}, "public")
+	if err != nil {
+		t.Fatalf("createIndex: %v", err)
+	}
+	assertContains(t, idxDDL, `WHERE ("isactive" = true)`)
+	if strings.Contains(idxDDL, "true))") {
+		t.Fatalf("filtered index bit comparison rewrite left an extra close paren:\n%s", idxDDL)
+	}
+}
+
 func TestDeterministicUnsupportedTypeFails(t *testing.T) {
 	renderer := newDeterministicDDL()
 	_, err := renderer.columnType(driver.Column{Name: "Mystery", DataType: "sql_variant"})
@@ -232,6 +252,30 @@ func TestDeterministicMSSQLComputedBitCaseColumn(t *testing.T) {
 	assertContains(t, def, `"ispreferred" boolean GENERATED ALWAYS AS (`)
 	assertContains(t, def, `case when "score" >= (10) then true else false end`)
 	assertContains(t, def, `) STORED`)
+}
+
+func TestDeterministicMSSQLComputedColumnTestsBitSource(t *testing.T) {
+	renderer := newDeterministicDDL()
+	ddl, _, err := renderer.createTable(&driver.Table{
+		Name: "Customers",
+		Columns: []driver.Column{
+			{Name: "IsActive", DataType: "bit"},
+			{
+				Name:               "ActiveRank",
+				DataType:           "int",
+				IsComputed:         true,
+				ComputedExpression: "(case when [IsActive]=(1) then (10) else (0) end)",
+				ComputedPersisted:  true,
+			},
+		},
+	}, "public", false)
+	if err != nil {
+		t.Fatalf("createTable: %v", err)
+	}
+	assertContains(t, ddl, `case when "isactive" = true then (10) else (0) end`)
+	if strings.Contains(ddl, "true)") {
+		t.Fatalf("computed bit source comparison rewrite left an extra close paren:\n%s", ddl)
+	}
 }
 
 func TestDeterministicUnsafeDefaultExpressionFails(t *testing.T) {

--- a/internal/driver/postgres/deterministic_test.go
+++ b/internal/driver/postgres/deterministic_test.go
@@ -184,6 +184,41 @@ func TestDeterministicMSSQLComputedColumn(t *testing.T) {
 	assertContains(t, def, `) STORED`)
 }
 
+func TestDeterministicMSSQLComputedColumnNullability(t *testing.T) {
+	renderer := newDeterministicDDL()
+	def, _, err := renderer.columnDefinition(driver.Column{
+		Name:               "LineTotal",
+		DataType:           "decimal",
+		Precision:          15,
+		Scale:              2,
+		IsNullable:         false,
+		IsComputed:         true,
+		ComputedExpression: "([quantity]*[unit_price])",
+		ComputedPersisted:  true,
+	})
+	if err != nil {
+		t.Fatalf("columnDefinition: %v", err)
+	}
+	assertContains(t, def, `) STORED NOT NULL`)
+
+	nullableDef, _, err := renderer.columnDefinition(driver.Column{
+		Name:               "LineTotal",
+		DataType:           "decimal",
+		Precision:          15,
+		Scale:              2,
+		IsNullable:         true,
+		IsComputed:         true,
+		ComputedExpression: "([quantity]*[unit_price])",
+		ComputedPersisted:  true,
+	})
+	if err != nil {
+		t.Fatalf("columnDefinition nullable: %v", err)
+	}
+	if strings.Contains(nullableDef, " NOT NULL") {
+		t.Fatalf("nullable computed column should not render NOT NULL:\n%s", nullableDef)
+	}
+}
+
 func TestDeterministicMSSQLComputedStringConcatColumn(t *testing.T) {
 	renderer := newDeterministicDDL()
 	def, _, err := renderer.columnDefinition(driver.Column{
@@ -349,6 +384,28 @@ func TestDeterministicMSSQLCheckBitComparisonReversed(t *testing.T) {
 	assertContains(t, ddl, `CHECK (false = "isactive")`)
 	if strings.Contains(ddl, "false)") {
 		t.Fatalf("reversed bit comparison rewrite left an extra close paren:\n%s", ddl)
+	}
+}
+
+func TestDeterministicMSSQLCheckBitInequality(t *testing.T) {
+	renderer := newDeterministicDDL()
+	ddl, err := renderer.createCheckConstraint(&driver.Table{
+		Name: "Customers",
+		Columns: []driver.Column{
+			{Name: "IsDeleted", DataType: "bit"},
+			{Name: "IsArchived", DataType: "bit"},
+			{Name: "IsLocked", DataType: "bit"},
+		},
+	}, &driver.CheckConstraint{
+		Name:       "CK_Cust_flags",
+		Definition: "([IsDeleted]<>(1) AND [IsArchived]!=(0) AND (0)<>[IsLocked])",
+	}, "public")
+	if err != nil {
+		t.Fatalf("createCheckConstraint: %v", err)
+	}
+	assertContains(t, ddl, `CHECK ("isdeleted" <> true AND "isarchived" != false AND false <> "islocked")`)
+	if strings.Contains(ddl, `<>(1)`) || strings.Contains(ddl, `!=(0)`) || strings.Contains(ddl, `(0)<>`) {
+		t.Fatalf("bit inequality rewrite left numeric literals behind:\n%s", ddl)
 	}
 }
 

--- a/internal/driver/postgres/deterministic_test.go
+++ b/internal/driver/postgres/deterministic_test.go
@@ -285,6 +285,27 @@ func TestDeterministicMSSQLCheckBitComparison(t *testing.T) {
 		t.Fatalf("createCheckConstraint: %v", err)
 	}
 	assertContains(t, ddl, `CHECK ("isactive" = true)`)
+	if strings.Contains(ddl, "true))") {
+		t.Fatalf("bit comparison rewrite left an extra close paren:\n%s", ddl)
+	}
+}
+
+func TestDeterministicMSSQLCheckBitComparisonReversed(t *testing.T) {
+	renderer := newDeterministicDDL()
+	ddl, err := renderer.createCheckConstraint(&driver.Table{
+		Name:    "Customers",
+		Columns: []driver.Column{{Name: "IsActive", DataType: "bit"}},
+	}, &driver.CheckConstraint{
+		Name:       "CK_Cust_active",
+		Definition: "((0)=[IsActive])",
+	}, "public")
+	if err != nil {
+		t.Fatalf("createCheckConstraint: %v", err)
+	}
+	assertContains(t, ddl, `CHECK (false = "isactive")`)
+	if strings.Contains(ddl, "false)") {
+		t.Fatalf("reversed bit comparison rewrite left an extra close paren:\n%s", ddl)
+	}
 }
 
 func TestDeterministicMSSQLCheckLikeBracketPattern(t *testing.T) {

--- a/internal/schemadiff/diff_test.go
+++ b/internal/schemadiff/diff_test.go
@@ -410,6 +410,48 @@ func TestRenderDeterministic_ChangedTableBitSideObjectsUseColumnContext(t *testi
 	}
 }
 
+func TestRenderDeterministic_AddedComputedColumnUsesTableBitContext(t *testing.T) {
+	d := Diff{ChangedTables: []TableDiff{{
+		Name: "Customers",
+		Curr: driver.Table{
+			Name: "Customers",
+			Columns: []driver.Column{
+				{Name: "Id", DataType: "int", IsNullable: false},
+				{Name: "IsActive", DataType: "bit", IsNullable: false},
+				{
+					Name:               "ActiveRank",
+					DataType:           "int",
+					IsComputed:         true,
+					ComputedExpression: "(case when [IsActive]=(1) then (10) else (0) end)",
+					ComputedPersisted:  true,
+				},
+			},
+		},
+		AddedColumns: []driver.Column{{
+			Name:               "ActiveRank",
+			DataType:           "int",
+			IsComputed:         true,
+			ComputedExpression: "(case when [IsActive]=(1) then (10) else (0) end)",
+			ComputedPersisted:  true,
+		}},
+	}}}.Normalize(func(name string) string {
+		return driver.NormalizeIdentifier("postgres", name)
+	}).WithTargetSchema("public")
+
+	plan, err := RenderDeterministic(d, "public", "postgres")
+	if err != nil {
+		t.Fatalf("RenderDeterministic: %v", err)
+	}
+	sql := plan.SQL()
+	want := `ADD COLUMN "activerank" integer GENERATED ALWAYS AS ((case when "isactive" = true then (10) else (0) end)) STORED`
+	if !strings.Contains(sql, want) {
+		t.Fatalf("expected SQL to contain %q, got:\n%s", want, sql)
+	}
+	if strings.Contains(sql, `"isactive"=(1)`) || strings.Contains(sql, "true))") {
+		t.Fatalf("added computed column bit context was not rendered cleanly:\n%s", sql)
+	}
+}
+
 func TestRenderDeterministic_AddedTableForeignKeysAfterAllCreateTables(t *testing.T) {
 	comments := driver.Table{
 		Schema: "dbo",

--- a/internal/schemadiff/diff_test.go
+++ b/internal/schemadiff/diff_test.go
@@ -369,6 +369,47 @@ func TestRenderDeterministic_AddedTableIncludesSideObjects(t *testing.T) {
 	}
 }
 
+func TestRenderDeterministic_ChangedTableBitSideObjectsUseColumnContext(t *testing.T) {
+	d := Diff{ChangedTables: []TableDiff{{
+		Name: "Customers",
+		Curr: driver.Table{
+			Name: "Customers",
+			Columns: []driver.Column{
+				{Name: "Id", DataType: "int", IsNullable: false},
+				{Name: "IsActive", DataType: "bit", IsNullable: false},
+			},
+		},
+		AddedIndexes: []driver.Index{{
+			Name:    "IX_Customers_Active",
+			Columns: []string{"Id"},
+			Filter:  "([IsActive]=(1))",
+		}},
+		AddedChecks: []driver.CheckConstraint{{
+			Name:       "CK_Customers_Active",
+			Definition: "([IsActive]=(1))",
+		}},
+	}}}.Normalize(func(name string) string {
+		return driver.NormalizeIdentifier("postgres", name)
+	}).WithTargetSchema("public")
+
+	plan, err := RenderDeterministic(d, "public", "postgres")
+	if err != nil {
+		t.Fatalf("RenderDeterministic: %v", err)
+	}
+	sql := plan.SQL()
+	for _, want := range []string{
+		`CREATE INDEX "ix_customers_active" ON "public"."customers" ("id") WHERE ("isactive" = true)`,
+		`ALTER TABLE "public"."customers" ADD CONSTRAINT "ck_customers_active" CHECK ("isactive" = true)`,
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("expected SQL to contain %q, got:\n%s", want, sql)
+		}
+	}
+	if strings.Contains(sql, "true))") {
+		t.Fatalf("bit comparison rewrite left an extra close paren:\n%s", sql)
+	}
+}
+
 func TestRenderDeterministic_AddedTableForeignKeysAfterAllCreateTables(t *testing.T) {
 	comments := driver.Table{
 		Schema: "dbo",

--- a/internal/schemadiff/render_deterministic.go
+++ b/internal/schemadiff/render_deterministic.go
@@ -132,7 +132,7 @@ func (r deterministicPostgresRenderer) renderTableDiff(plan *Plan, td TableDiff)
 	}
 
 	for _, c := range td.AddedColumns {
-		def, err := pgddl.RenderColumnDefinitionWithPolicy(c, r.unknownTypePolicy)
+		def, err := pgddl.RenderColumnDefinitionWithContextAndPolicy(c, td.Curr.Columns, r.unknownTypePolicy)
 		if err != nil {
 			return err
 		}

--- a/internal/schemadiff/render_deterministic.go
+++ b/internal/schemadiff/render_deterministic.go
@@ -81,14 +81,14 @@ func (r deterministicPostgresRenderer) renderAddedTableDefinition(plan *Plan, t 
 func (r deterministicPostgresRenderer) renderAddedTableSideObjects(plan *Plan, tables []driver.Table) error {
 	for _, t := range tables {
 		for _, idx := range t.Indexes {
-			if err := r.renderAddedIndex(plan, t.Name, idx); err != nil {
+			if err := r.renderAddedIndex(plan, t, idx); err != nil {
 				return err
 			}
 		}
 	}
 	for _, t := range tables {
 		for _, chk := range t.CheckConstraints {
-			if err := r.renderAddedCheck(plan, t.Name, chk); err != nil {
+			if err := r.renderAddedCheck(plan, t, chk); err != nil {
 				return err
 			}
 		}
@@ -168,7 +168,7 @@ func (r deterministicPostgresRenderer) renderTableDiff(plan *Plan, td TableDiff)
 	}
 
 	for _, idx := range td.AddedIndexes {
-		if err := r.renderAddedIndex(plan, tableName, idx); err != nil {
+		if err := r.renderAddedIndex(plan, td.Curr, idx); err != nil {
 			return err
 		}
 	}
@@ -178,7 +178,7 @@ func (r deterministicPostgresRenderer) renderTableDiff(plan *Plan, td TableDiff)
 		}
 	}
 	for _, chk := range td.AddedChecks {
-		if err := r.renderAddedCheck(plan, tableName, chk); err != nil {
+		if err := r.renderAddedCheck(plan, td.Curr, chk); err != nil {
 			return err
 		}
 	}
@@ -268,8 +268,8 @@ func (r deterministicPostgresRenderer) renderColumnChange(plan *Plan, tableName 
 	return nil
 }
 
-func (r deterministicPostgresRenderer) renderAddedIndex(plan *Plan, tableName string, idx driver.Index) error {
-	t := driver.Table{Name: tableName}
+func (r deterministicPostgresRenderer) renderAddedIndex(plan *Plan, t driver.Table, idx driver.Index) error {
+	tableName := t.Name
 	ddl, err := pgddl.RenderCreateIndexDDL(&t, &idx, r.schema)
 	if err != nil {
 		return err
@@ -300,8 +300,8 @@ func (r deterministicPostgresRenderer) renderAddedForeignKey(plan *Plan, tableNa
 	return nil
 }
 
-func (r deterministicPostgresRenderer) renderAddedCheck(plan *Plan, tableName string, chk driver.CheckConstraint) error {
-	t := driver.Table{Name: tableName}
+func (r deterministicPostgresRenderer) renderAddedCheck(plan *Plan, t driver.Table, chk driver.CheckConstraint) error {
+	tableName := t.Name
 	ddl, err := pgddl.RenderCreateCheckConstraintDDL(&t, &chk, r.schema)
 	if err != nil {
 		return err


### PR DESCRIPTION
﻿## Summary
- extend deterministic SQL Server -> PostgreSQL DDL rendering for CRM fixture edge cases
- support persisted computed columns, SQL Server datetimeoffset defaults, boolean/CASE syntax, and SQL Server LIKE bracket patterns as PostgreSQL regex checks
- reject non-persisted SQL Server computed columns instead of silently changing semantics

## Verification
- `go test ./internal/driver/postgres`
- `go test ./...`
- CRM MSSQL -> PostgreSQL deterministic migration with Anthropic Sonnet review enabled, `ai_concurrency: 8`
- Deep verification on `smt_crm_sonnet_deepcheck_001`:
  - 148/148 columns matched criteria 1-6
  - aggregate counts matched: tables, columns, PKs, unique indexes, FKs, checks, computed columns
  - PK, unique index, and FK signatures matched
  - computed/generated columns matched
  - `Tags.color` accepted valid hex and rejected invalid hex on both source and target

## Notes
- Sonnet still produced advisory false positives around implicit PostgreSQL `NO ACTION` FK actions, but deterministic FK signature verification passed all 22 FKs.
