### PR TITLE
Map pg timestamptz to DATETIMEOFFSET on MSSQL targets

### DIFF
--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -586,9 +586,9 @@ func (r Renderer) mssqlColumnType(col driver.Column, dt string) (string, error) 
 		return sizedType("NVARCHAR", setStringLength(col), "255"), nil
 	case "rowversion":
 		return "ROWVERSION", nil
-	case "datetime", "datetime2", "smalldatetime", "timestamp", "timestamp without time zone", "timestamptz":
+	case "datetime", "datetime2", "smalldatetime", "timestamp", "timestamp without time zone":
 		return fspType("DATETIME2", col, 7), nil
-	case "datetimeoffset", "timestamp with time zone":
+	case "datetimeoffset", "timestamptz", "timestamp with time zone":
 		return fspType("DATETIMEOFFSET", col, 7), nil
 	case "date":
 		return "DATE", nil

--- a/internal/ddl/renderer_fixes_test.go
+++ b/internal/ddl/renderer_fixes_test.go
@@ -228,3 +228,24 @@ func TestComputedColumn_MySQLStringConcatStillRewritten(t *testing.T) {
 		t.Fatalf("string concat not rewritten: %q", got)
 	}
 }
+
+// #100 — pg's timestamptz udt_name is TZ-aware and must land as
+// DATETIMEOFFSET on mssql targets, not naive DATETIME2.
+func TestColumnType_TimestamptzKeepsTZClassOnMSSQL(t *testing.T) {
+	r, _ := NewRenderer("mssql", "dbo", "fail")
+	p := 6
+	got, err := r.ColumnType(driver.Column{Name: "created_at", DataType: "timestamptz", DatetimePrecision: &p})
+	if err != nil {
+		t.Fatalf("ColumnType: %v", err)
+	}
+	if got != "DATETIMEOFFSET(6)" {
+		t.Fatalf("timestamptz = %q, want DATETIMEOFFSET(6)", got)
+	}
+	naive, err := r.ColumnType(driver.Column{Name: "created_at", DataType: "timestamp without time zone"})
+	if err != nil {
+		t.Fatalf("ColumnType: %v", err)
+	}
+	if naive != "DATETIME2" {
+		t.Fatalf("naive timestamp = %q, want DATETIME2", naive)
+	}
+}

--- a/internal/ddl/renderer_fixes_test.go
+++ b/internal/ddl/renderer_fixes_test.go
@@ -241,6 +241,13 @@ func TestColumnType_TimestamptzKeepsTZClassOnMSSQL(t *testing.T) {
 	if got != "DATETIMEOFFSET(6)" {
 		t.Fatalf("timestamptz = %q, want DATETIMEOFFSET(6)", got)
 	}
+	spelled, err := r.ColumnType(driver.Column{Name: "created_at", DataType: "timestamp with time zone"})
+	if err != nil {
+		t.Fatalf("ColumnType: %v", err)
+	}
+	if spelled != "DATETIMEOFFSET" {
+		t.Fatalf("timestamp with time zone = %q, want DATETIMEOFFSET", spelled)
+	}
 	naive, err := r.ColumnType(driver.Column{Name: "created_at", DataType: "timestamp without time zone"})
 	if err != nil {
 		t.Fatalf("ColumnType: %v", err)


### PR DESCRIPTION
Found running the CRM matrix end-to-end: pg→mssql landed every `timestamptz` column as naive `datetime2(6)` instead of `DATETIMEOFFSET(6)` — `timestamptz` (the udt_name the pg reader reports) sat in the wrong case list of `mssqlColumnType`, while the spelled-out `timestamp with time zone` was classified correctly. One-line move + regression test pinning both spellings.

Resolves #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)