### PR TITLE
Drop un-configured render concurrency to 2 when AI review is on (#54)

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -32,6 +32,9 @@ ai_review:
   enabled: false                       # optional review of deterministic DDL
   mode: warn                           # warn | fail
   # model: strong-reviewer             # provider entry in ~/.secrets/smt-config.yaml
+  # Note: with review enabled the un-configured render fan-out drops from 8
+  # to 2 so cold-cache runs stay under provider rate limits (#54). Set
+  # migration.ai_concurrency explicitly to override.
 
 profile:
   name: example

--- a/internal/orchestrator/phases.go
+++ b/internal/orchestrator/phases.go
@@ -30,6 +30,13 @@ import (
 // schemas (try 16-32) or for local LM Studio / Ollama (set to 1).
 const defaultAIConcurrency = 8
 
+// defaultAIReviewConcurrency is the un-configured fan-out when AI review is
+// enabled. Cold-cache verify-on runs make 1-2 provider calls per rendered
+// object; concurrency 8 pushed past Anthropic's per-org throughput limit
+// and surfaced as sustained 529s partway through matrix runs (#54).
+// Empirically 2 stays under the limit; warm-cache re-runs are unaffected.
+const defaultAIReviewConcurrency = 2
+
 // runParallel calls fn concurrently for each item in items, with at
 // most n calls in flight at once. First non-nil return cancels the
 // rest via the shared context. Same error semantics as the previous
@@ -174,6 +181,16 @@ func (o *Orchestrator) aiConcurrency() int {
 	n := o.config.Migration.AIConcurrency
 	if n <= 0 {
 		n = defaultAIConcurrency
+		// With AI review enabled every rendered object costs an AI call
+		// during the render fan-out, and reviewer-driven retries multiply
+		// that further. Eight parallel renderers against one provider
+		// rate-limit pool is how the #54 matrix run hit sustained 529s,
+		// so the un-configured default drops to 2 when review is on. An
+		// explicit ai_concurrency always passes through — the user opted
+		// into that number.
+		if aiReviewEnabled(o.config) {
+			n = defaultAIReviewConcurrency
+		}
 	}
 	return n
 }

--- a/internal/orchestrator/phases_test.go
+++ b/internal/orchestrator/phases_test.go
@@ -163,3 +163,35 @@ func TestMatchesAny_InvalidGlobIsTreatedAsNoMatch(t *testing.T) {
 		t.Errorf("malformed glob should not match")
 	}
 }
+
+// #54 — verify-on cold-cache runs at concurrency 8 exhaust the provider's
+// rate-limit pool (sustained 529s). The un-configured default must drop to
+// defaultAIReviewConcurrency when review is on; explicit user values pass
+// through unchanged in both postures.
+func TestAIConcurrency_ReviewAwareDefault(t *testing.T) {
+	enabled, disabled := true, false
+	cases := []struct {
+		name      string
+		userValue int
+		review    *bool
+		want      int
+	}{
+		{"unset, review off", 0, &disabled, defaultAIConcurrency},
+		{"unset, review omitted", 0, nil, defaultAIConcurrency},
+		{"unset, review on", 0, &enabled, defaultAIReviewConcurrency},
+		{"explicit, review off", 16, &disabled, 16},
+		{"explicit, review on", 16, &enabled, 16},
+		{"explicit 1, review on", 1, &enabled, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Migration.AIConcurrency = tc.userValue
+			cfg.AIReview.Enabled = tc.review
+			o := &Orchestrator{config: cfg}
+			if got := o.aiConcurrency(); got != tc.want {
+				t.Errorf("aiConcurrency() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `aiConcurrency()` defaults to `2` (new `defaultAIReviewConcurrency`) when `ai_review.enabled: true` and the user hasn't set `migration.ai_concurrency` — the posture that produced sustained 529s in the #54 matrix run at the old default of 8
- Explicit `ai_concurrency` values always pass through, review on or off
- Interaction documented in `config.yaml.example`

Closes #54.

## Test plan
- [x] Unit test covers all six branches (unset/explicit × review off/omitted/on)
- [x] `go test ./... -short` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)