### PR TITLE
Fix deterministic renderer correctness bugs

### DIFF
--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -208,17 +208,37 @@ func (r Renderer) ColumnDefault(col driver.Column) (string, error) {
 		}
 	}
 	if isTextualSourceType(col.DataType) && isBareSQLWord(expr) {
-		return "'" + escapeSQLString(expr) + "'", nil
+		lit := "'" + escapeSQLString(expr) + "'"
+		if r.target == "mysql" {
+			lit = r.mysqlDefaultForm(lit, col)
+		}
+		return lit, nil
 	}
 	lower := strings.ToLower(expr)
 	switch r.target {
 	case "mssql":
+		// MSSQL-native functions pass through unchanged; foreign now-style
+		// functions translate to the equivalent with the same local-vs-UTC
+		// class (now()/current_timestamp are local time, never UTC).
 		if strings.HasPrefix(lower, "current_timestamp(") || strings.HasPrefix(lower, "now(") {
+			return "SYSDATETIME()", nil
+		}
+		if strings.HasPrefix(lower, "utc_timestamp") {
 			return "SYSUTCDATETIME()", nil
 		}
 		switch lower {
-		case "current_timestamp", "now()", "getdate()":
+		case "current_timestamp", "now()":
+			return "SYSDATETIME()", nil
+		case "getdate()":
+			return "GETDATE()", nil
+		case "getutcdate()":
+			return "GETUTCDATE()", nil
+		case "sysdatetime()":
+			return "SYSDATETIME()", nil
+		case "sysutcdatetime()":
 			return "SYSUTCDATETIME()", nil
+		case "sysdatetimeoffset()":
+			return "SYSDATETIMEOFFSET()", nil
 		case "gen_random_uuid()", "uuid_generate_v4()", "uuid()", "newid()":
 			return "NEWID()", nil
 		}
@@ -247,7 +267,57 @@ func (r Renderer) ColumnDefault(col driver.Column) (string, error) {
 			return "(UUID())", nil
 		}
 	}
-	return r.Expression(expr, nil)
+	out, err := r.Expression(expr, nil)
+	if err != nil {
+		return "", err
+	}
+	if r.target == "mysql" {
+		out = r.mysqlDefaultForm(out, col)
+	}
+	return out, nil
+}
+
+var plainNumberLiteralRE = regexp.MustCompile(`^-?[0-9]+(?:\.[0-9]+)?$`)
+
+// mysqlDefaultForm wraps a rendered default in parentheses where MySQL 8
+// requires the expression-default form: any non-literal expression, and every
+// default on a BLOB/TEXT/JSON column (which accept only expression defaults).
+func (r Renderer) mysqlDefaultForm(def string, col driver.Column) string {
+	d := strings.TrimSpace(def)
+	if d == "" || strings.HasPrefix(d, "(") {
+		return d
+	}
+	upper := strings.ToUpper(d)
+	// NULL and CURRENT_TIMESTAMP[(n)] are valid bare (and ON UPDATE accepts
+	// only the bare form).
+	if upper == "NULL" || strings.HasPrefix(upper, "CURRENT_TIMESTAMP") {
+		return d
+	}
+	if isPlainLiteral(d) {
+		if r.mysqlRequiresExpressionDefault(col) {
+			return "(" + d + ")"
+		}
+		return d
+	}
+	return "(" + d + ")"
+}
+
+func isPlainLiteral(d string) bool {
+	if len(d) >= 2 && d[0] == '\'' && d[len(d)-1] == '\'' {
+		_, ok := unquoteSQLString(d)
+		return ok
+	}
+	return plainNumberLiteralRE.MatchString(d)
+}
+
+func (r Renderer) mysqlRequiresExpressionDefault(col driver.Column) bool {
+	typ, err := r.ColumnType(col)
+	if err != nil {
+		return false
+	}
+	base := strings.ToUpper(normalizeTypeName(typ))
+	return base == "JSON" || base == "GEOMETRY" ||
+		strings.HasSuffix(base, "TEXT") || strings.HasSuffix(base, "BLOB")
 }
 
 func (r Renderer) CreateIndexDDL(t *driver.Table, idx *driver.Index) (string, error) {
@@ -488,12 +558,18 @@ func (r Renderer) mssqlColumnType(col driver.Column, dt string) (string, error) 
 	case "bit", "bool", "boolean":
 		return "BIT", nil
 	case "varchar", "character varying":
-		return sizedType("VARCHAR", col.MaxLength, "MAX"), nil
+		return sizedTypeCapped("VARCHAR", col.MaxLength, 8000, "MAX"), nil
 	case "nvarchar":
-		return sizedType("NVARCHAR", col.MaxLength, "MAX"), nil
+		return sizedTypeCapped("NVARCHAR", col.MaxLength, 4000, "MAX"), nil
 	case "char", "character", "bpchar":
+		if col.MaxLength > 8000 {
+			return "VARCHAR(MAX)", nil
+		}
 		return sizedType("CHAR", col.MaxLength, "1"), nil
 	case "nchar":
+		if col.MaxLength > 4000 {
+			return "NVARCHAR(MAX)", nil
+		}
 		return sizedType("NCHAR", col.MaxLength, "1"), nil
 	case "text", "ntext", "tinytext", "mediumtext", "longtext", "json", "jsonb", "xml", "array", "_text", "text[]", "_varchar", "varchar[]", "_bpchar", "bpchar[]", "_int2", "int2[]", "_int4", "int4[]", "_int8", "int8[]", "_uuid", "uuid[]":
 		return "NVARCHAR(MAX)", nil
@@ -504,9 +580,6 @@ func (r Renderer) mssqlColumnType(col driver.Column, dt string) (string, error) 
 	case "rowversion":
 		return "ROWVERSION", nil
 	case "datetime", "datetime2", "smalldatetime", "timestamp", "timestamp without time zone", "timestamptz":
-		if dt == "timestamp" && col.MaxLength == 8 {
-			return "ROWVERSION", nil
-		}
 		return "DATETIME2", nil
 	case "datetimeoffset", "timestamp with time zone":
 		return "DATETIMEOFFSET", nil
@@ -527,7 +600,7 @@ func (r Renderer) mssqlColumnType(col driver.Column, dt string) (string, error) 
 	case "uniqueidentifier", "uuid":
 		return "UNIQUEIDENTIFIER", nil
 	case "varbinary", "binary", "image", "bytea", "blob", "mediumblob", "longblob":
-		return sizedType("VARBINARY", col.MaxLength, "MAX"), nil
+		return sizedTypeCapped("VARBINARY", col.MaxLength, 8000, "MAX"), nil
 	default:
 		return r.unknownType(dt)
 	}
