### PR TITLE
Add snapshot versioning and FK-aware drop ordering to sync

### DIFF
--- a/cmd/smt/sync.go
+++ b/cmd/smt/sync.go
@@ -65,6 +65,7 @@ func runSnapshot(c *cli.Context) error {
 	}
 
 	snap := schemadiff.Snapshot{
+		Version:    schemadiff.CurrentSnapshotVersion,
 		Schema:     cfg.Source.Schema,
 		SourceType: cfg.Source.Type,
 		CapturedAt: time.Now().UTC(),
@@ -149,6 +150,7 @@ func runSync(c *cli.Context) error {
 	}
 
 	currSnap := schemadiff.Snapshot{
+		Version:    schemadiff.CurrentSnapshotVersion,
 		Schema:     cfg.Source.Schema,
 		SourceType: cfg.Source.Type,
 		CapturedAt: time.Now().UTC(),

--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -366,7 +366,9 @@ func (r Renderer) DropCheckDDL(tableName, chkName string) string {
 }
 
 func (r Renderer) DropTableDDL(tableName string) string {
-	return fmt.Sprintf("DROP TABLE %s", r.qualify(r.normalize(tableName)))
+	// IF EXISTS is supported by all three targets (MSSQL since 2016, and SMT
+	// requires compatibility level 140+).
+	return fmt.Sprintf("DROP TABLE IF EXISTS %s", r.qualify(r.normalize(tableName)))
 }
 
 func (r Renderer) AddColumnDDL(tableName string, col driver.Column, tableColumns []driver.Column) (string, error) {

--- a/internal/schemadiff/compat_test.go
+++ b/internal/schemadiff/compat_test.go
@@ -1,0 +1,172 @@
+package schemadiff
+
+import (
+	"strings"
+	"testing"
+
+	"smt/internal/driver"
+)
+
+// #78 — a pre-v2 snapshot (no IsUnsigned/EnumValues/OnUpdateExpression) must
+// not diff those fields against a fresh extraction that has them.
+func TestCompute_PreV2SnapshotDoesNotSpuriouslyDiff(t *testing.T) {
+	prev := Snapshot{
+		// Version 0: stored before the v2 fields existed.
+		Tables: []driver.Table{{
+			Name: "orders",
+			Columns: []driver.Column{
+				{Name: "id", DataType: "int"},
+				{Name: "status", DataType: "enum"},
+				{Name: "updated_at", DataType: "timestamp"},
+			},
+		}},
+	}
+	curr := Snapshot{
+		Version: CurrentSnapshotVersion,
+		Tables: []driver.Table{{
+			Name: "orders",
+			Columns: []driver.Column{
+				{Name: "id", DataType: "int", IsUnsigned: true},
+				{Name: "status", DataType: "enum", EnumValues: []string{"new", "shipped"}},
+				{Name: "updated_at", DataType: "timestamp", OnUpdateExpression: "CURRENT_TIMESTAMP"},
+			},
+		}},
+	}
+
+	diff := Compute(prev, curr)
+	if !diff.IsEmpty() {
+		t.Fatalf("pre-v2 snapshot produced a spurious diff: %+v", diff.ChangedTables)
+	}
+}
+
+// #78 — version-aware comparison still detects real changes between two
+// current-version snapshots.
+func TestCompute_CurrentVersionStillDetectsUnsignedChange(t *testing.T) {
+	prev := Snapshot{
+		Version: CurrentSnapshotVersion,
+		Tables: []driver.Table{{
+			Name:    "orders",
+			Columns: []driver.Column{{Name: "id", DataType: "int"}},
+		}},
+	}
+	curr := Snapshot{
+		Version: CurrentSnapshotVersion,
+		Tables: []driver.Table{{
+			Name:    "orders",
+			Columns: []driver.Column{{Name: "id", DataType: "int", IsUnsigned: true}},
+		}},
+	}
+
+	diff := Compute(prev, curr)
+	if len(diff.ChangedTables) != 1 || len(diff.ChangedTables[0].ChangedColumns) != 1 {
+		t.Fatalf("unsigned change not detected: %+v", diff)
+	}
+}
+
+// #78 — backfill must not mutate the caller's snapshot.
+func TestBackfillDoesNotMutateInput(t *testing.T) {
+	prev := Snapshot{
+		Tables: []driver.Table{{
+			Name:    "orders",
+			Columns: []driver.Column{{Name: "id", DataType: "int"}},
+		}},
+	}
+	curr := Snapshot{
+		Version: CurrentSnapshotVersion,
+		Tables: []driver.Table{{
+			Name:    "orders",
+			Columns: []driver.Column{{Name: "id", DataType: "int", IsUnsigned: true}},
+		}},
+	}
+	_ = Compute(prev, curr)
+	if prev.Tables[0].Columns[0].IsUnsigned {
+		t.Fatal("Compute mutated the caller's snapshot")
+	}
+}
+
+// #84 — removed tables drop children-first, with IF EXISTS.
+func TestRenderDeterministic_RemovedTablesDropChildrenFirst(t *testing.T) {
+	diff := Diff{
+		RemovedTables: []driver.Table{
+			{
+				// Alphabetically first, but it's the parent — must drop last.
+				Name:    "accounts",
+				Columns: []driver.Column{{Name: "id", DataType: "int"}},
+			},
+			{
+				Name:    "invoices",
+				Columns: []driver.Column{{Name: "id", DataType: "int"}},
+				ForeignKeys: []driver.ForeignKey{
+					{Name: "fk_invoices_accounts", Columns: []string{"account_id"}, RefTable: "accounts", RefColumns: []string{"id"}},
+				},
+			},
+		},
+	}
+	plan, err := RenderDeterministic(diff, "public", "postgres")
+	if err != nil {
+		t.Fatalf("RenderDeterministic: %v", err)
+	}
+	var drops []string
+	for _, st := range plan.Statements {
+		if strings.HasPrefix(st.SQL, "DROP TABLE") {
+			if !strings.Contains(st.SQL, "IF EXISTS") {
+				t.Errorf("drop without IF EXISTS: %q", st.SQL)
+			}
+			drops = append(drops, st.Table)
+		}
+	}
+	if len(drops) != 2 || drops[0] != "invoices" || drops[1] != "accounts" {
+		t.Fatalf("drop order = %v, want [invoices accounts]", drops)
+	}
+}
+
+// #84 — an FK cycle among removed tables gets its FKs dropped first.
+func TestRenderDeterministic_RemovedTableCycleDropsFKsFirst(t *testing.T) {
+	diff := Diff{
+		RemovedTables: []driver.Table{
+			{
+				Name:    "a",
+				Columns: []driver.Column{{Name: "id", DataType: "int"}},
+				ForeignKeys: []driver.ForeignKey{
+					{Name: "fk_a_b", Columns: []string{"b_id"}, RefTable: "b", RefColumns: []string{"id"}},
+				},
+			},
+			{
+				Name:    "b",
+				Columns: []driver.Column{{Name: "id", DataType: "int"}},
+				ForeignKeys: []driver.ForeignKey{
+					{Name: "fk_b_a", Columns: []string{"a_id"}, RefTable: "a", RefColumns: []string{"id"}},
+				},
+			},
+		},
+	}
+	plan, err := RenderDeterministic(diff, "public", "postgres")
+	if err != nil {
+		t.Fatalf("RenderDeterministic: %v", err)
+	}
+	sawFKDrop := false
+	for _, st := range plan.Statements {
+		if strings.Contains(st.SQL, "DROP CONSTRAINT") {
+			sawFKDrop = true
+		}
+		if strings.HasPrefix(st.SQL, "DROP TABLE") && !sawFKDrop {
+			t.Fatalf("table dropped before cycle FKs: %v", plan.Statements)
+		}
+	}
+	if !sawFKDrop {
+		t.Fatal("no FK drop emitted for cycle")
+	}
+}
+
+func TestOrderTablesForDrop_SelfReferenceIsNotACycle(t *testing.T) {
+	tables := []driver.Table{{
+		Name: "employees",
+		ForeignKeys: []driver.ForeignKey{
+			{Name: "fk_mgr", Columns: []string{"manager_id"}, RefTable: "employees", RefColumns: []string{"id"}},
+		},
+	}}
+	ordered, cyclic := orderTablesForDrop(tables)
+	if len(cyclic) != 0 || len(ordered) != 1 {
+		t.Fatalf("self-reference treated as cycle: ordered=%v cyclic=%v", ordered, cyclic)
+	}
+}

--- a/internal/schemadiff/compat_test.go
+++ b/internal/schemadiff/compat_test.go
@@ -144,17 +144,72 @@ func TestRenderDeterministic_RemovedTableCycleDropsFKsFirst(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RenderDeterministic: %v", err)
 	}
-	sawFKDrop := false
+	fkDrops := 0
 	for _, st := range plan.Statements {
 		if strings.Contains(st.SQL, "DROP CONSTRAINT") {
-			sawFKDrop = true
+			fkDrops++
 		}
-		if strings.HasPrefix(st.SQL, "DROP TABLE") && !sawFKDrop {
-			t.Fatalf("table dropped before cycle FKs: %v", plan.Statements)
+		if strings.HasPrefix(st.SQL, "DROP TABLE") && fkDrops == 0 {
+			t.Fatalf("cyclic table dropped before its FKs: %v", plan.Statements)
 		}
 	}
-	if !sawFKDrop {
-		t.Fatal("no FK drop emitted for cycle")
+	if fkDrops != 2 {
+		t.Fatalf("expected 2 intra-cycle FK drops, got %d", fkDrops)
+	}
+}
+
+// #84 — only FKs pointing inside the cycle are dropped; an FK from a cyclic
+// table to an already-dropped (acyclic) or surviving table is left alone.
+func TestRenderDeterministic_CycleFKDropsAreScoped(t *testing.T) {
+	diff := Diff{
+		RemovedTables: []driver.Table{
+			{
+				Name:    "a",
+				Columns: []driver.Column{{Name: "id", DataType: "int"}},
+				ForeignKeys: []driver.ForeignKey{
+					{Name: "fk_a_b", Columns: []string{"b_id"}, RefTable: "b", RefColumns: []string{"id"}},
+					{Name: "fk_a_lookup", Columns: []string{"l_id"}, RefTable: "lookup", RefColumns: []string{"id"}},
+				},
+			},
+			{
+				Name:    "b",
+				Columns: []driver.Column{{Name: "id", DataType: "int"}},
+				ForeignKeys: []driver.ForeignKey{
+					{Name: "fk_b_a", Columns: []string{"a_id"}, RefTable: "a", RefColumns: []string{"id"}},
+				},
+			},
+			{
+				// Acyclic: must drop before any FK-drop statements appear.
+				Name:    "lookup",
+				Columns: []driver.Column{{Name: "id", DataType: "int"}},
+			},
+		},
+	}
+	plan, err := RenderDeterministic(diff, "public", "postgres")
+	if err != nil {
+		t.Fatalf("RenderDeterministic: %v", err)
+	}
+	var tableOrder []string
+	fkDrops := 0
+	for _, st := range plan.Statements {
+		if strings.Contains(st.SQL, "fk_a_lookup") {
+			t.Fatalf("out-of-cycle FK dropped: %q", st.SQL)
+		}
+		if strings.Contains(st.SQL, "DROP CONSTRAINT") {
+			fkDrops++
+		}
+		if strings.HasPrefix(st.SQL, "DROP TABLE") {
+			tableOrder = append(tableOrder, st.Table)
+		}
+	}
+	if fkDrops != 2 {
+		t.Fatalf("expected 2 intra-cycle FK drops, got %d", fkDrops)
+	}
+	// lookup is referenced by cycle member a, so it can only drop after the
+	// cycle is broken and a is gone.
+	want := []string{"a", "b", "lookup"}
+	if strings.Join(tableOrder, ",") != strings.Join(want, ",") {
+		t.Fatalf("drop order = %v, want %v", tableOrder, want)
 	}
 }
 
@@ -165,8 +220,8 @@ func TestOrderTablesForDrop_SelfReferenceIsNotACycle(t *testing.T) {
 			{Name: "fk_mgr", Columns: []string{"manager_id"}, RefTable: "employees", RefColumns: []string{"id"}},
 		},
 	}}
-	ordered, cyclic := orderTablesForDrop(tables)
-	if len(cyclic) != 0 || len(ordered) != 1 {
-		t.Fatalf("self-reference treated as cycle: ordered=%v cyclic=%v", ordered, cyclic)
+	actions := orderTablesForDrop(tables)
+	if len(actions) != 1 || actions[0].dropFK != nil {
+		t.Fatalf("self-reference treated as cycle: %+v", actions)
 	}
 }

--- a/internal/schemadiff/diff.go
+++ b/internal/schemadiff/diff.go
@@ -273,6 +273,8 @@ func normalizeTableDiff(td TableDiff, norm func(string) string) TableDiff {
 // indexes, FKs, and checks are matched by name; differences in attributes
 // (column type/nullability, etc.) become ChangedColumns entries.
 func Compute(prev, curr Snapshot) Diff {
+	prev = backfillPreVersionFields(prev, curr)
+
 	d := Diff{
 		PrevCapturedAt: prev.CapturedAt,
 		CurrCapturedAt: curr.CapturedAt,
@@ -300,6 +302,52 @@ func Compute(prev, curr Snapshot) Diff {
 	}
 
 	return d
+}
+
+// backfillPreVersionFields copies snapshot-version-gated Column fields from
+// the current extraction into an older snapshot before diffing. A snapshot
+// written before a field existed stores its zero value, and comparing that
+// against the freshly-extracted value would mark every such column as changed
+// (#78) — e.g. every unsigned MySQL column after the v2 upgrade. Assuming the
+// field is unchanged is the conservative read: a wrong assumption misses one
+// real change (the next snapshot captures it) instead of emitting spurious
+// rebuild ALTERs.
+func backfillPreVersionFields(prev, curr Snapshot) Snapshot {
+	if prev.Version >= CurrentSnapshotVersion {
+		return prev
+	}
+
+	currTables := indexTablesByName(curr.Tables)
+	tables := make([]driver.Table, len(prev.Tables))
+	copy(tables, prev.Tables)
+	for ti := range tables {
+		ct, ok := currTables[tables[ti].Name]
+		if !ok {
+			continue
+		}
+		currCols := make(map[string]driver.Column, len(ct.Columns))
+		for _, c := range ct.Columns {
+			currCols[c.Name] = c
+		}
+		cols := make([]driver.Column, len(tables[ti].Columns))
+		copy(cols, tables[ti].Columns)
+		for ci := range cols {
+			cc, ok := currCols[cols[ci].Name]
+			if !ok {
+				continue
+			}
+			if prev.Version < 2 {
+				cols[ci].IsUnsigned = cc.IsUnsigned
+				cols[ci].OnUpdateExpression = cc.OnUpdateExpression
+				if len(cols[ci].EnumValues) == 0 {
+					cols[ci].EnumValues = cc.EnumValues
+				}
+			}
+		}
+		tables[ti].Columns = cols
+	}
+	prev.Tables = tables
+	return prev
 }
 
 func indexTablesByName(tables []driver.Table) map[string]driver.Table {

--- a/internal/schemadiff/diff_test.go
+++ b/internal/schemadiff/diff_test.go
@@ -111,8 +111,8 @@ func TestCompute_ChangedMySQLColumnFlags(t *testing.T) {
 	oldCol := driver.Column{Name: "UpdatedAt", DataType: "datetime", DefaultExpression: "CURRENT_TIMESTAMP"}
 	newCol := oldCol
 	newCol.OnUpdateExpression = "CURRENT_TIMESTAMP"
-	prev := Snapshot{Tables: []driver.Table{table("Events", oldCol)}}
-	curr := Snapshot{Tables: []driver.Table{table("Events", newCol)}}
+	prev := Snapshot{Version: CurrentSnapshotVersion, Tables: []driver.Table{table("Events", oldCol)}}
+	curr := Snapshot{Version: CurrentSnapshotVersion, Tables: []driver.Table{table("Events", newCol)}}
 
 	d := Compute(prev, curr)
 	if len(d.ChangedTables) != 1 || len(d.ChangedTables[0].ChangedColumns) != 1 {
@@ -122,7 +122,7 @@ func TestCompute_ChangedMySQLColumnFlags(t *testing.T) {
 	oldID := driver.Column{Name: "ID", DataType: "int"}
 	newID := oldID
 	newID.IsUnsigned = true
-	d = Compute(Snapshot{Tables: []driver.Table{table("Events", oldID)}}, Snapshot{Tables: []driver.Table{table("Events", newID)}})
+	d = Compute(Snapshot{Version: CurrentSnapshotVersion, Tables: []driver.Table{table("Events", oldID)}}, Snapshot{Version: CurrentSnapshotVersion, Tables: []driver.Table{table("Events", newID)}})
 	if len(d.ChangedTables) != 1 || len(d.ChangedTables[0].ChangedColumns) != 1 {
 		t.Fatalf("expected unsigned change to be detected, got %+v", d)
 	}

--- a/internal/schemadiff/render_deterministic.go
+++ b/internal/schemadiff/render_deterministic.go
@@ -57,24 +57,20 @@ func (r deterministicRenderer) render(diff Diff) (Plan, error) {
 		}
 	}
 
-	ordered, cyclic := orderTablesForDrop(diff.RemovedTables)
-	for _, t := range cyclic {
-		// FK cycle among the removed tables: no drop order works, so drop
-		// the foreign keys between them first.
-		for _, fk := range t.ForeignKeys {
+	for _, action := range orderTablesForDrop(diff.RemovedTables) {
+		if action.dropFK != nil {
 			plan.Statements = append(plan.Statements, Statement{
-				Table:       t.Name,
-				Description: fmt.Sprintf("drop foreign key %s (breaks drop-order cycle)", fk.Name),
-				SQL:         r.renderer.DropForeignKeyDDL(t.Name, fk.Name),
+				Table:       action.table,
+				Description: fmt.Sprintf("drop foreign key %s (breaks drop-order cycle)", action.dropFK.Name),
+				SQL:         r.renderer.DropForeignKeyDDL(action.table, action.dropFK.Name),
 				Risk:        RiskSafe,
 			})
+			continue
 		}
-	}
-	for _, t := range ordered {
 		plan.Statements = append(plan.Statements, Statement{
-			Table:       t.Name,
-			Description: fmt.Sprintf("drop table %s", t.Name),
-			SQL:         r.renderer.DropTableDDL(t.Name),
+			Table:       action.table,
+			Description: fmt.Sprintf("drop table %s", action.table),
+			SQL:         r.renderer.DropTableDDL(action.table),
 			Risk:        RiskDataLoss,
 			RiskNotes:   "drops the table and its data",
 		})
@@ -83,27 +79,41 @@ func (r deterministicRenderer) render(diff Diff) (Plan, error) {
 	return plan, nil
 }
 
-// orderTablesForDrop sorts removed tables children-first so a DROP TABLE
-// never fails on a still-referencing child (#84). Only FKs between removed
-// tables matter — a surviving referencing table would make the drop invalid
-// in any order. Tables stuck in an FK cycle are returned separately (and
-// appended at the end of the drop order) so the caller can break the cycle
-// by dropping their FKs first.
-func orderTablesForDrop(tables []driver.Table) (ordered, cyclic []driver.Table) {
+// dropAction is one step of the removed-table drop sequence: either a table
+// drop, or (when dropFK is set) an FK drop that breaks a drop-order cycle.
+type dropAction struct {
+	table  string
+	dropFK *driver.ForeignKey
+}
+
+// orderTablesForDrop sequences removed-table drops children-first so a DROP
+// TABLE never fails on a still-referencing child (#84). Only FKs between
+// removed tables matter — a surviving referencing table would make the drop
+// invalid in any order. When the remaining tables contain an FK cycle, the
+// FKs between cycle members (and only those) are dropped first, then ordering
+// resumes — tables merely blocked by the cycle drop in dependency order once
+// it is broken.
+func orderTablesForDrop(tables []driver.Table) []dropAction {
 	remaining := make(map[string]driver.Table, len(tables))
 	for _, t := range tables {
 		remaining[t.Name] = t
 	}
+	droppedFK := make(map[string]bool)
+	fkActive := func(t driver.Table, fk driver.ForeignKey) bool {
+		if droppedFK[t.Name+"\x00"+fk.Name] || fk.RefTable == t.Name {
+			return false // dropped, or self-reference (never blocks)
+		}
+		_, ok := remaining[fk.RefTable]
+		return ok
+	}
 
+	var actions []dropAction
 	for len(remaining) > 0 {
 		// referenced[p] is true while a remaining table still points at p.
 		referenced := make(map[string]bool, len(remaining))
 		for _, t := range remaining {
 			for _, fk := range t.ForeignKeys {
-				if fk.RefTable == t.Name {
-					continue // self-reference doesn't block the drop
-				}
-				if _, ok := remaining[fk.RefTable]; ok {
+				if fkActive(t, fk) {
 					referenced[fk.RefTable] = true
 				}
 			}
@@ -111,20 +121,76 @@ func orderTablesForDrop(tables []driver.Table) (ordered, cyclic []driver.Table) 
 		progressed := false
 		for _, name := range sortedKeys(remaining) {
 			if !referenced[name] {
-				ordered = append(ordered, remaining[name])
+				actions = append(actions, dropAction{table: name})
 				delete(remaining, name)
 				progressed = true
 			}
 		}
-		if !progressed {
-			for _, name := range sortedKeys(remaining) {
-				cyclic = append(cyclic, remaining[name])
+		if progressed {
+			continue
+		}
+
+		// Stuck: every remaining table is referenced, so there is at least
+		// one cycle. Drop the FKs between cycle members.
+		cyc := cycleMembers(remaining, fkActive)
+		broke := false
+		for _, name := range sortedKeys(remaining) {
+			if !cyc[name] {
+				continue
 			}
-			ordered = append(ordered, cyclic...)
-			return ordered, cyclic
+			t := remaining[name]
+			for i := range t.ForeignKeys {
+				fk := t.ForeignKeys[i]
+				if fkActive(t, fk) && cyc[fk.RefTable] {
+					droppedFK[t.Name+"\x00"+fk.Name] = true
+					actions = append(actions, dropAction{table: t.Name, dropFK: &t.ForeignKeys[i]})
+					broke = true
+				}
+			}
+		}
+		if !broke {
+			// Defensive: cannot make progress (should be unreachable). Emit
+			// the rest in name order rather than looping forever.
+			for _, name := range sortedKeys(remaining) {
+				actions = append(actions, dropAction{table: name})
+				delete(remaining, name)
+			}
 		}
 	}
-	return ordered, nil
+	return actions
+}
+
+// cycleMembers returns the remaining tables that sit on an FK cycle (i.e.
+// can reach themselves through active FKs between remaining tables).
+func cycleMembers(remaining map[string]driver.Table, fkActive func(driver.Table, driver.ForeignKey) bool) map[string]bool {
+	members := make(map[string]bool)
+	for start := range remaining {
+		seen := map[string]bool{}
+		stack := []string{start}
+		for len(stack) > 0 {
+			name := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			t, ok := remaining[name]
+			if !ok {
+				continue
+			}
+			for _, fk := range t.ForeignKeys {
+				if !fkActive(t, fk) {
+					continue
+				}
+				if fk.RefTable == start {
+					members[start] = true
+					stack = nil
+					break
+				}
+				if !seen[fk.RefTable] {
+					seen[fk.RefTable] = true
+					stack = append(stack, fk.RefTable)
+				}
+			}
+		}
+	}
+	return members
 }
 
 func (r deterministicRenderer) renderAddedTableDefinition(plan *Plan, t driver.Table) error {

--- a/internal/schemadiff/render_deterministic.go
+++ b/internal/schemadiff/render_deterministic.go
@@ -57,7 +57,20 @@ func (r deterministicRenderer) render(diff Diff) (Plan, error) {
 		}
 	}
 
-	for _, t := range diff.RemovedTables {
+	ordered, cyclic := orderTablesForDrop(diff.RemovedTables)
+	for _, t := range cyclic {
+		// FK cycle among the removed tables: no drop order works, so drop
+		// the foreign keys between them first.
+		for _, fk := range t.ForeignKeys {
+			plan.Statements = append(plan.Statements, Statement{
+				Table:       t.Name,
+				Description: fmt.Sprintf("drop foreign key %s (breaks drop-order cycle)", fk.Name),
+				SQL:         r.renderer.DropForeignKeyDDL(t.Name, fk.Name),
+				Risk:        RiskSafe,
+			})
+		}
+	}
+	for _, t := range ordered {
 		plan.Statements = append(plan.Statements, Statement{
 			Table:       t.Name,
 			Description: fmt.Sprintf("drop table %s", t.Name),
@@ -68,6 +81,50 @@ func (r deterministicRenderer) render(diff Diff) (Plan, error) {
 	}
 
 	return plan, nil
+}
+
+// orderTablesForDrop sorts removed tables children-first so a DROP TABLE
+// never fails on a still-referencing child (#84). Only FKs between removed
+// tables matter — a surviving referencing table would make the drop invalid
+// in any order. Tables stuck in an FK cycle are returned separately (and
+// appended at the end of the drop order) so the caller can break the cycle
+// by dropping their FKs first.
+func orderTablesForDrop(tables []driver.Table) (ordered, cyclic []driver.Table) {
+	remaining := make(map[string]driver.Table, len(tables))
+	for _, t := range tables {
+		remaining[t.Name] = t
+	}
+
+	for len(remaining) > 0 {
+		// referenced[p] is true while a remaining table still points at p.
+		referenced := make(map[string]bool, len(remaining))
+		for _, t := range remaining {
+			for _, fk := range t.ForeignKeys {
+				if fk.RefTable == t.Name {
+					continue // self-reference doesn't block the drop
+				}
+				if _, ok := remaining[fk.RefTable]; ok {
+					referenced[fk.RefTable] = true
+				}
+			}
+		}
+		progressed := false
+		for _, name := range sortedKeys(remaining) {
+			if !referenced[name] {
+				ordered = append(ordered, remaining[name])
+				delete(remaining, name)
+				progressed = true
+			}
+		}
+		if !progressed {
+			for _, name := range sortedKeys(remaining) {
+				cyclic = append(cyclic, remaining[name])
+			}
+			ordered = append(ordered, cyclic...)
+			return ordered, cyclic
+		}
+	}
+	return ordered, nil
 }
 
 func (r deterministicRenderer) renderAddedTableDefinition(plan *Plan, t driver.Table) error {

--- a/internal/schemadiff/snapshot.go
+++ b/internal/schemadiff/snapshot.go
@@ -15,8 +15,19 @@ import (
 	"smt/internal/driver"
 )
 
+// CurrentSnapshotVersion is stamped into every new snapshot. Bump it whenever
+// driver.Column (or anything else snapshot-persisted) gains a field that
+// columnsEqual compares, and teach backfillPreVersionFields how to fill the
+// gap for older snapshots.
+//
+// Version history:
+//   - 0/1: original format (a snapshot without a version field decodes as 0)
+//   - 2: Column gained IsUnsigned, EnumValues, OnUpdateExpression
+const CurrentSnapshotVersion = 2
+
 // Snapshot is a serializable point-in-time view of a source schema.
 type Snapshot struct {
+	Version    int            `json:"version,omitempty"`
 	Schema     string         `json:"schema"`
 	SourceType string         `json:"source_type"`
 	CapturedAt time.Time      `json:"captured_at"`


### PR DESCRIPTION
Second PR in the post-#76/#77 review series.

## #78 — pre-upgrade snapshots no longer break `smt sync`
- `schemadiff.Snapshot` gains `version` (omitted in old payloads → decodes 0); `CurrentSnapshotVersion = 2` documents which fields each version added.
- `Compute` backfills the v2 fields (`IsUnsigned`, `EnumValues`, `OnUpdateExpression`) from the current extraction when the stored snapshot predates them. Backfilling is the conservative choice: a real change to one of those fields between snapshot and upgrade is missed once (the next snapshot captures it) instead of every unsigned column emitting a rebuild-risk ALTER that `--apply` executes unprompted, and old enum columns hard-failing the render with "missing allowed values".
- Backfill copies tables/columns; the caller's snapshot is not mutated.
- `snapshot`/`sync` stamp the version on save.

## #84 — removed-table drops are FK-ordered
- `orderTablesForDrop` topologically sorts removed tables children-first using the FK graph restricted to the removed set (self-references don't block; FK cycles get their FKs dropped first, then name-ordered drops).
- `DropTableDDL` now emits `DROP TABLE IF EXISTS` (valid on pg, mysql, and mssql ≥2016 — SMT already requires compat level 140+).

## Tests
- `internal/schemadiff/compat_test.go`: pre-v2 no-spurious-diff, real-change detection at current version, input non-mutation, child-before-parent drop order, cycle FK-drop, self-reference.
- One existing test updated to stamp the version it always semantically had (it simulates two fresh extractions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)