### PR TITLE
Serialize MySQL CHECK phase, label generate runs, reject partial targets

### DIFF
--- a/internal/checkpoint/backend.go
+++ b/internal/checkpoint/backend.go
@@ -5,11 +5,18 @@ import (
 	"time"
 )
 
+// Run kinds distinguish runs that executed DDL against a target from
+// generate-only previews in history and notifications (#90).
+const (
+	RunKindApply    = "apply"
+	RunKindGenerate = "generate"
+)
+
 // StateBackend defines the interface for state persistence.
 // Implementations include SQLite (full featured) and file-based (minimal, for Airflow).
 type StateBackend interface {
 	// Run management
-	CreateRun(id, sourceSchema, targetSchema string, config any, profileName, configPath string) error
+	CreateRun(id, kind, sourceSchema, targetSchema string, config any, profileName, configPath string) error
 	UpdateRunConfig(id string, config any) error // Persist post-AI-tuning config snapshot
 	CompleteRun(id string, status string, errorMsg string) error
 	GetLastIncompleteRun() (*Run, error)

--- a/internal/checkpoint/filestate.go
+++ b/internal/checkpoint/filestate.go
@@ -86,8 +86,10 @@ func (fs *FileState) save() error {
 	return nil
 }
 
-// CreateRun initializes a new migration run.
-func (fs *FileState) CreateRun(id, sourceSchema, targetSchema string, config any, profileName, configPath string) error {
+// CreateRun initializes a new migration run. The file backend does not
+// surface run history, so kind is accepted for interface parity only.
+func (fs *FileState) CreateRun(id, kind, sourceSchema, targetSchema string, config any, profileName, configPath string) error {
+	_ = kind
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 

--- a/internal/checkpoint/filestate_test.go
+++ b/internal/checkpoint/filestate_test.go
@@ -18,7 +18,7 @@ func TestFileState_CreateAndResumeRun(t *testing.T) {
 	}
 
 	// Create a run
-	err = fs.CreateRun("test123", "dbo", "public", map[string]string{"key": "value"}, "myprofile", "")
+	err = fs.CreateRun("test123", RunKindApply, "dbo", "public", map[string]string{"key": "value"}, "myprofile", "")
 	if err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestFileState_ClearTransferProgress(t *testing.T) {
 	}
 
 	// Create a run and task
-	err = fs.CreateRun("test456", "dbo", "public", nil, "", "")
+	err = fs.CreateRun("test456", RunKindApply, "dbo", "public", nil, "", "")
 	if err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestFileState_ConfigHash(t *testing.T) {
 		"source": map[string]string{"host": "localhost"},
 		"target": map[string]string{"host": "postgres"},
 	}
-	err = fs.CreateRun("hash123", "dbo", "public", config, "", "/path/to/config.yaml")
+	err = fs.CreateRun("hash123", RunKindApply, "dbo", "public", config, "", "/path/to/config.yaml")
 	if err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestFileState_ConfigHash(t *testing.T) {
 
 	// Verify hash is deterministic (same config = same hash)
 	fs2, _ := NewFileState(filepath.Join(tmpDir, "state2.yaml"))
-	fs2.CreateRun("hash456", "dbo", "public", config, "", "")
+	fs2.CreateRun("hash456", RunKindApply, "dbo", "public", config, "", "")
 	run2, _ := fs2.GetLastIncompleteRun()
 	if run.ConfigHash != run2.ConfigHash {
 		t.Errorf("config hashes differ for same config: %s != %s", run.ConfigHash, run2.ConfigHash)
@@ -222,7 +222,7 @@ func TestFileState_ConfigHash(t *testing.T) {
 		"target": map[string]string{"host": "postgres"},
 	}
 	fs3, _ := NewFileState(filepath.Join(tmpDir, "state3.yaml"))
-	fs3.CreateRun("hash789", "dbo", "public", config2, "", "")
+	fs3.CreateRun("hash789", RunKindApply, "dbo", "public", config2, "", "")
 	run3, _ := fs3.GetLastIncompleteRun()
 	if run.ConfigHash == run3.ConfigHash {
 		t.Errorf("config hashes should differ for different configs: %s == %s", run.ConfigHash, run3.ConfigHash)

--- a/internal/checkpoint/runkind_test.go
+++ b/internal/checkpoint/runkind_test.go
@@ -1,0 +1,50 @@
+package checkpoint
+
+import "testing"
+
+// #90 — run kind is persisted and surfaced so history can distinguish
+// generate-only previews from runs that executed DDL.
+func TestRunKindPersisted(t *testing.T) {
+	state, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	defer state.Close()
+
+	if err := state.CreateRun("gen-run", RunKindGenerate, "dbo", "public", nil, "", ""); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := state.CreateRun("apply-run", RunKindApply, "dbo", "public", nil, "", ""); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := state.CreateRun("legacy-run", "", "dbo", "public", nil, "", ""); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	for id, want := range map[string]string{
+		"gen-run":    RunKindGenerate,
+		"apply-run":  RunKindApply,
+		"legacy-run": RunKindApply,
+	} {
+		r, err := state.GetRunByID(id)
+		if err != nil || r == nil {
+			t.Fatalf("GetRunByID(%s): %v %v", id, r, err)
+		}
+		if r.Kind != want {
+			t.Errorf("run %s kind = %q, want %q", id, r.Kind, want)
+		}
+	}
+
+	runs, err := state.GetAllRuns()
+	if err != nil {
+		t.Fatalf("GetAllRuns: %v", err)
+	}
+	if len(runs) != 3 {
+		t.Fatalf("GetAllRuns returned %d runs, want 3", len(runs))
+	}
+	for _, r := range runs {
+		if r.Kind == "" {
+			t.Errorf("run %s has empty kind", r.ID)
+		}
+	}
+}

--- a/internal/checkpoint/state.go
+++ b/internal/checkpoint/state.go
@@ -38,6 +38,7 @@ type Task struct {
 // Run represents a migration run
 type Run struct {
 	ID           string
+	Kind         string // "apply" (executed DDL on a target) or "generate" (preview only)
 	StartedAt    time.Time
 	CompletedAt  *time.Time
 	Status       string
@@ -124,6 +125,7 @@ func (s *State) migrate() error {
 	schema := `
 	CREATE TABLE IF NOT EXISTS runs (
 		id TEXT PRIMARY KEY,
+		kind TEXT NOT NULL DEFAULT 'apply',
 		started_at TEXT NOT NULL,
 		completed_at TEXT,
 		status TEXT NOT NULL DEFAULT 'running',
@@ -268,6 +270,7 @@ func (s *State) ensureRunColumns() error {
 	needsError := true
 	needsPhase := true
 	needsConfigHash := true
+	needsKind := true
 	for _, col := range columns {
 		switch col {
 		case "profile_name":
@@ -280,6 +283,8 @@ func (s *State) ensureRunColumns() error {
 			needsPhase = false
 		case "config_hash":
 			needsConfigHash = false
+		case "kind":
+			needsKind = false
 		}
 	}
 
@@ -305,6 +310,11 @@ func (s *State) ensureRunColumns() error {
 	}
 	if needsConfigHash {
 		if _, err := s.db.Exec(`ALTER TABLE runs ADD COLUMN config_hash TEXT`); err != nil {
+			return err
+		}
+	}
+	if needsKind {
+		if _, err := s.db.Exec(`ALTER TABLE runs ADD COLUMN kind TEXT NOT NULL DEFAULT 'apply'`); err != nil {
 			return err
 		}
 	}
@@ -481,17 +491,20 @@ func (s *State) Close() error {
 }
 
 // CreateRun creates a new migration run
-func (s *State) CreateRun(id, sourceSchema, targetSchema string, config any, profileName, configPath string) error {
+func (s *State) CreateRun(id, kind, sourceSchema, targetSchema string, config any, profileName, configPath string) error {
 	configJSON, _ := json.Marshal(config)
 
 	// Compute config hash for change detection on resume (matches filestate behavior)
 	hash := sha256.Sum256(configJSON)
 	configHash := hex.EncodeToString(hash[:8])
 
+	if kind == "" {
+		kind = RunKindApply
+	}
 	_, err := s.db.Exec(`
-		INSERT INTO runs (id, started_at, status, source_schema, target_schema, config, profile_name, config_path, config_hash)
-		VALUES (?, datetime('now'), 'running', ?, ?, ?, ?, ?, ?)
-	`, id, sourceSchema, targetSchema, string(configJSON), profileName, configPath, configHash)
+		INSERT INTO runs (id, kind, started_at, status, source_schema, target_schema, config, profile_name, config_path, config_hash)
+		VALUES (?, ?, datetime('now'), 'running', ?, ?, ?, ?, ?, ?)
+	`, id, kind, sourceSchema, targetSchema, string(configJSON), profileName, configPath, configHash)
 	return err
 }
 
@@ -821,7 +834,7 @@ func (p *ProgressSaver) GetProgress(taskID int64) (lastPK any, rowsDone int64, e
 // GetAllRuns returns all runs for history
 func (s *State) GetAllRuns() ([]Run, error) {
 	rows, err := s.db.Query(`
-		SELECT id, started_at, completed_at, status, source_schema, target_schema, config, profile_name, config_path, error
+		SELECT id, COALESCE(kind, 'apply'), started_at, completed_at, status, source_schema, target_schema, config, profile_name, config_path, error
 		FROM runs ORDER BY started_at DESC LIMIT 20
 	`)
 	if err != nil {
@@ -836,7 +849,7 @@ func (s *State) GetAllRuns() ([]Run, error) {
 		var completedAtStr sql.NullString
 		var configStr sql.NullString
 		var profileName, configPath, errorMsg sql.NullString
-		if err := rows.Scan(&r.ID, &startedAtStr, &completedAtStr, &r.Status, &r.SourceSchema, &r.TargetSchema, &configStr, &profileName, &configPath, &errorMsg); err != nil {
+		if err := rows.Scan(&r.ID, &r.Kind, &startedAtStr, &completedAtStr, &r.Status, &r.SourceSchema, &r.TargetSchema, &configStr, &profileName, &configPath, &errorMsg); err != nil {
 			return nil, err
 		}
 		r.StartedAt, _ = time.Parse("2006-01-02 15:04:05", startedAtStr)
@@ -956,9 +969,9 @@ func (s *State) GetRunByID(runID string) (*Run, error) {
 
 	var profileName, configPath, errorMsg sql.NullString
 	err := s.db.QueryRow(`
-		SELECT id, started_at, completed_at, status, source_schema, target_schema, config, profile_name, config_path, error
+		SELECT id, COALESCE(kind, 'apply'), started_at, completed_at, status, source_schema, target_schema, config, profile_name, config_path, error
 		FROM runs WHERE id = ?
-	`, runID).Scan(&r.ID, &startedAtStr, &completedAtStr, &r.Status, &r.SourceSchema, &r.TargetSchema, &configStr, &profileName, &configPath, &errorMsg)
+	`, runID).Scan(&r.ID, &r.Kind, &startedAtStr, &completedAtStr, &r.Status, &r.SourceSchema, &r.TargetSchema, &configStr, &profileName, &configPath, &errorMsg)
 
 	if err == sql.ErrNoRows {
 		return nil, nil

--- a/internal/checkpoint/state_test.go
+++ b/internal/checkpoint/state_test.go
@@ -22,7 +22,7 @@ func TestCleanupOldRuns(t *testing.T) {
 	running := "running"
 
 	for _, runID := range []string{oldSuccess, oldFailed, recentSuccess, running} {
-		if err := state.CreateRun(runID, "dbo", "public", map[string]string{"run": runID}, "", ""); err != nil {
+		if err := state.CreateRun(runID, RunKindApply, "dbo", "public", map[string]string{"run": runID}, "", ""); err != nil {
 			t.Fatalf("CreateRun(%s) error: %v", runID, err)
 		}
 	}
@@ -313,7 +313,7 @@ func TestAIAdjustmentsLimitZeroReturnsAll(t *testing.T) {
 	defer state.Close()
 
 	// Create a run to attach adjustments to
-	if err := state.CreateRun("test-run", "dbo", "public", "", "", ""); err != nil {
+	if err := state.CreateRun("test-run", RunKindApply, "dbo", "public", "", "", ""); err != nil {
 		t.Fatalf("CreateRun error: %v", err)
 	}
 
@@ -429,7 +429,7 @@ func TestUpdateRunConfig(t *testing.T) {
 
 	const runID = "run-update-config"
 	original := map[string]any{"workers": 12, "chunk_size": 113510}
-	if err := state.CreateRun(runID, "dbo", "public", original, "", ""); err != nil {
+	if err := state.CreateRun(runID, RunKindApply, "dbo", "public", original, "", ""); err != nil {
 		t.Fatalf("CreateRun error: %v", err)
 	}
 
@@ -466,7 +466,7 @@ func TestCountPartitionTasks(t *testing.T) {
 	defer state.Close()
 
 	runID := "test-run"
-	if err := state.CreateRun(runID, "public", "public", nil, "", ""); err != nil {
+	if err := state.CreateRun(runID, RunKindApply, "public", "public", nil, "", ""); err != nil {
 		t.Fatalf("CreateRun() error: %v", err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -962,6 +962,12 @@ func (c *Config) validate() error {
 	if !isValidDriverType(c.Target.Type) {
 		return fmt.Errorf("target.type '%s' is not a valid driver type (supported: %v)", c.Target.Type, availableDriverTypes())
 	}
+	// A target with exactly one of host/database set is a typo, not a
+	// deliberate DDL-only config. Fail at load instead of silently running
+	// source-only and reporting the system healthy (#91).
+	if (strings.TrimSpace(c.Target.Host) != "") != (strings.TrimSpace(c.Target.Database) != "") {
+		return fmt.Errorf("target.host and target.database must both be set (or both omitted for DDL-only mode)")
+	}
 
 	// Same-engine migration validation: prevent migration to the exact same database
 	// Compare canonical driver names to handle aliases (e.g., "mssql" == "sqlserver")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1469,3 +1469,44 @@ func TestBooleanGlobalDefaultsDocumentedLimitation(t *testing.T) {
 	// Document this is a known limitation, not a bug
 	t.Log("Known limitation: cannot override global 'true' to 'false' per-migration")
 }
+
+// #91 — a target with exactly one of host/database set is a typo, not a
+// DDL-only config; it must fail at load instead of silently running
+// source-only.
+func TestValidateRejectsPartialTargetConnection(t *testing.T) {
+	base := func() *Config {
+		return &Config{
+			Source: SourceConfig{
+				Type:     "mssql",
+				Host:     "localhost",
+				Database: "source",
+			},
+			Target: TargetConfig{
+				Type:   "postgres",
+				Schema: "public",
+			},
+			Migration: MigrationConfig{
+				TargetMode: "drop_recreate",
+			},
+		}
+	}
+
+	hostOnly := base()
+	hostOnly.Target.Host = "pg.example.com"
+	if err := hostOnly.validate(); err == nil {
+		t.Fatal("validate() accepted target.host without target.database")
+	}
+
+	dbOnly := base()
+	dbOnly.Target.Database = "targetdb"
+	if err := dbOnly.validate(); err == nil {
+		t.Fatal("validate() accepted target.database without target.host")
+	}
+
+	both := base()
+	both.Target.Host = "pg.example.com"
+	both.Target.Database = "targetdb"
+	if err := both.validate(); err != nil {
+		t.Fatalf("validate() rejected complete target connection: %v", err)
+	}
+}

--- a/internal/orchestrator/check_concurrency_test.go
+++ b/internal/orchestrator/check_concurrency_test.go
@@ -1,0 +1,25 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"smt/internal/config"
+)
+
+// #81/#25 — the CHECK phase serializes on MySQL targets to avoid InnoDB
+// metadata-lock deadlocks (Error 1213); other targets keep full concurrency.
+func TestCheckConcurrencySerializesMySQL(t *testing.T) {
+	for targetType, want := range map[string]int{
+		"mysql":    1,
+		"mariadb":  1,
+		"postgres": defaultAIConcurrency,
+		"mssql":    defaultAIConcurrency,
+	} {
+		cfg := &config.Config{}
+		cfg.Target.Type = targetType
+		o := &Orchestrator{config: cfg}
+		if got := o.checkConcurrency(); got != want {
+			t.Errorf("checkConcurrency(target=%s) = %d, want %d", targetType, got, want)
+		}
+	}
+}

--- a/internal/orchestrator/ddl_plan.go
+++ b/internal/orchestrator/ddl_plan.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"smt/internal/checkpoint"
 	"smt/internal/ddl"
 	"smt/internal/driver"
 	"smt/internal/logging"
@@ -29,37 +30,35 @@ func (o *Orchestrator) GenerateDDL(ctx context.Context, outputPath string) (sche
 		runID = uuid.NewString()
 	}
 
-	if err := o.state.CreateRun(runID, o.config.Source.Schema, o.config.Target.Schema, o.config.Sanitized(), o.runProfile, o.runConfig); err != nil {
+	if err := o.state.CreateRun(runID, checkpoint.RunKindGenerate, o.config.Source.Schema, o.config.Target.Schema, o.config.Sanitized(), o.runProfile, o.runConfig); err != nil {
 		return schemadiff.Plan{}, "", fmt.Errorf("recording run start: %w", err)
 	}
 
+	// Generate-only runs intentionally skip Slack notifications: nothing was
+	// executed against a target, and a "Migration started/completed" ping for
+	// every preview misleads operators (#90).
 	start := time.Now()
-	_ = o.notifier.MigrationStarted(runID, o.config.Source.Type, o.config.Target.Type, 0)
 
 	plan, err := o.renderDDLPlan(ctx, runID)
 	if err != nil {
 		_ = o.state.CompleteRun(runID, "failed", err.Error())
-		_ = o.notifier.MigrationFailed(runID, err, time.Since(start))
 		return schemadiff.Plan{}, runID, err
 	}
 
 	sql := plan.SQL()
 	if err := o.writeSQLArtifact(runID, "schema.sql", sql); err != nil {
 		_ = o.state.CompleteRun(runID, "failed", err.Error())
-		_ = o.notifier.MigrationFailed(runID, err, time.Since(start))
 		return schemadiff.Plan{}, runID, fmt.Errorf("writing DDL artifact: %w", err)
 	}
 	if strings.TrimSpace(outputPath) != "" {
 		if err := os.WriteFile(outputPath, []byte(sql), 0600); err != nil {
 			_ = o.state.CompleteRun(runID, "failed", err.Error())
-			_ = o.notifier.MigrationFailed(runID, err, time.Since(start))
 			return schemadiff.Plan{}, runID, fmt.Errorf("writing output file: %w", err)
 		}
 	}
 
 	dur := time.Since(start)
 	_ = o.state.CompleteRun(runID, "success", "")
-	_ = o.notifier.MigrationCompleted(runID, start, dur, len(o.tables), 0, 0)
 	logging.Info("DDL generation complete in %s (%d tables)", dur.Round(time.Millisecond), len(o.tables))
 	return plan, runID, nil
 }

--- a/internal/orchestrator/history.go
+++ b/internal/orchestrator/history.go
@@ -23,11 +23,11 @@ func (o *Orchestrator) ShowHistory() error {
 		return nil
 	}
 
-	fmt.Printf("%-36s %-10s %-19s %-19s %s\n", "RUN ID", "STATUS", "STARTED", "ENDED", "PHASE")
-	fmt.Println(strings.Repeat("-", 105))
+	fmt.Printf("%-36s %-9s %-10s %-19s %-19s %s\n", "RUN ID", "KIND", "STATUS", "STARTED", "ENDED", "PHASE")
+	fmt.Println(strings.Repeat("-", 115))
 	for _, r := range runs {
-		fmt.Printf("%-36s %-10s %-19s %-19s %s\n",
-			r.ID, r.Status, fmtTime(&r.StartedAt), fmtTime(r.CompletedAt), r.Phase)
+		fmt.Printf("%-36s %-9s %-10s %-19s %-19s %s\n",
+			r.ID, runKindLabel(r.Kind), r.Status, fmtTime(&r.StartedAt), fmtTime(r.CompletedAt), r.Phase)
 	}
 	return nil
 }
@@ -43,6 +43,7 @@ func (o *Orchestrator) ShowRunDetails(runID string) error {
 		return nil
 	}
 	fmt.Printf("Run:        %s\n", r.ID)
+	fmt.Printf("Kind:       %s\n", runKindLabel(r.Kind))
 	fmt.Printf("Status:     %s\n", r.Status)
 	fmt.Printf("Phase:      %s\n", r.Phase)
 	fmt.Printf("Source:     %s\n", r.SourceSchema)
@@ -65,6 +66,13 @@ func (o *Orchestrator) ShowRunDetails(runID string) error {
 		fmt.Printf("  %-30s %s\n", t.TaskKey, t.Status)
 	}
 	return nil
+}
+
+func runKindLabel(kind string) string {
+	if kind == "" {
+		return checkpoint.RunKindApply
+	}
+	return kind
 }
 
 func fmtTime(t *time.Time) string {

--- a/internal/orchestrator/phases.go
+++ b/internal/orchestrator/phases.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 
+	"smt/internal/checkpoint"
 	"smt/internal/driver"
 	"smt/internal/logging"
 	"smt/internal/source"
@@ -67,7 +68,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		runID = uuid.NewString()
 	}
 
-	if err := o.state.CreateRun(runID, o.config.Source.Schema, o.config.Target.Schema, o.config.Sanitized(), o.runProfile, o.runConfig); err != nil {
+	if err := o.state.CreateRun(runID, checkpoint.RunKindApply, o.config.Source.Schema, o.config.Target.Schema, o.config.Sanitized(), o.runProfile, o.runConfig); err != nil {
 		return fmt.Errorf("recording run start: %w", err)
 	}
 
@@ -233,10 +234,11 @@ func (o *Orchestrator) CreateForeignKeys(ctx context.Context, runID string) erro
 // other constraint phases.
 func (o *Orchestrator) CreateCheckConstraints(ctx context.Context, runID string) error {
 	_ = o.state.UpdatePhase(runID, string(TaskCreateChecks))
-	logging.Info("[%s] loading and creating check constraints (concurrency=%d)", TaskCreateChecks, o.aiConcurrency())
+	concurrency := o.checkConcurrency()
+	logging.Info("[%s] loading and creating check constraints (concurrency=%d)", TaskCreateChecks, concurrency)
 	aiReviewEnabled := o.config.AIReview.Enabled != nil && *o.config.AIReview.Enabled
 	opts := driver.FinalizeOptions{AIReviewEnabled: aiReviewEnabled, AIReviewMode: o.config.AIReview.Mode, ArtifactDir: o.ddlArtifactDir(runID)}
-	return runParallel(ctx, o.tables, o.aiConcurrency(), func(ctx context.Context, i int, t source.Table) error {
+	return runParallel(ctx, o.tables, concurrency, func(ctx context.Context, i int, t source.Table) error {
 		if err := o.source.LoadCheckConstraints(ctx, &t); err != nil {
 			return fmt.Errorf("loading checks for %s: %w", t.Name, err)
 		}
@@ -250,6 +252,17 @@ func (o *Orchestrator) CreateCheckConstraints(ctx context.Context, runID string)
 		}
 		return nil
 	})
+}
+
+// checkConcurrency returns the concurrency for the CHECK-constraint phase.
+// MySQL targets are serialized: InnoDB takes metadata locks on the FK graph
+// when adding a CHECK, and concurrent ADD CONSTRAINT on related tables
+// deadlocks with Error 1213 (#25, #81).
+func (o *Orchestrator) checkConcurrency() int {
+	if driver.Canonicalize(o.config.Target.Type) == "mysql" {
+		return 1
+	}
+	return o.aiConcurrency()
 }
 
 // aiConcurrency returns the configured per-phase concurrency limit, or


### PR DESCRIPTION
Third PR in the post-#76/#77 review series.

## #81 / #25 — MySQL CHECK deadlocks
`Orchestrator.CreateCheckConstraints` now uses `checkConcurrency()`: 1 for MySQL targets (resolved through the driver registry, so `mariadb`/`maria` count), the configured concurrency elsewhere. This is the fix #25 proposed; with the AI retry loop gone since #77, a single Error 1213 aborted the whole run.

## #90 — generate-only runs are distinguishable
- `runs` table gains `kind` (`apply`/`generate`, defaulted/backfilled to `apply`; guarded ALTER for existing state DBs).
- `StateBackend.CreateRun` takes the kind; `smt history` and run details show it.
- `GenerateDDL` no longer sends Slack started/completed/failed notifications — previews execute nothing against a target.

## #91 — partial target config fails fast
`validate()` rejects a target with exactly one of host/database set ("target.host and target.database must both be set (or both omitted for DDL-only mode)"). Previously it was classified as "not configured": `smt create` silently went generate-only and `health-check` reported Overall HEALTHY.

## Tests
- `runkind_test.go`: kind persisted, legacy empty kind reads as apply.
- `check_concurrency_test.go`: mysql/mariadb→1, pg/mssql→default.
- config test: host-only and db-only rejected, both accepted.
- `go test ./... -short` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)