@@ -550,6 +623,9 @@ func (r Renderer) mysqlColumnType(col driver.Column, dt string) (string, error) 
 	case "varchar", "nvarchar", "character varying":
 		return mysqlVarcharType(col.MaxLength), nil
 	case "char", "nchar", "character", "bpchar":
+		if col.MaxLength > 255 {
+			return mysqlVarcharType(col.MaxLength), nil
+		}
 		return sizedType("CHAR", col.MaxLength, "1"), nil
 	case "text", "ntext", "tinytext", "mediumtext", "longtext":
 		return mysqlTextType(dt), nil
@@ -558,9 +634,6 @@ func (r Renderer) mysqlColumnType(col driver.Column, dt string) (string, error) 
 	case "rowversion":
 		return "BINARY(8)", nil
 	case "datetime", "datetime2", "smalldatetime", "timestamp", "timestamp without time zone", "timestamptz", "datetimeoffset", "timestamp with time zone":
-		if dt == "timestamp" && col.MaxLength == 8 {
-			return "BINARY(8)", nil
-		}
 		return "DATETIME(6)", nil
 	case "date":
 		return "DATE", nil
@@ -579,6 +652,9 @@ func (r Renderer) mysqlColumnType(col driver.Column, dt string) (string, error) 
 	case "uniqueidentifier", "uuid":
 		return "CHAR(36)", nil
 	case "varbinary", "binary", "bytea":
+		if col.MaxLength > 65535 {
+			return "BLOB", nil
+		}
 		return sizedType("VARBINARY", col.MaxLength, "255"), nil
 	case "image", "blob", "mediumblob", "longblob":
 		return "BLOB", nil
@@ -671,12 +747,14 @@ func canonicalTarget(target string) string {
 	switch strings.ToLower(strings.TrimSpace(target)) {
 	case "postgres", "postgresql", "pg":
 		return "postgres"
-	case "mssql", "sqlserver", "sql_server":
+	case "mssql", "sqlserver", "sql-server", "sql_server":
 		return "mssql"
-	case "mysql", "mariadb":
+	case "mysql", "mariadb", "maria":
 		return "mysql"
 	default:
-		return strings.ToLower(strings.TrimSpace(target))
+		// Defer to the driver registry so any alias a driver registers
+		// (including future engines) resolves without editing this list.
+		return strings.ToLower(driver.Canonicalize(strings.TrimSpace(target)))
 	}
 }
 
@@ -693,6 +771,15 @@ func sizedType(name string, length int, unbounded string) string {
 		return fmt.Sprintf("%s(%s)", name, unbounded)
 	}
 	return fmt.Sprintf("%s(%d)", name, length)
