### PR TITLE
Preserve MySQL TIMESTAMP and tinyint(1) on same-dialect migrations

### DIFF
--- a/cmd/smt/sync.go
+++ b/cmd/smt/sync.go
@@ -180,7 +180,12 @@ func runSync(c *cli.Context) error {
 	fmt.Printf("Diff: %s\n", diff.Summary())
 
 	logging.Info("rendering diff deterministically as %s SQL...", cfg.Target.Type)
-	plan, err := schemadiff.RenderDeterministicWithUnknownTypePolicy(diff, cfg.Target.Schema, cfg.Target.Type, cfg.SchemaGeneration.UnknownTypePolicy)
+	plan, err := schemadiff.RenderDeterministicWithOptions(diff, schemadiff.RenderOptions{
+		TargetSchema:      cfg.Target.Schema,
+		TargetDialect:     cfg.Target.Type,
+		SourceDialect:     cfg.Source.Type,
+		UnknownTypePolicy: cfg.SchemaGeneration.UnknownTypePolicy,
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -15,6 +15,7 @@ type Renderer struct {
 	target            string
 	schema            string
 	unknownTypePolicy string
+	source            string // canonical source dialect; empty = unknown (cross-dialect mappings only)
 }
 
 func NewRenderer(target, schema, unknownTypePolicy string) (Renderer, error) {
@@ -34,6 +35,16 @@ func NewRenderer(target, schema, unknownTypePolicy string) (Renderer, error) {
 }
 
 func (r Renderer) Target() string { return r.target }
+
+// WithSource returns a copy of the renderer that knows the source dialect.
+// Same-dialect runs use it to pass types through verbatim where the generic
+// cross-dialect mapping would lose semantics (e.g. MySQL TIMESTAMP's UTC
+// normalization, tinyint(1)'s boolean convention). An unrecognized or empty
+// source leaves cross-dialect behavior unchanged.
+func (r Renderer) WithSource(source string) Renderer {
+	r.source = canonicalTarget(source)
+	return r
+}
 
 func (r Renderer) CreateSchemaDDL() (string, error) {
 	schema := strings.TrimSpace(r.schema)
@@ -616,6 +627,9 @@ func (r Renderer) mssqlColumnType(col driver.Column, dt string) (string, error) 
 func (r Renderer) mysqlColumnType(col driver.Column, dt string) (string, error) {
 	switch dt {
 	case "tinyint":
+		if r.source == "mysql" && col.DisplayWidth == 1 {
+			return mysqlUnsignedType("TINYINT(1)", col), nil
+		}
 		return mysqlUnsignedType("TINYINT", col), nil
 	case "smallint", "int2":
 		return mysqlUnsignedType("SMALLINT", col), nil
@@ -640,7 +654,16 @@ func (r Renderer) mysqlColumnType(col driver.Column, dt string) (string, error) 
 		return "JSON", nil
 	case "rowversion":
 		return "BINARY(8)", nil
-	case "datetime", "datetime2", "smalldatetime", "timestamp", "timestamp without time zone", "timestamptz", "datetimeoffset", "timestamp with time zone":
+	case "timestamp":
+		// MySQL TIMESTAMP is UTC-normalized with session-tz conversion; a
+		// same-dialect run must keep it. For foreign sources "timestamp" is
+		// pg's naive datetime, where TIMESTAMP's 1970–2038 range and UTC
+		// normalization make DATETIME the right target.
+		if r.source == "mysql" {
+			return mysqlFspType("TIMESTAMP", col, 6), nil
+		}
+		return mysqlFspType("DATETIME", col, 6), nil
+	case "datetime", "datetime2", "smalldatetime", "timestamp without time zone", "timestamptz", "datetimeoffset", "timestamp with time zone":
 		return mysqlFspType("DATETIME", col, 6), nil
 	case "date":
 		return "DATE", nil

--- a/internal/ddl/renderer_source_dialect_test.go
+++ b/internal/ddl/renderer_source_dialect_test.go
@@ -1,0 +1,67 @@
+package ddl
+
+import (
+	"testing"
+
+	"smt/internal/driver"
+)
+
+// #101 — mysql→mysql round-trips must preserve TIMESTAMP (UTC-normalized,
+// session-tz conversion) and the tinyint(1) boolean convention verbatim.
+// Cross-dialect mappings stay unchanged: pg's naive "timestamp" still lands
+// as DATETIME, and DisplayWidth without a mysql source is ignored.
+func TestColumnType_MySQLSameDialectPassthrough(t *testing.T) {
+	base, _ := NewRenderer("mysql", "crm", "fail")
+	fromMySQL := base.WithSource("mysql")
+	fromMaria := base.WithSource("mariadb")
+	fromPG := base.WithSource("postgres")
+
+	cases := []struct {
+		name string
+		r    Renderer
+		col  driver.Column
+		want string
+	}{
+		{"mysql ts fsp0", fromMySQL, driver.Column{DataType: "timestamp", DatetimePrecision: intp(0)}, "TIMESTAMP"},
+		{"mysql ts fsp3", fromMySQL, driver.Column{DataType: "timestamp", DatetimePrecision: intp(3)}, "TIMESTAMP(3)"},
+		{"mariadb alias ts", fromMaria, driver.Column{DataType: "timestamp", DatetimePrecision: intp(6)}, "TIMESTAMP(6)"},
+		{"pg naive ts stays datetime", fromPG, driver.Column{DataType: "timestamp", DatetimePrecision: intp(3)}, "DATETIME(3)"},
+		{"unknown source ts stays datetime", base, driver.Column{DataType: "timestamp", DatetimePrecision: intp(3)}, "DATETIME(3)"},
+		{"mysql tinyint(1)", fromMySQL, driver.Column{DataType: "tinyint", DisplayWidth: 1}, "TINYINT(1)"},
+		{"mysql tinyint(1) unsigned", fromMySQL, driver.Column{DataType: "tinyint", DisplayWidth: 1, IsUnsigned: true}, "TINYINT(1) UNSIGNED"},
+		{"mysql tinyint plain", fromMySQL, driver.Column{DataType: "tinyint"}, "TINYINT"},
+		{"unknown source ignores width", base, driver.Column{DataType: "tinyint", DisplayWidth: 1}, "TINYINT"},
+	}
+	for _, tc := range cases {
+		got, err := tc.r.ColumnType(tc.col)
+		if err != nil {
+			t.Fatalf("%s: ColumnType(%+v): %v", tc.name, tc.col, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s: ColumnType = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// #101 — source awareness must not leak into non-mysql targets: a mysql
+// TIMESTAMP still maps by datetime class on mssql, and bit/bool sources
+// still map to TINYINT(1) on mysql regardless of source dialect.
+func TestColumnType_SourceDialectScopedToMySQLTarget(t *testing.T) {
+	mssql, _ := NewRenderer("mssql", "dbo", "fail")
+	got, err := mssql.WithSource("mysql").ColumnType(driver.Column{DataType: "timestamp", DatetimePrecision: intp(3)})
+	if err != nil {
+		t.Fatalf("ColumnType: %v", err)
+	}
+	if got != "DATETIME2(3)" {
+		t.Errorf("mssql target ColumnType = %q, want DATETIME2(3)", got)
+	}
+
+	mysql, _ := NewRenderer("mysql", "crm", "fail")
+	got, err = mysql.WithSource("postgres").ColumnType(driver.Column{DataType: "boolean"})
+	if err != nil {
+		t.Fatalf("ColumnType: %v", err)
+	}
+	if got != "TINYINT(1)" {
+		t.Errorf("pg boolean ColumnType = %q, want TINYINT(1)", got)
+	}
+}

--- a/internal/driver/mysql/reader.go
+++ b/internal/driver/mysql/reader.go
@@ -248,6 +248,15 @@ func isUnsignedColumnType(columnType string) bool {
 	return false
 }
 
+// isTinyint1ColumnType reports whether COLUMN_TYPE declares the tinyint(1)
+// boolean convention. Only width 1 matters: other display widths are
+// deprecated cosmetics (MySQL 8.0.17+), but tinyint(1) is what connectors and
+// ORMs treat as boolean, so a same-dialect migration must preserve it.
+func isTinyint1ColumnType(columnType string) bool {
+	first, _, _ := strings.Cut(strings.ToLower(strings.TrimSpace(columnType)), " ")
+	return first == "tinyint(1)"
+}
+
 func parseOnUpdateExpression(extra string) string {
 	lower := strings.ToLower(extra)
 	idx := strings.Index(lower, "on update ")
@@ -366,6 +375,9 @@ func (r *Reader) loadColumns(ctx context.Context, t *driver.Table) error {
 			c.EnumValues = values
 		}
 		c.IsUnsigned = isUnsignedColumnType(columnType)
+		if strings.EqualFold(c.DataType, "tinyint") && isTinyint1ColumnType(columnType) {
+			c.DisplayWidth = 1
+		}
 		c.OnUpdateExpression = parseOnUpdateExpression(extra)
 		if computed, persisted := parseGeneratedColumnExtra(extra); computed {
 			c.IsComputed = true

--- a/internal/driver/mysql/reader_test.go
+++ b/internal/driver/mysql/reader_test.go
@@ -99,3 +99,27 @@ func TestParseOnUpdateExpression(t *testing.T) {
 		}
 	}
 }
+
+// #101 — COLUMN_TYPE "tinyint(1)" is the boolean convention and must survive
+// a same-dialect round-trip; every other tinyint declaration is left alone.
+func TestIsTinyint1ColumnType(t *testing.T) {
+	tests := []struct {
+		columnType string
+		want       bool
+	}{
+		{"tinyint(1)", true},
+		{"TINYINT(1)", true},
+		{"tinyint(1) unsigned", true},
+		{"tinyint(1) unsigned zerofill", true},
+		{"tinyint", false},
+		{"tinyint(4)", false},
+		{"tinyint(3) unsigned", false},
+		{"smallint(1)", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		if got := isTinyint1ColumnType(tc.columnType); got != tc.want {
+			t.Errorf("isTinyint1ColumnType(%q) = %v, want %v", tc.columnType, got, tc.want)
+		}
+	}
+}

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -115,7 +115,8 @@ type Column struct {
 	DatetimePrecision  *int     `json:"datetime_precision,omitempty"` // fractional-seconds precision for datetime/time-class columns; nil = unknown (pre-v3 snapshots)
 	IsNullable         bool     `json:"is_nullable"`
 	IsIdentity         bool     `json:"is_identity"`
-	IsUnsigned         bool     `json:"is_unsigned,omitempty"` // true for MySQL unsigned numeric columns
+	IsUnsigned         bool     `json:"is_unsigned,omitempty"`   // true for MySQL unsigned numeric columns
+	DisplayWidth       int      `json:"display_width,omitempty"` // MySQL integer display width, captured only for tinyint(1) (the boolean convention); other widths are deprecated and intentionally not captured
 	OrdinalPos         int      `json:"ordinal_position"`
 	DefaultExpression  string   `json:"default_expression,omitempty"`   // raw default clause from source dialect (e.g. "((0))", "getutcdate()", "'pending'") — empty if no default
 	OnUpdateExpression string   `json:"on_update_expression,omitempty"` // raw MySQL ON UPDATE expression (e.g. "CURRENT_TIMESTAMP")

--- a/internal/orchestrator/ddl_plan.go
+++ b/internal/orchestrator/ddl_plan.go
@@ -138,6 +138,7 @@ func (o *Orchestrator) newCreateDDLRenderer() (createDDLRenderer, error) {
 	if err != nil {
 		return createDDLRenderer{}, err
 	}
+	ddlRenderer = ddlRenderer.WithSource(sourceType)
 
 	reviewEnabled := aiReviewEnabled(o.config)
 

--- a/internal/schemadiff/compat_test.go
+++ b/internal/schemadiff/compat_test.go
@@ -260,3 +260,36 @@ func TestCompute_DatetimePrecisionVersioning(t *testing.T) {
 		t.Fatalf("real fsp change not detected: %+v", d)
 	}
 }
+
+// #101 — pre-v4 snapshots lack DisplayWidth; backfill prevents spurious
+// diffs on tinyint(1) columns, while v4 snapshots still detect real changes.
+func TestCompute_DisplayWidthVersioning(t *testing.T) {
+	oldSnap := Snapshot{
+		Version: 3,
+		Tables: []driver.Table{{
+			Name:    "flags",
+			Columns: []driver.Column{{Name: "active", DataType: "tinyint"}},
+		}},
+	}
+	curr := Snapshot{
+		Version: CurrentSnapshotVersion,
+		Tables: []driver.Table{{
+			Name:    "flags",
+			Columns: []driver.Column{{Name: "active", DataType: "tinyint", DisplayWidth: 1}},
+		}},
+	}
+	if d := Compute(oldSnap, curr); !d.IsEmpty() {
+		t.Fatalf("v3 snapshot produced spurious display-width diff: %+v", d.ChangedTables)
+	}
+
+	prev := Snapshot{
+		Version: CurrentSnapshotVersion,
+		Tables: []driver.Table{{
+			Name:    "flags",
+			Columns: []driver.Column{{Name: "active", DataType: "tinyint"}},
+		}},
+	}
+	if d := Compute(prev, curr); len(d.ChangedTables) != 1 {
+		t.Fatalf("real display-width change not detected: %+v", d)
+	}
+}

--- a/internal/schemadiff/diff.go
+++ b/internal/schemadiff/diff.go
@@ -346,6 +346,9 @@ func backfillPreVersionFields(prev, curr Snapshot) Snapshot {
 			if prev.Version < 3 {
 				cols[ci].DatetimePrecision = cc.DatetimePrecision
 			}
+			if prev.Version < 4 {
+				cols[ci].DisplayWidth = cc.DisplayWidth
+			}
 		}
 		tables[ti].Columns = cols
 	}
@@ -423,6 +426,7 @@ func columnsEqual(a, b driver.Column) bool {
 		a.IsNullable == b.IsNullable &&
 		a.SRID == b.SRID &&
 		a.IsUnsigned == b.IsUnsigned &&
+		a.DisplayWidth == b.DisplayWidth &&
 		stringSlicesEqual(a.EnumValues, b.EnumValues) &&
 		strings.TrimSpace(a.DefaultExpression) == strings.TrimSpace(b.DefaultExpression) &&
 		strings.TrimSpace(a.OnUpdateExpression) == strings.TrimSpace(b.OnUpdateExpression) &&

--- a/internal/schemadiff/render_deterministic.go
+++ b/internal/schemadiff/render_deterministic.go
@@ -15,11 +15,27 @@ func RenderDeterministic(diff Diff, targetSchema, targetDialect string) (Plan, e
 }
 
 func RenderDeterministicWithUnknownTypePolicy(diff Diff, targetSchema, targetDialect, unknownTypePolicy string) (Plan, error) {
+	return RenderDeterministicWithOptions(diff, RenderOptions{
+		TargetSchema:      targetSchema,
+		TargetDialect:     targetDialect,
+		UnknownTypePolicy: unknownTypePolicy,
+	})
+}
+
+// RenderOptions parameterizes deterministic plan rendering.
+type RenderOptions struct {
+	TargetSchema      string
+	TargetDialect     string
+	SourceDialect     string // enables same-dialect type passthrough in the renderer; empty = cross-dialect mappings only
+	UnknownTypePolicy string
+}
+
+func RenderDeterministicWithOptions(diff Diff, opts RenderOptions) (Plan, error) {
 	if diff.IsEmpty() {
 		return Plan{}, nil
 	}
 
-	renderer, err := newDeterministicRenderer(targetDialect, targetSchema, unknownTypePolicy)
+	renderer, err := newDeterministicRenderer(opts)
 	if err != nil {
 		return Plan{}, err
 	}
@@ -31,11 +47,12 @@ type deterministicRenderer struct {
 	renderer ddl.Renderer
 }
 
-func newDeterministicRenderer(targetDialect, targetSchema, unknownTypePolicy string) (deterministicRenderer, error) {
-	r, err := ddl.NewRenderer(targetDialect, targetSchema, unknownTypePolicy)
+func newDeterministicRenderer(opts RenderOptions) (deterministicRenderer, error) {
+	r, err := ddl.NewRenderer(opts.TargetDialect, opts.TargetSchema, opts.UnknownTypePolicy)
 	if err != nil {
 		return deterministicRenderer{}, err
 	}
+	r = r.WithSource(opts.SourceDialect)
 	return deterministicRenderer{target: r.Target(), renderer: r}, nil
 }
 

--- a/internal/schemadiff/snapshot.go
+++ b/internal/schemadiff/snapshot.go
@@ -24,7 +24,8 @@ import (
 //   - 0/1: original format (a snapshot without a version field decodes as 0)
 //   - 2: Column gained IsUnsigned, EnumValues, OnUpdateExpression
 //   - 3: Column gained DatetimePrecision
-const CurrentSnapshotVersion = 3
+//   - 4: Column gained DisplayWidth (tinyint(1) boolean convention)
+const CurrentSnapshotVersion = 4
 
 // Snapshot is a serializable point-in-time view of a source schema.
 type Snapshot struct {


### PR DESCRIPTION
## Summary
- Plumb the source dialect into `ddl.Renderer` (`WithSource`) so same-dialect runs can pass types through verbatim where the generic cross-dialect mapping loses semantics
- mysql→mysql now preserves `TIMESTAMP(p)` (UTC-normalized, session-tz conversion) instead of rewriting it to `DATETIME(p)`; pg sources still map `timestamp` → `DATETIME` since pg's naive type shares the name
- The mysql reader captures the `tinyint(1)` boolean convention from `COLUMN_TYPE` into a new `Column.DisplayWidth` field (set only for width 1 — other display widths are deprecated cosmetics); mysql→mysql renders `TINYINT(1)` verbatim
- Snapshot version 3→4 with backfill so pre-v4 snapshots don't emit spurious tinyint ALTERs
- `schemadiff.RenderOptions` added so sync passes the source dialect without breaking the existing exported render functions

Fixes #101.

## Test plan
- [x] `internal/ddl` unit tests: passthrough cases (fsp variants, unsigned, mariadb alias), cross-dialect unchanged (pg→mysql, unknown source, mssql target)
- [x] `internal/driver/mysql` unit test for the `COLUMN_TYPE` tinyint(1) parser
- [x] `internal/schemadiff` versioning test: v3 snapshot backfill suppresses spurious diff, v4→v4 still detects a real change
- [x] `go test ./... -short` green, `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)