### PR TITLE
Capture and render fractional-second datetime precision end-to-end

### DIFF
--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -244,7 +244,7 @@ func (r Renderer) ColumnDefault(col driver.Column) (string, error) {
 		}
 	case "mysql":
 		if strings.HasPrefix(lower, "current_timestamp(") || strings.HasPrefix(lower, "now(") {
-			return "CURRENT_TIMESTAMP(6)", nil
+			return mysqlNowDefault(col), nil
 		}
 		if isArraySourceType(col.DataType) {
 			switch lower {
@@ -262,7 +262,7 @@ func (r Renderer) ColumnDefault(col driver.Column) (string, error) {
 		}
 		switch lower {
 		case "current_timestamp", "now()", "getdate()", "getutcdate()", "sysdatetime()", "sysutcdatetime()", "sysdatetimeoffset()":
-			return "CURRENT_TIMESTAMP(6)", nil
+			return mysqlNowDefault(col), nil
 		case "gen_random_uuid()", "uuid_generate_v4()", "newid()", "uuid()":
 			return "(UUID())", nil
 		}
@@ -586,13 +586,13 @@ func (r Renderer) mssqlColumnType(col driver.Column, dt string) (string, error) 
 	case "rowversion":
 		return "ROWVERSION", nil
 	case "datetime", "datetime2", "smalldatetime", "timestamp", "timestamp without time zone", "timestamptz":
-		return "DATETIME2", nil
+		return fspType("DATETIME2", col, 7), nil
 	case "datetimeoffset", "timestamp with time zone":
-		return "DATETIMEOFFSET", nil
+		return fspType("DATETIMEOFFSET", col, 7), nil
 	case "date":
 		return "DATE", nil
 	case "time", "time without time zone", "time with time zone":
-		return "TIME", nil
+		return fspType("TIME", col, 7), nil
 	case "decimal", "numeric", "number":
 		return decimalType("DECIMAL", col), nil
 	case "money":
@@ -640,11 +640,11 @@ func (r Renderer) mysqlColumnType(col driver.Column, dt string) (string, error) 
 	case "rowversion":
 		return "BINARY(8)", nil
 	case "datetime", "datetime2", "smalldatetime", "timestamp", "timestamp without time zone", "timestamptz", "datetimeoffset", "timestamp with time zone":
-		return "DATETIME(6)", nil
+		return mysqlFspType("DATETIME", col, 6), nil
 	case "date":
 		return "DATE", nil
 	case "time", "time without time zone", "time with time zone":
-		return "TIME", nil
+		return mysqlFspType("TIME", col, 0), nil
 	case "decimal", "numeric", "number":
 		return mysqlUnsignedType(decimalType("DECIMAL", col), col), nil
 	case "money":
@@ -788,6 +788,54 @@ func sizedTypeCapped(name string, length, max int, unbounded string) string {
 		return fmt.Sprintf("%s(%s)", name, unbounded)
 	}
 	return sizedType(name, length, unbounded)
+}
+
+// fspType renders a datetime/time type with the source's fractional-seconds
+// precision when known (#88), clamped to the target's maximum; unknown
+// precision keeps the bare type (target default).
+func fspType(name string, col driver.Column, max int) string {
+	if col.DatetimePrecision == nil || *col.DatetimePrecision < 0 {
+		return name
+	}
+	p := *col.DatetimePrecision
+	if p > max {
+		p = max
+	}
+	return fmt.Sprintf("%s(%d)", name, p)
+}
+
+// mysqlFspType is fspType for MySQL (max fsp 6), with a default precision for
+// unknown sources — 6 for DATETIME (the pre-#88 behavior), 0 for TIME. fsp 0
+// renders bare (DATETIME == DATETIME(0)).
+func mysqlFspType(name string, col driver.Column, def int) string {
+	p := def
+	if col.DatetimePrecision != nil && *col.DatetimePrecision >= 0 {
+		p = *col.DatetimePrecision
+		if p > 6 {
+			p = 6
+		}
+	}
+	if p == 0 {
+		return name
+	}
+	return fmt.Sprintf("%s(%d)", name, p)
+}
+
+// mysqlNowDefault renders the CURRENT_TIMESTAMP default with the same fsp the
+// column type will carry — MySQL rejects a default whose fsp differs from the
+// column's.
+func mysqlNowDefault(col driver.Column) string {
+	p := 6
+	if col.DatetimePrecision != nil && *col.DatetimePrecision >= 0 {
+		p = *col.DatetimePrecision
+		if p > 6 {
+			p = 6
+		}
+	}
+	if p == 0 {
+		return "CURRENT_TIMESTAMP"
+	}
+	return fmt.Sprintf("CURRENT_TIMESTAMP(%d)", p)
 }
 
 func decimalType(name string, col driver.Column) string {

--- a/internal/ddl/renderer_fsp_test.go
+++ b/internal/ddl/renderer_fsp_test.go
@@ -1,0 +1,65 @@
+package ddl
+
+import (
+	"testing"
+
+	"smt/internal/driver"
+)
+
+func intp(v int) *int { return &v }
+
+// #88 — fractional-seconds precision renders on every target when known and
+// keeps the pre-#88 defaults when unknown.
+func TestColumnType_DatetimePrecision(t *testing.T) {
+	mssql, _ := NewRenderer("mssql", "dbo", "fail")
+	mysql, _ := NewRenderer("mysql", "crm", "fail")
+	cases := []struct {
+		r    Renderer
+		col  driver.Column
+		want string
+	}{
+		{mssql, driver.Column{DataType: "datetime2", DatetimePrecision: intp(3)}, "DATETIME2(3)"},
+		{mssql, driver.Column{DataType: "datetime2"}, "DATETIME2"},
+		{mssql, driver.Column{DataType: "datetimeoffset", DatetimePrecision: intp(0)}, "DATETIMEOFFSET(0)"},
+		{mssql, driver.Column{DataType: "time", DatetimePrecision: intp(3)}, "TIME(3)"},
+		{mysql, driver.Column{DataType: "datetime", DatetimePrecision: intp(0)}, "DATETIME"},
+		{mysql, driver.Column{DataType: "datetime", DatetimePrecision: intp(3)}, "DATETIME(3)"},
+		{mysql, driver.Column{DataType: "datetime"}, "DATETIME(6)"},
+		// mssql datetime2(7) clamps to MySQL's max of 6
+		{mysql, driver.Column{DataType: "datetime2", DatetimePrecision: intp(7)}, "DATETIME(6)"},
+		{mysql, driver.Column{DataType: "time", DatetimePrecision: intp(3)}, "TIME(3)"},
+		{mysql, driver.Column{DataType: "time"}, "TIME"},
+	}
+	for _, tc := range cases {
+		got, err := tc.r.ColumnType(tc.col)
+		if err != nil {
+			t.Fatalf("ColumnType(%+v): %v", tc.col, err)
+		}
+		if got != tc.want {
+			t.Errorf("ColumnType(%s, %s fsp=%v) = %q, want %q", tc.r.Target(), tc.col.DataType, tc.col.DatetimePrecision, got, tc.want)
+		}
+	}
+}
+
+// #88 — MySQL rejects a CURRENT_TIMESTAMP default whose fsp differs from the
+// column's, so the rendered default must track the column precision.
+func TestColumnDefault_MySQLNowTracksColumnFsp(t *testing.T) {
+	r, _ := NewRenderer("mysql", "crm", "fail")
+	cases := []struct {
+		col  driver.Column
+		want string
+	}{
+		{driver.Column{DataType: "datetime", DatetimePrecision: intp(0), DefaultExpression: "CURRENT_TIMESTAMP"}, "CURRENT_TIMESTAMP"},
+		{driver.Column{DataType: "datetime", DatetimePrecision: intp(3), DefaultExpression: "now()"}, "CURRENT_TIMESTAMP(3)"},
+		{driver.Column{DataType: "datetime", DefaultExpression: "getdate()"}, "CURRENT_TIMESTAMP(6)"},
+	}
+	for _, tc := range cases {
+		got, err := r.ColumnDefault(tc.col)
+		if err != nil {
+			t.Fatalf("ColumnDefault: %v", err)
+		}
+		if got != tc.want {
+			t.Errorf("ColumnDefault(fsp=%v) = %q, want %q", tc.col.DatetimePrecision, got, tc.want)
+		}
+	}
+}

--- a/internal/driver/mssql/reader.go
+++ b/internal/driver/mssql/reader.go
@@ -221,6 +221,7 @@ func (r *Reader) loadColumns(ctx context.Context, t *driver.Table) error {
 			ISNULL(CHARACTER_MAXIMUM_LENGTH, 0),
 			ISNULL(NUMERIC_PRECISION, 0),
 			ISNULL(NUMERIC_SCALE, 0),
+			ISNULL(DATETIME_PRECISION, -1),
 			CASE WHEN IS_NULLABLE = 'YES' THEN 1 ELSE 0 END,
 			COLUMNPROPERTY(OBJECT_ID(TABLE_SCHEMA + '.' + TABLE_NAME), COLUMN_NAME, 'IsIdentity'),
 			ORDINAL_POSITION,
@@ -237,9 +238,13 @@ func (r *Reader) loadColumns(ctx context.Context, t *driver.Table) error {
 	t.Columns = nil
 	for rows.Next() {
 		var col driver.Column
-		var isNullable, isIdentity int
-		if err := rows.Scan(&col.Name, &col.DataType, &col.MaxLength, &col.Precision, &col.Scale, &isNullable, &isIdentity, &col.OrdinalPos, &col.DefaultExpression); err != nil {
+		var isNullable, isIdentity, dtPrecision int
+		if err := rows.Scan(&col.Name, &col.DataType, &col.MaxLength, &col.Precision, &col.Scale, &dtPrecision, &isNullable, &isIdentity, &col.OrdinalPos, &col.DefaultExpression); err != nil {
 			return fmt.Errorf("scanning column: %w", err)
+		}
+		if dtPrecision >= 0 {
+			p := dtPrecision
+			col.DatetimePrecision = &p
 		}
 		col.IsNullable = isNullable == 1
 		col.IsIdentity = isIdentity == 1

--- a/internal/driver/mysql/reader.go
+++ b/internal/driver/mysql/reader.go
@@ -329,6 +329,7 @@ func (r *Reader) loadColumns(ctx context.Context, t *driver.Table) error {
 			COALESCE(CHARACTER_MAXIMUM_LENGTH, 0),
 			COALESCE(NUMERIC_PRECISION, 0),
 			COALESCE(NUMERIC_SCALE, 0),
+			COALESCE(DATETIME_PRECISION, -1),
 			CASE WHEN IS_NULLABLE = 'YES' THEN true ELSE false END,
 			CASE WHEN EXTRA LIKE '%auto_increment%' THEN true ELSE false END,
 			ORDINAL_POSITION,
@@ -347,10 +348,15 @@ func (r *Reader) loadColumns(ctx context.Context, t *driver.Table) error {
 	for rows.Next() {
 		var c driver.Column
 		var columnType, extra, generationExpr string
+		var dtPrecision int
 		if err := rows.Scan(&c.Name, &c.DataType, &columnType, &c.MaxLength, &c.Precision, &c.Scale,
-			&c.IsNullable, &c.IsIdentity, &c.OrdinalPos,
+			&dtPrecision, &c.IsNullable, &c.IsIdentity, &c.OrdinalPos,
 			&c.DefaultExpression, &extra, &generationExpr); err != nil {
 			return fmt.Errorf("scanning column: %w", err)
+		}
+		if dtPrecision >= 0 {
+			p := dtPrecision
+			c.DatetimePrecision = &p
 		}
 		if strings.EqualFold(c.DataType, "enum") || strings.EqualFold(c.DataType, "set") {
 			values, err := parseEnumSetValues(columnType)

--- a/internal/driver/postgres/deterministic.go
+++ b/internal/driver/postgres/deterministic.go
@@ -311,17 +311,17 @@ func (r deterministicDDL) columnType(col driver.Column) (string, error) {
 	case "text", "ntext", "tinytext", "mediumtext", "longtext":
 		typ = "text"
 	case "datetime", "datetime2", "smalldatetime", "timestamp":
-		typ = "timestamp without time zone"
+		typ = pgFspType("timestamp", col, "without time zone")
 	case "rowversion":
 		// SQL Server's rowversion (reported by old snapshots as "timestamp")
 		// is an opaque 8-byte binary counter.
 		typ = "bytea"
 	case "datetimeoffset", "timestamptz", "timestamp with time zone":
-		typ = "timestamp with time zone"
+		typ = pgFspType("timestamp", col, "with time zone")
 	case "date":
 		typ = "date"
 	case "time":
-		typ = "time"
+		typ = pgFspType("time", col, "")
 	case "decimal", "numeric", "number":
 		if col.Precision > 0 {
 			typ = fmt.Sprintf("numeric(%d,%d)", col.Precision, col.Scale)
@@ -738,6 +738,24 @@ func isTextualPGType(colType string) bool {
 	return strings.HasPrefix(colType, "character varying") ||
 		strings.HasPrefix(colType, "character(") ||
 		colType == "text"
+}
+
+// pgFspType renders a timestamp/time type with the source's
+// fractional-seconds precision when known (#88), clamped to PostgreSQL's
+// maximum of 6; unknown precision keeps the bare type.
+func pgFspType(base string, col driver.Column, suffix string) string {
+	out := base
+	if col.DatetimePrecision != nil && *col.DatetimePrecision >= 0 {
+		p := *col.DatetimePrecision
+		if p > 6 {
+			p = 6
+		}
+		out = fmt.Sprintf("%s(%d)", base, p)
+	}
+	if suffix != "" {
+		out += " " + suffix
+	}
+	return out
 }
 
 func isTextualSourceType(dataType string) bool {

--- a/internal/driver/postgres/deterministic_fixes_test.go
+++ b/internal/driver/postgres/deterministic_fixes_test.go
@@ -40,3 +40,28 @@ func TestDeterministicDefaultBareWordStillQuoted(t *testing.T) {
 		t.Fatalf("bare word default rendered as %q, want 'active'", got)
 	}
 }
+
+func intp(v int) *int { return &v }
+
+// #88 — fsp renders on pg targets when known; bare otherwise.
+func TestDeterministicDatetimePrecision(t *testing.T) {
+	renderer := newDeterministicDDL()
+	cases := []struct {
+		col  driver.Column
+		want string
+	}{
+		{driver.Column{Name: "a", DataType: "datetime2", DatetimePrecision: intp(3)}, "timestamp(3) without time zone"},
+		{driver.Column{Name: "b", DataType: "datetime2"}, "timestamp without time zone"},
+		{driver.Column{Name: "c", DataType: "datetimeoffset", DatetimePrecision: intp(7)}, "timestamp(6) with time zone"},
+		{driver.Column{Name: "d", DataType: "time", DatetimePrecision: intp(0)}, "time(0)"},
+	}
+	for _, tc := range cases {
+		got, err := renderer.columnType(tc.col)
+		if err != nil {
+			t.Fatalf("columnType(%+v): %v", tc.col, err)
+		}
+		if got != tc.want {
+			t.Errorf("columnType(%s fsp=%v) = %q, want %q", tc.col.DataType, tc.col.DatetimePrecision, got, tc.want)
+		}
+	}
+}

--- a/internal/driver/postgres/reader.go
+++ b/internal/driver/postgres/reader.go
@@ -259,6 +259,7 @@ func (r *Reader) loadColumnsSQL(ctx context.Context) string {
 			COALESCE(character_maximum_length, 0),
 			COALESCE(numeric_precision, 0),
 			COALESCE(numeric_scale, 0),
+			COALESCE(datetime_precision, -1),
 			CASE WHEN is_nullable = 'YES' THEN true ELSE false END,
 			CASE WHEN is_identity = 'YES' OR column_default LIKE 'nextval%' THEN true ELSE false END,
 			ordinal_position,
@@ -276,6 +277,7 @@ func (r *Reader) loadColumnsSQL(ctx context.Context) string {
 			COALESCE(character_maximum_length, 0),
 			COALESCE(numeric_precision, 0),
 			COALESCE(numeric_scale, 0),
+			COALESCE(datetime_precision, -1),
 			CASE WHEN is_nullable = 'YES' THEN true ELSE false END,
 			CASE WHEN is_identity = 'YES' OR column_default LIKE 'nextval%' THEN true ELSE false END,
 			ordinal_position,
@@ -293,6 +295,7 @@ func (r *Reader) loadColumnsSQL(ctx context.Context) string {
 			COALESCE(character_maximum_length, 0),
 			COALESCE(numeric_precision, 0),
 			COALESCE(numeric_scale, 0),
+			COALESCE(datetime_precision, -1),
 			CASE WHEN is_nullable = 'YES' THEN true ELSE false END,
 			CASE WHEN column_default LIKE 'nextval%' THEN true ELSE false END,
 			ordinal_position,
@@ -339,10 +342,15 @@ func (r *Reader) loadColumns(ctx context.Context, t *driver.Table) error {
 
 	for rows.Next() {
 		var c driver.Column
+		var dtPrecision int
 		if err := rows.Scan(&c.Name, &c.DataType, &c.MaxLength, &c.Precision, &c.Scale,
-			&c.IsNullable, &c.IsIdentity, &c.OrdinalPos,
+			&dtPrecision, &c.IsNullable, &c.IsIdentity, &c.OrdinalPos,
 			&c.DefaultExpression, &c.IsComputed, &c.ComputedExpression); err != nil {
 			return fmt.Errorf("scanning column: %w", err)
+		}
+		if dtPrecision >= 0 {
+			p := dtPrecision
+			c.DatetimePrecision = &p
 		}
 		// PG generated columns are always STORED; reflect that.
 		if c.IsComputed {

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -112,6 +112,7 @@ type Column struct {
 	MaxLength          int      `json:"max_length"`
 	Precision          int      `json:"precision"`
 	Scale              int      `json:"scale"`
+	DatetimePrecision  *int     `json:"datetime_precision,omitempty"` // fractional-seconds precision for datetime/time-class columns; nil = unknown (pre-v3 snapshots)
 	IsNullable         bool     `json:"is_nullable"`
 	IsIdentity         bool     `json:"is_identity"`
 	IsUnsigned         bool     `json:"is_unsigned,omitempty"` // true for MySQL unsigned numeric columns

--- a/internal/schemadiff/compat_test.go
+++ b/internal/schemadiff/compat_test.go
@@ -225,3 +225,38 @@ func TestOrderTablesForDrop_SelfReferenceIsNotACycle(t *testing.T) {
 		t.Fatalf("self-reference treated as cycle: %+v", actions)
 	}
 }
+
+func intp(v int) *int { return &v }
+
+// #88/#78 — pre-v3 snapshots lack DatetimePrecision; backfill prevents
+// spurious diffs, while v3 snapshots still detect real fsp changes.
+func TestCompute_DatetimePrecisionVersioning(t *testing.T) {
+	oldSnap := Snapshot{
+		Version: 2,
+		Tables: []driver.Table{{
+			Name:    "events",
+			Columns: []driver.Column{{Name: "at", DataType: "datetime"}},
+		}},
+	}
+	curr := Snapshot{
+		Version: CurrentSnapshotVersion,
+		Tables: []driver.Table{{
+			Name:    "events",
+			Columns: []driver.Column{{Name: "at", DataType: "datetime", DatetimePrecision: intp(3)}},
+		}},
+	}
+	if d := Compute(oldSnap, curr); !d.IsEmpty() {
+		t.Fatalf("v2 snapshot produced spurious fsp diff: %+v", d.ChangedTables)
+	}
+
+	prev := Snapshot{
+		Version: CurrentSnapshotVersion,
+		Tables: []driver.Table{{
+			Name:    "events",
+			Columns: []driver.Column{{Name: "at", DataType: "datetime", DatetimePrecision: intp(0)}},
+		}},
+	}
+	if d := Compute(prev, curr); len(d.ChangedTables) != 1 {
+		t.Fatalf("real fsp change not detected: %+v", d)
+	}
+}

--- a/internal/schemadiff/diff.go
+++ b/internal/schemadiff/diff.go
@@ -343,6 +343,9 @@ func backfillPreVersionFields(prev, curr Snapshot) Snapshot {
 					cols[ci].EnumValues = cc.EnumValues
 				}
 			}
+			if prev.Version < 3 {
+				cols[ci].DatetimePrecision = cc.DatetimePrecision
+			}
 		}
 		tables[ti].Columns = cols
 	}
@@ -416,6 +419,7 @@ func columnsEqual(a, b driver.Column) bool {
 		a.MaxLength == b.MaxLength &&
 		a.Precision == b.Precision &&
 		a.Scale == b.Scale &&
+		equalIntPtr(a.DatetimePrecision, b.DatetimePrecision) &&
 		a.IsNullable == b.IsNullable &&
 		a.SRID == b.SRID &&
 		a.IsUnsigned == b.IsUnsigned &&
@@ -425,6 +429,13 @@ func columnsEqual(a, b driver.Column) bool {
 		a.IsComputed == b.IsComputed &&
 		strings.TrimSpace(a.ComputedExpression) == strings.TrimSpace(b.ComputedExpression) &&
 		a.ComputedPersisted == b.ComputedPersisted
+}
+
+func equalIntPtr(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 func stringSlicesEqual(a, b []string) bool {

--- a/internal/schemadiff/snapshot.go
+++ b/internal/schemadiff/snapshot.go
@@ -23,7 +23,8 @@ import (
 // Version history:
 //   - 0/1: original format (a snapshot without a version field decodes as 0)
 //   - 2: Column gained IsUnsigned, EnumValues, OnUpdateExpression
-const CurrentSnapshotVersion = 2
+//   - 3: Column gained DatetimePrecision
+const CurrentSnapshotVersion = 3
 
 // Snapshot is a serializable point-in-time view of a source schema.
 type Snapshot struct {


### PR DESCRIPTION
Fifth PR in the post-#76/#77 review series. Resolves #88.

## What
- `driver.Column.DatetimePrecision *int` (nil = unknown), captured by all three readers via `DATETIME_PRECISION` (`ISNULL/COALESCE(..., -1)` → nil).
- Renderers emit the precision when known, clamped to the target's max:
  - mssql: `DATETIME2(N)`, `DATETIMEOFFSET(N)`, `TIME(N)` (max 7)
  - mysql: `DATETIME(N)`, `TIME(N)` (max 6; fsp 0 renders bare — identical semantics)
  - postgres: `timestamp(N) without/with time zone`, `time(N)` (max 6)
- Unknown precision keeps the previous defaults (bare `DATETIME2`, `DATETIME(6)`, bare `timestamp`), so old snapshots and hand-built columns behave exactly as before.
- **Coupling fix**: MySQL `CURRENT_TIMESTAMP` defaults now track the column fsp. MySQL hard-rejects a default whose fsp differs from the column's, so rendering `DATETIME(0) DEFAULT CURRENT_TIMESTAMP(6)` would have failed.
- Snapshot version → 3 with the #78 backfill mechanism extended, so pre-upgrade baselines don't diff every datetime column.

## Notes
- Matrix pass criterion 2 now holds for datetime/time columns (was: every datetime landed as fsp-6/7 regardless of source).
- `ai_verify`'s deterministic comparator class-skips precision for datetime classes (same-fixed-class rule), so no false flags from the new output; extracting fsp in the parse step for a tighter criterion-2 check is a follow-up.
- CRM fixtures with non-default fsp columns are tracked by #46.

## Tests
Renderer fsp matrix (known/unknown/clamp/zero), MySQL default-fsp coupling, pg fsp rendering, snapshot v2→v3 backfill + real-change detection. `go test ./... -short` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)