+}
+
+// sizedTypeCapped degrades lengths above the target dialect's maximum for the
+// type to the unbounded form instead of emitting DDL the target rejects.
+func sizedTypeCapped(name string, length, max int, unbounded string) string {
+	if length > max {
+		return fmt.Sprintf("%s(%s)", name, unbounded)
+	}
+	return sizedType(name, length, unbounded)
 }
 
 func decimalType(name string, col driver.Column) string {
@@ -714,6 +801,11 @@ func mysqlVarcharType(length int) string {
 		return "LONGTEXT"
 	}
 	if length <= 0 {
+		return "TEXT"
+	}
+	// 16383 is the longest VARCHAR that fits MySQL's 65535-byte row limit
+	// under utf8mb4 (the charset our CREATE TABLE emits).
+	if length > 16383 {
 		return "TEXT"
 	}
 	return fmt.Sprintf("VARCHAR(%d)", length)
@@ -1098,8 +1190,11 @@ func rewriteFunctionNames(expr, target string) string {
 	replacements := map[string]string{}
 	switch canonicalTarget(target) {
 	case "mssql":
+		// CURRENT_TIMESTAMP is valid T-SQL (local time) and stays as-is;
+		// rewriting it to SYSUTCDATETIME() would silently change local-time
+		// semantics to UTC.
 		replacements = map[string]string{
-			"CURRENT_TIMESTAMP":  "SYSUTCDATETIME()",
+			"NOW()":              "SYSDATETIME()",
 			"gen_random_uuid()":  "NEWID()",
 			"uuid_generate_v4()": "NEWID()",
 			"UUID()":             "NEWID()",
@@ -1124,7 +1219,7 @@ func rewriteFunctionNames(expr, target string) string {
 }
 
 func replaceCaseInsensitive(s, old, new string) string {
-	re := regexp.MustCompile(`(?i)` + regexp.QuoteMeta(old))
+	re := regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(old))
 	return re.ReplaceAllString(s, new)
 }
 
@@ -1506,7 +1601,12 @@ func splitTopLevel(expr string, sep rune) []string {
 func stripOuterCheckParens(expr string) string {
 	expr = strings.TrimSpace(expr)
 	if strings.HasPrefix(strings.ToUpper(expr), "CHECK") {
-		expr = strings.TrimSpace(expr[5:])
+		// Only strip the keyword, not identifiers like "checked_in": the next
+		// character must end the word.
+		rest := expr[5:]
+		if rest == "" || rest[0] == '(' || rest[0] == ' ' || rest[0] == '\t' || rest[0] == '\n' || rest[0] == '\r' {
+			expr = strings.TrimSpace(rest)
+		}
 	}
 	return unwrapDefaultParens(expr)
 }

--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -277,7 +277,10 @@ func (r Renderer) ColumnDefault(col driver.Column) (string, error) {
 	return out, nil
 }
 
-var plainNumberLiteralRE = regexp.MustCompile(`^-?[0-9]+(?:\.[0-9]+)?$`)
+var (
+	plainNumberLiteralRE   = regexp.MustCompile(`^-?[0-9]+(?:\.[0-9]+)?$`)
+	bareCurrentTimestampRE = regexp.MustCompile(`^CURRENT_TIMESTAMP(?:\([0-9]*\))?$`)
+)
 
 // mysqlDefaultForm wraps a rendered default in parentheses where MySQL 8
 // requires the expression-default form: any non-literal expression, and every
@@ -288,9 +291,10 @@ func (r Renderer) mysqlDefaultForm(def string, col driver.Column) string {
 		return d
 	}
 	upper := strings.ToUpper(d)
-	// NULL and CURRENT_TIMESTAMP[(n)] are valid bare (and ON UPDATE accepts
-	// only the bare form).
-	if upper == "NULL" || strings.HasPrefix(upper, "CURRENT_TIMESTAMP") {
+	// NULL and bare CURRENT_TIMESTAMP[(n)] are valid unparenthesized (and ON
+	// UPDATE accepts only the bare form); larger expressions that merely start
+	// with CURRENT_TIMESTAMP still need wrapping.
+	if upper == "NULL" || bareCurrentTimestampRE.MatchString(upper) {
 		return d
 	}
 	if isPlainLiteral(d) {
@@ -652,10 +656,12 @@ func (r Renderer) mysqlColumnType(col driver.Column, dt string) (string, error) 
 	case "uniqueidentifier", "uuid":
 		return "CHAR(36)", nil
 	case "varbinary", "binary", "bytea":
-		if col.MaxLength > 65535 {
+		// Unbounded sources (pg bytea reports 0, mssql varbinary(max) -1)
+		// must not truncate to a sized VARBINARY.
+		if col.MaxLength <= 0 || col.MaxLength > 65535 {
 			return "BLOB", nil
 		}
-		return sizedType("VARBINARY", col.MaxLength, "255"), nil
+		return fmt.Sprintf("VARBINARY(%d)", col.MaxLength), nil
 	case "image", "blob", "mediumblob", "longblob":
 		return "BLOB", nil
 	case "enum":
@@ -1554,12 +1560,24 @@ func parseInlineEnumSetValues(columnType string) ([]string, bool) {
 
 func rewriteSQLServerStringConcatToConcat(expr string) string {
 	// Handles the CRM-style "a + ' ' + b" computed expression without trying
-	// to become a SQL parser.
+	// to become a SQL parser. Only fires when a top-level operand is a string
+	// literal — numeric/date arithmetic ("subtotal + tax",
+	// "CURRENT_TIMESTAMP + INTERVAL '1' DAY") must stay arithmetic.
 	if !strings.Contains(expr, "+") || strings.ContainsAny(expr, "*/") {
 		return expr
 	}
 	parts := splitTopLevel(expr, '+')
 	if len(parts) < 2 {
+		return expr
+	}
+	hasStringOperand := false
+	for _, p := range parts {
+		if strings.HasPrefix(strings.TrimSpace(p), "'") {
+			hasStringOperand = true
+			break
+		}
+	}
+	if !hasStringOperand {
 		return expr
 	}
 	return "CONCAT(" + strings.Join(parts, ", ") + ")"

--- a/internal/ddl/renderer_fixes_test.go
+++ b/internal/ddl/renderer_fixes_test.go
@@ -124,6 +124,8 @@ func TestColumnDefault_MySQLExpressionForm(t *testing.T) {
 		{driver.Column{Name: "qty", DataType: "int", DefaultExpression: "0"}, "0"},
 		{driver.Column{Name: "ts", DataType: "datetime", DefaultExpression: "CURRENT_TIMESTAMP"}, "CURRENT_TIMESTAMP(6)"},
 		{driver.Column{Name: "note", DataType: "text", DefaultExpression: "'n/a'"}, "('n/a')"},
+		// Expressions that merely start with CURRENT_TIMESTAMP still need parens.
+		{driver.Column{Name: "due", DataType: "datetime", DefaultExpression: "(CURRENT_TIMESTAMP + INTERVAL '1' DAY)"}, "(CURRENT_TIMESTAMP + INTERVAL '1' DAY)"},
 	}
 	for _, tc := range cases {
 		got, err := r.ColumnDefault(tc.col)
@@ -162,6 +164,10 @@ func TestColumnType_LengthClamping(t *testing.T) {
 		{mysql, driver.Column{DataType: "varchar", MaxLength: 16383}, "VARCHAR(16383)"},
 		{mysql, driver.Column{DataType: "char", MaxLength: 300}, "VARCHAR(300)"},
 		{mysql, driver.Column{DataType: "varbinary", MaxLength: 70000}, "BLOB"},
+		// Unbounded binary sources (pg bytea = 0, mssql varbinary(max) = -1)
+		// must not truncate to VARBINARY(255).
+		{mysql, driver.Column{DataType: "bytea", MaxLength: 0}, "BLOB"},
+		{mysql, driver.Column{DataType: "varbinary", MaxLength: -1}, "BLOB"},
 	}
 	for _, tc := range cases {
 		got, err := tc.r.ColumnType(tc.col)
@@ -185,5 +191,40 @@ func TestColumnType_Rowversion(t *testing.T) {
 	}
 	if got, _ := mysql.ColumnType(col); got != "BINARY(8)" {
 		t.Errorf("mysql rowversion = %q, want BINARY(8)", got)
+	}
+}
+
+// Arithmetic '+' in CHECK constraints must not become CONCAT on MySQL targets.
+func TestCheckConstraint_MySQLArithmeticPlusStaysArithmetic(t *testing.T) {
+	r, err := NewRenderer("mysql", "crm", "fail")
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	table := &driver.Table{Name: "orders", Columns: []driver.Column{
+		{Name: "total", DataType: "decimal", Precision: 18, Scale: 4},
+		{Name: "subtotal", DataType: "decimal", Precision: 18, Scale: 4},
+		{Name: "tax", DataType: "decimal", Precision: 18, Scale: 4},
+	}}
+	got, err := r.CreateCheckConstraintDDL(table, &driver.CheckConstraint{Name: "ck_total", Definition: "(total >= subtotal + tax)"})
+	if err != nil {
+		t.Fatalf("CreateCheckConstraintDDL: %v", err)
+	}
+	if strings.Contains(got, "CONCAT") {
+		t.Fatalf("arithmetic rewritten to CONCAT: %q", got)
+	}
+}
+
+// String concatenation still becomes CONCAT on MySQL targets.
+func TestComputedColumn_MySQLStringConcatStillRewritten(t *testing.T) {
+	r, err := NewRenderer("mysql", "crm", "fail")
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	got, err := r.Expression("[FirstName] + ' ' + [LastName]", nil)
+	if err != nil {
+		t.Fatalf("Expression: %v", err)
+	}
+	if !strings.Contains(got, "CONCAT(") {
+		t.Fatalf("string concat not rewritten: %q", got)
 	}
 }

--- a/internal/ddl/renderer_fixes_test.go
+++ b/internal/ddl/renderer_fixes_test.go
@@ -1,0 +1,189 @@
+package ddl
+
+import (
+	"strings"
+	"testing"
+
+	"smt/internal/driver"
+)
+
+// #86 — the CHECK keyword must only be stripped at a word boundary, not off
+// the front of identifiers like "checked_in".
+func TestCheckConstraint_IdentifierStartingWithCheck(t *testing.T) {
+	for _, target := range []string{"mssql", "mysql"} {
+		r, err := NewRenderer(target, "crm", "fail")
+		if err != nil {
+			t.Fatalf("NewRenderer %s: %v", target, err)
+		}
+		table := &driver.Table{Name: "visits", Columns: []driver.Column{{Name: "checked_in", DataType: "int"}}}
+		got, err := r.CreateCheckConstraintDDL(table, &driver.CheckConstraint{Name: "ck_visits", Definition: "(checked_in > 0)"})
+		if err != nil {
+			t.Fatalf("CreateCheckConstraintDDL %s: %v", target, err)
+		}
+		if !strings.Contains(got, "checked_in > 0") {
+			t.Fatalf("%s check DDL mangled the identifier: %q", target, got)
+		}
+	}
+}
+
+func TestStripOuterCheckParens(t *testing.T) {
+	cases := map[string]string{
+		"CHECK (x > 0)":    "x > 0",
+		"CHECK(x > 0)":     "x > 0",
+		"(checked_in > 0)": "checked_in > 0",
+		"checked_in > 0":   "checked_in > 0",
+		"(x > 0)":          "x > 0",
+	}
+	for in, want := range cases {
+		if got := stripOuterCheckParens(in); got != want {
+			t.Errorf("stripOuterCheckParens(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// #85 — registry aliases accepted by config validation must construct a renderer.
+func TestNewRenderer_RegistryAliases(t *testing.T) {
+	for alias, want := range map[string]string{
+		"sql-server": "mssql",
+		"sql_server": "mssql",
+		"sqlserver":  "mssql",
+		"maria":      "mysql",
+		"mariadb":    "mysql",
+		"pg":         "postgres",
+	} {
+		r, err := NewRenderer(alias, "s", "fail")
+		if err != nil {
+			t.Fatalf("NewRenderer(%q): %v", alias, err)
+		}
+		if r.Target() != want {
+			t.Errorf("NewRenderer(%q).Target() = %q, want %q", alias, r.Target(), want)
+		}
+	}
+}
+
+// #82 — MSSQL-native default functions pass through; foreign now-style
+// functions keep their local-vs-UTC class.
+func TestColumnDefault_MSSQLPreservesTimeClass(t *testing.T) {
+	r, err := NewRenderer("mssql", "dbo", "fail")
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	cases := map[string]string{
+		"(getdate())":          "GETDATE()",
+		"(getutcdate())":       "GETUTCDATE()",
+		"(sysutcdatetime())":   "SYSUTCDATETIME()",
+		"(sysdatetime())":      "SYSDATETIME()",
+		"now()":                "SYSDATETIME()",
+		"CURRENT_TIMESTAMP":    "SYSDATETIME()",
+		"current_timestamp(6)": "SYSDATETIME()",
+		"utc_timestamp()":      "SYSUTCDATETIME()",
+		"(newid())":            "NEWID()",
+	}
+	for in, want := range cases {
+		got, err := r.ColumnDefault(driver.Column{Name: "c", DataType: "datetime2", DefaultExpression: in})
+		if err != nil {
+			t.Fatalf("ColumnDefault(%q): %v", in, err)
+		}
+		if got != want {
+			t.Errorf("ColumnDefault(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// #82 — CURRENT_TIMESTAMP inside expressions is valid T-SQL and must not be
+// rewritten to a UTC function.
+func TestExpression_MSSQLKeepsCurrentTimestamp(t *testing.T) {
+	r, err := NewRenderer("mssql", "dbo", "fail")
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	got, err := r.Expression("([CreatedAt] <= CURRENT_TIMESTAMP)", nil)
+	if err != nil {
+		t.Fatalf("Expression: %v", err)
+	}
+	if strings.Contains(got, "SYSUTCDATETIME") {
+		t.Fatalf("CURRENT_TIMESTAMP rewritten to UTC: %q", got)
+	}
+}
+
+// #80 — MySQL requires parenthesized expression defaults, and BLOB/TEXT/JSON
+// columns accept only the expression form.
+func TestColumnDefault_MySQLExpressionForm(t *testing.T) {
+	r, err := NewRenderer("mysql", "crm", "fail")
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	cases := []struct {
+		col  driver.Column
+		want string
+	}{
+		{driver.Column{Name: "id", DataType: "binary", MaxLength: 16, DefaultExpression: "(uuid_to_bin(uuid()))"}, "(uuid_to_bin(uuid()))"},
+		{driver.Column{Name: "doc", DataType: "json", DefaultExpression: `'{"a": 1}'`}, `('{"a": 1}')`},
+		{driver.Column{Name: "doc", DataType: "json", DefaultExpression: "'{}'"}, "(JSON_OBJECT())"},
+		{driver.Column{Name: "name", DataType: "varchar", MaxLength: 20, DefaultExpression: "'abc'"}, "'abc'"},
+		{driver.Column{Name: "qty", DataType: "int", DefaultExpression: "0"}, "0"},
+		{driver.Column{Name: "ts", DataType: "datetime", DefaultExpression: "CURRENT_TIMESTAMP"}, "CURRENT_TIMESTAMP(6)"},
+		{driver.Column{Name: "note", DataType: "text", DefaultExpression: "'n/a'"}, "('n/a')"},
+	}
+	for _, tc := range cases {
+		got, err := r.ColumnDefault(tc.col)
+		if err != nil {
+			t.Fatalf("ColumnDefault(%q): %v", tc.col.DefaultExpression, err)
+		}
+		if got != tc.want {
+			t.Errorf("ColumnDefault(%s %q) = %q, want %q", tc.col.DataType, tc.col.DefaultExpression, got, tc.want)
+		}
+	}
+}
+
+// #89 — lengths above the target's maximum degrade to the unbounded form
+// instead of DDL the target rejects.
+func TestColumnType_LengthClamping(t *testing.T) {
+	mssql, err := NewRenderer("mssql", "dbo", "fail")
+	if err != nil {
+		t.Fatalf("NewRenderer mssql: %v", err)
+	}
+	mysql, err := NewRenderer("mysql", "crm", "fail")
+	if err != nil {
+		t.Fatalf("NewRenderer mysql: %v", err)
+	}
+	cases := []struct {
+		r    Renderer
+		col  driver.Column
+		want string
+	}{
+		{mssql, driver.Column{DataType: "varchar", MaxLength: 10000}, "VARCHAR(MAX)"},
+		{mssql, driver.Column{DataType: "varchar", MaxLength: 8000}, "VARCHAR(8000)"},
+		{mssql, driver.Column{DataType: "nvarchar", MaxLength: 5000}, "NVARCHAR(MAX)"},
+		{mssql, driver.Column{DataType: "char", MaxLength: 9000}, "VARCHAR(MAX)"},
+		{mssql, driver.Column{DataType: "nchar", MaxLength: 5000}, "NVARCHAR(MAX)"},
+		{mssql, driver.Column{DataType: "varbinary", MaxLength: 9000}, "VARBINARY(MAX)"},
+		{mysql, driver.Column{DataType: "varchar", MaxLength: 20000}, "TEXT"},
+		{mysql, driver.Column{DataType: "varchar", MaxLength: 16383}, "VARCHAR(16383)"},
+		{mysql, driver.Column{DataType: "char", MaxLength: 300}, "VARCHAR(300)"},
+		{mysql, driver.Column{DataType: "varbinary", MaxLength: 70000}, "BLOB"},
+	}
+	for _, tc := range cases {
+		got, err := tc.r.ColumnType(tc.col)
+		if err != nil {
+			t.Fatalf("ColumnType(%s %d): %v", tc.col.DataType, tc.col.MaxLength, err)
+		}
+		if got != tc.want {
+			t.Errorf("ColumnType(%s, %s(%d)) = %q, want %q", tc.r.Target(), tc.col.DataType, tc.col.MaxLength, got, tc.want)
+		}
+	}
+}
+
+// #83 — rowversion (normalized by the mssql reader) maps to the right type
+// class on every target.
+func TestColumnType_Rowversion(t *testing.T) {
+	mssql, _ := NewRenderer("mssql", "dbo", "fail")
+	mysql, _ := NewRenderer("mysql", "crm", "fail")
+	col := driver.Column{Name: "Version", DataType: "rowversion", MaxLength: 8}
+	if got, _ := mssql.ColumnType(col); got != "ROWVERSION" {
+		t.Errorf("mssql rowversion = %q, want ROWVERSION", got)
+	}
+	if got, _ := mysql.ColumnType(col); got != "BINARY(8)" {
+		t.Errorf("mysql rowversion = %q, want BINARY(8)", got)
+	}
+}

--- a/internal/ddl/renderer_test.go
+++ b/internal/ddl/renderer_test.go
@@ -296,7 +296,7 @@ func TestRenderer_RowversionAndUnsignedTypes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRenderer mssql: %v", err)
 	}
-	mssqlRowversion, err := mssqlRenderer.ColumnType(driver.Column{Name: "Version", DataType: "timestamp", MaxLength: 8})
+	mssqlRowversion, err := mssqlRenderer.ColumnType(driver.Column{Name: "Version", DataType: "rowversion", MaxLength: 8})
 	if err != nil {
 		t.Fatalf("ColumnType mssql rowversion: %v", err)
 	}
@@ -312,7 +312,7 @@ func TestRenderer_RowversionAndUnsignedTypes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRenderer mysql: %v", err)
 	}
-	mysqlRowversion, err := mysqlRenderer.ColumnType(driver.Column{Name: "Version", DataType: "timestamp", MaxLength: 8})
+	mysqlRowversion, err := mysqlRenderer.ColumnType(driver.Column{Name: "Version", DataType: "rowversion", MaxLength: 8})
 	if err != nil {
 		t.Fatalf("ColumnType mysql rowversion: %v", err)
 	}
@@ -447,7 +447,7 @@ func TestRenderer_DefaultsNormalizePostgresCastsAndTimestampPrecision(t *testing
 	if err != nil {
 		t.Fatalf("ColumnDefault mssql timestamp: %v", err)
 	}
-	assertEqualSQL(t, mssqlTime, "SYSUTCDATETIME()")
+	assertEqualSQL(t, mssqlTime, "SYSDATETIME()")
 
 	mysqlRenderer, err := NewRenderer("mysql", "crm", "fail")
 	if err != nil {

--- a/internal/driver/mssql/reader.go
+++ b/internal/driver/mssql/reader.go
@@ -243,6 +243,13 @@ func (r *Reader) loadColumns(ctx context.Context, t *driver.Table) error {
 		}
 		col.IsNullable = isNullable == 1
 		col.IsIdentity = isIdentity == 1
+		if strings.EqualFold(col.DataType, "timestamp") {
+			// INFORMATION_SCHEMA reports rowversion under its deprecated
+			// synonym "timestamp" with NULL CHARACTER_MAXIMUM_LENGTH; rename
+			// so renderers don't conflate it with datetime types.
+			col.DataType = "rowversion"
+			col.MaxLength = 8
+		}
 		t.Columns = append(t.Columns, col)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/driver/postgres/deterministic.go
+++ b/internal/driver/postgres/deterministic.go
@@ -310,15 +310,12 @@ func (r deterministicDDL) columnType(col driver.Column) (string, error) {
 		}
 	case "text", "ntext", "tinytext", "mediumtext", "longtext":
 		typ = "text"
-	case "datetime", "datetime2", "smalldatetime":
+	case "datetime", "datetime2", "smalldatetime", "timestamp":
 		typ = "timestamp without time zone"
-	case "timestamp":
-		// SQL Server's timestamp is the legacy rowversion binary type.
-		if col.MaxLength == 8 {
-			typ = "bytea"
-		} else {
-			typ = "timestamp without time zone"
-		}
+	case "rowversion":
+		// SQL Server's rowversion (reported by old snapshots as "timestamp")
+		// is an opaque 8-byte binary counter.
+		typ = "bytea"
 	case "datetimeoffset", "timestamptz", "timestamp with time zone":
 		typ = "timestamp with time zone"
 	case "date":
@@ -765,7 +762,14 @@ func isBareSQLWord(expr string) bool {
 		}
 		return false
 	}
-	return true
+	// SQL keywords that must stay unquoted: DEFAULT (NULL) means SQL NULL,
+	// not the string 'NULL'.
+	switch strings.ToLower(expr) {
+	case "null", "true", "false", "current_timestamp":
+		return false
+	default:
+		return true
+	}
 }
 
 func rewriteSQLServerStringConcat(expr string) string {

--- a/internal/driver/postgres/deterministic_fixes_test.go
+++ b/internal/driver/postgres/deterministic_fixes_test.go
@@ -1,0 +1,42 @@
+package postgres
+
+import (
+	"testing"
+
+	"smt/internal/driver"
+)
+
+// #79 — DEFAULT (NULL) on a textual column must stay SQL NULL, not become the
+// string literal 'NULL'.
+func TestDeterministicDefaultNullStaysKeyword(t *testing.T) {
+	renderer := newDeterministicDDL()
+	got, err := renderer.defaultExpression(driver.Column{
+		Name:              "Notes",
+		DataType:          "varchar",
+		MaxLength:         50,
+		DefaultExpression: "(NULL)",
+	})
+	if err != nil {
+		t.Fatalf("defaultExpression: %v", err)
+	}
+	if got != "NULL" {
+		t.Fatalf("DEFAULT (NULL) rendered as %q, want NULL", got)
+	}
+}
+
+// #79 — bare textual defaults still get quoted.
+func TestDeterministicDefaultBareWordStillQuoted(t *testing.T) {
+	renderer := newDeterministicDDL()
+	got, err := renderer.defaultExpression(driver.Column{
+		Name:              "Status",
+		DataType:          "varchar",
+		MaxLength:         20,
+		DefaultExpression: "(active)",
+	})
+	if err != nil {
+		t.Fatalf("defaultExpression: %v", err)
+	}
+	if got != "'active'" {
+		t.Fatalf("bare word default rendered as %q, want 'active'", got)
+	}
+}

--- a/internal/driver/postgres/deterministic_test.go
+++ b/internal/driver/postgres/deterministic_test.go
@@ -122,12 +122,12 @@ func TestDeterministicUnsupportedTypeFails(t *testing.T) {
 
 func TestDeterministicMSSQLTimestampRowversionMapsToBytea(t *testing.T) {
 	renderer := newDeterministicDDL()
-	got, err := renderer.columnType(driver.Column{Name: "Version", DataType: "timestamp", MaxLength: 8})
+	got, err := renderer.columnType(driver.Column{Name: "Version", DataType: "rowversion", MaxLength: 8})
 	if err != nil {
 		t.Fatalf("columnType: %v", err)
 	}
 	if got != "bytea" {
-		t.Fatalf("timestamp max_length=8 maps to %q, want bytea", got)
+		t.Fatalf("rowversion maps to %q, want bytea", got)
 	}
 }
 


### PR DESCRIPTION
First of a series of PRs resolving the issues found in the post-#76/#77 review.

## Fixes

| Issue | Fix |
|---|---|
| #79 | `internal/driver/postgres/deterministic.go` `isBareSQLWord` now excludes `null`/`true`/`false`/`current_timestamp` like the `internal/ddl` copy, so `DEFAULT (NULL)` on a textual column renders `DEFAULT NULL`, not `DEFAULT 'NULL'` |
| #80 | MySQL targets wrap expression defaults — and every default on BLOB/TEXT/JSON columns — in the parenthesized expression form MySQL 8 requires (`DEFAULT (uuid_to_bin(uuid()))`, `DEFAULT ('{"a": 1}')`) |
| #82 | MSSQL-native default functions pass through unchanged; `now()`/`current_timestamp` translate to `SYSDATETIME()` (local class) instead of `SYSUTCDATETIME()` (UTC). `rewriteFunctionNames` no longer rewrites valid T-SQL `CURRENT_TIMESTAMP` in expressions, and `replaceCaseInsensitive` got a word boundary so `NOW()` can't match inside `know()` |
| #83 | mssql reader normalizes `DATA_TYPE='timestamp'` to `rowversion` (the INFORMATION_SCHEMA synonym was never detectable downstream because CHARACTER_MAXIMUM_LENGTH is NULL→0); dead `MaxLength==8` heuristics deleted; pg targets map rowversion → `bytea` |
| #85 | `canonicalTarget` accepts the registry aliases config validation accepts (`sql-server`, `maria`) and defers unknown names to `driver.Canonicalize` |
| #86 | `stripOuterCheckParens` strips `CHECK` only at a word boundary — `(checked_in > 0)` no longer becomes `CHECK (ed_in > 0)` |
| #89 | Lengths above the target's maximum degrade to the unbounded form (`VARCHAR(10000)` → `VARCHAR(MAX)` on mssql, `TEXT` on mysql) instead of emitting DDL the target rejects |

## Tests
- New `internal/ddl/renderer_fixes_test.go` and `internal/driver/postgres/deterministic_fixes_test.go` pin every fix
- Three existing pins updated to the new intended behavior (rowversion via reader-normalized type; `current_timestamp(6)` → local-class `SYSDATETIME()`)
- `go test ./... -short` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)