### PR TITLE
Stop downgrading LOB capacity on MySQL targets (#108)

### DIFF
--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -649,6 +649,13 @@ func (r Renderer) mysqlColumnType(col driver.Column, dt string) (string, error) 
 		}
 		return sizedType("CHAR", col.MaxLength, "1"), nil
 	case "text", "ntext", "tinytext", "mediumtext", "longtext":
+		// "text" is dialect-ambiguous: MySQL's 64KiB tier vs the unbounded
+		// LOB of pg (1GB) and legacy mssql (2GB). Same-dialect keeps the
+		// tier verbatim; foreign unbounded sources need LONGTEXT to avoid
+		// a silent capacity downgrade (#108).
+		if dt == "text" && r.source != "mysql" {
+			return "LONGTEXT", nil
+		}
 		return mysqlTextType(dt), nil
 	case "json", "jsonb", "array", "_text", "text[]", "_varchar", "varchar[]", "_bpchar", "bpchar[]", "_int2", "int2[]", "_int4", "int4[]", "_int8", "int8[]", "_uuid", "uuid[]":
 		return "JSON", nil
@@ -683,13 +690,21 @@ func (r Renderer) mysqlColumnType(col driver.Column, dt string) (string, error) 
 		return "CHAR(36)", nil
 	case "varbinary", "binary", "bytea":
 		// Unbounded sources (pg bytea reports 0, mssql varbinary(max) -1)
-		// must not truncate to a sized VARBINARY.
-		if col.MaxLength <= 0 || col.MaxLength > 65535 {
-			return "BLOB", nil
+		// hold up to 1-2GB — only LONGBLOB doesn't lose capacity. Sized
+		// sources past VARBINARY's 65535-byte ceiling fit MEDIUMBLOB.
+		if col.MaxLength <= 0 {
+			return "LONGBLOB", nil
+		}
+		if col.MaxLength > 65535 {
+			return "MEDIUMBLOB", nil
 		}
 		return fmt.Sprintf("VARBINARY(%d)", col.MaxLength), nil
-	case "image", "blob", "tinyblob", "mediumblob", "longblob":
-		return "BLOB", nil
+	case "image":
+		// MSSQL IMAGE holds 2GB; BLOB (64KiB) would silently truncate.
+		return "LONGBLOB", nil
+	case "blob", "tinyblob", "mediumblob", "longblob":
+		// MySQL-only names: preserve the tier verbatim.
+		return strings.ToUpper(dt), nil
 	case "enum":
 		return r.enumSetType("ENUM", col)
 	case "set":
@@ -877,16 +892,21 @@ func mysqlUnsignedType(base string, col driver.Column) string {
 }
 
 func mysqlVarcharType(length int) string {
-	if length == -1 {
+	// Unbounded sources (mssql MAX = -1, pg unconstrained varchar = 0)
+	// hold up to 1-2GB — only LONGTEXT doesn't lose capacity.
+	if length <= 0 {
 		return "LONGTEXT"
 	}
-	if length <= 0 {
-		return "TEXT"
-	}
 	// 16383 is the longest VARCHAR that fits MySQL's 65535-byte row limit
-	// under utf8mb4 (the charset our CREATE TABLE emits).
+	// under utf8mb4 (the charset our CREATE TABLE emits). Past it, pick the
+	// smallest text tier whose BYTE capacity covers the worst case of 4
+	// bytes per character: TEXT (64KiB) can hold only 16383 such chars, so
+	// the next safe tier is MEDIUMTEXT (16MiB, ~4.19M chars).
+	if length > 16777215/4 {
+		return "LONGTEXT"
+	}
 	if length > 16383 {
-		return "TEXT"
+		return "MEDIUMTEXT"
 	}
 	return fmt.Sprintf("VARCHAR(%d)", length)
 }

--- a/internal/ddl/renderer_fixes_test.go
+++ b/internal/ddl/renderer_fixes_test.go
@@ -160,14 +160,14 @@ func TestColumnType_LengthClamping(t *testing.T) {
 		{mssql, driver.Column{DataType: "char", MaxLength: 9000}, "VARCHAR(MAX)"},
 		{mssql, driver.Column{DataType: "nchar", MaxLength: 5000}, "NVARCHAR(MAX)"},
 		{mssql, driver.Column{DataType: "varbinary", MaxLength: 9000}, "VARBINARY(MAX)"},
-		{mysql, driver.Column{DataType: "varchar", MaxLength: 20000}, "TEXT"},
+		{mysql, driver.Column{DataType: "varchar", MaxLength: 20000}, "MEDIUMTEXT"},
 		{mysql, driver.Column{DataType: "varchar", MaxLength: 16383}, "VARCHAR(16383)"},
 		{mysql, driver.Column{DataType: "char", MaxLength: 300}, "VARCHAR(300)"},
-		{mysql, driver.Column{DataType: "varbinary", MaxLength: 70000}, "BLOB"},
+		{mysql, driver.Column{DataType: "varbinary", MaxLength: 70000}, "MEDIUMBLOB"},
 		// Unbounded binary sources (pg bytea = 0, mssql varbinary(max) = -1)
-		// must not truncate to VARBINARY(255).
-		{mysql, driver.Column{DataType: "bytea", MaxLength: 0}, "BLOB"},
-		{mysql, driver.Column{DataType: "varbinary", MaxLength: -1}, "BLOB"},
+		// hold 1-2GB; only LONGBLOB keeps that capacity (#108).
+		{mysql, driver.Column{DataType: "bytea", MaxLength: 0}, "LONGBLOB"},
+		{mysql, driver.Column{DataType: "varbinary", MaxLength: -1}, "LONGBLOB"},
 	}
 	for _, tc := range cases {
 		got, err := tc.r.ColumnType(tc.col)

--- a/internal/ddl/renderer_source_dialect_test.go
+++ b/internal/ddl/renderer_source_dialect_test.go
@@ -65,3 +65,62 @@ func TestColumnType_SourceDialectScopedToMySQLTarget(t *testing.T) {
 		t.Errorf("pg boolean ColumnType = %q, want TINYINT(1)", got)
 	}
 }
+
+// #108 — "text" is dialect-ambiguous on mysql targets: MySQL's own TEXT is
+// the 64KiB tier and must round-trip verbatim, but pg text (1GB) and legacy
+// mssql TEXT (2GB) are unbounded LOBs that silently lose capacity unless
+// they land as LONGTEXT. ntext already mapped to LONGTEXT; tiers untouched.
+func TestColumnType_TextToMySQLBySourceDialect(t *testing.T) {
+	base, _ := NewRenderer("mysql", "crm", "fail")
+	cases := []struct {
+		name string
+		r    Renderer
+		dt   string
+		want string
+	}{
+		{"mysql text keeps tier", base.WithSource("mysql"), "text", "TEXT"},
+		{"mariadb text keeps tier", base.WithSource("mariadb"), "text", "TEXT"},
+		{"pg text upgrades", base.WithSource("postgres"), "text", "LONGTEXT"},
+		{"mssql legacy text upgrades", base.WithSource("mssql"), "text", "LONGTEXT"},
+		{"unknown source upgrades", base, "text", "LONGTEXT"},
+		{"ntext still longtext", base.WithSource("mssql"), "ntext", "LONGTEXT"},
+		{"mysql mediumtext untouched", base.WithSource("mysql"), "mediumtext", "MEDIUMTEXT"},
+	}
+	for _, tc := range cases {
+		got, err := tc.r.ColumnType(driver.Column{Name: "c", DataType: tc.dt})
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s: ColumnType(%s) = %q, want %q", tc.name, tc.dt, got, tc.want)
+		}
+	}
+}
+
+// #108 (binary/varchar capacity classes) — unbounded and oversized sources
+// must land on a tier that holds their capacity; MySQL's own blob tiers
+// round-trip verbatim instead of flattening to BLOB.
+func TestColumnType_MySQLCapacityTiers(t *testing.T) {
+	r, _ := NewRenderer("mysql", "crm", "fail")
+	cases := []struct {
+		col  driver.Column
+		want string
+	}{
+		{driver.Column{DataType: "image", MaxLength: 2147483647}, "LONGBLOB"},
+		{driver.Column{DataType: "blob"}, "BLOB"},
+		{driver.Column{DataType: "tinyblob"}, "TINYBLOB"},
+		{driver.Column{DataType: "mediumblob"}, "MEDIUMBLOB"},
+		{driver.Column{DataType: "longblob"}, "LONGBLOB"},
+		{driver.Column{DataType: "varchar", MaxLength: 5000000}, "LONGTEXT"},
+		{driver.Column{DataType: "varchar"}, "LONGTEXT"},
+	}
+	for _, tc := range cases {
+		got, err := r.ColumnType(tc.col)
+		if err != nil {
+			t.Fatalf("ColumnType(%s): %v", tc.col.DataType, err)
+		}
+		if got != tc.want {
+			t.Errorf("ColumnType(%s, len=%d) = %q, want %q", tc.col.DataType, tc.col.MaxLength, got, tc.want)
+		}
+	}
+}

--- a/internal/ddl/renderer_test.go
+++ b/internal/ddl/renderer_test.go
@@ -265,7 +265,8 @@ func TestRenderer_MySQLTargetPreservesLargeTextAndOnUpdate(t *testing.T) {
 		want string
 	}{
 		{name: "nvarchar max", col: driver.Column{Name: "Notes", DataType: "nvarchar", MaxLength: -1}, want: "LONGTEXT"},
-		{name: "unbounded varchar", col: driver.Column{Name: "Notes", DataType: "varchar", MaxLength: 0}, want: "TEXT"},
+		// Unbounded pg varchar holds 1GB; LONGTEXT is the only tier that keeps that capacity (#108).
+		{name: "unbounded varchar", col: driver.Column{Name: "Notes", DataType: "varchar", MaxLength: 0}, want: "LONGTEXT"},
 		{name: "mediumtext", col: driver.Column{Name: "Notes", DataType: "mediumtext"}, want: "MEDIUMTEXT"},
 		{name: "longtext", col: driver.Column{Name: "Notes", DataType: "longtext"}, want: "LONGTEXT"},
 	} {


### PR DESCRIPTION
## Summary
Fixes the capacity-downgrade class found while reviewing #105's LOB rules:
- Foreign `text` (pg 1GB / legacy mssql 2GB) → `LONGTEXT` (mysql→mysql keeps `TEXT` verbatim via the #101 source-dialect gate)
- `IMAGE` (2GB) → `LONGBLOB` instead of `BLOB` (64KiB)
- Unbounded binary (`bytea`, `varbinary(max)`) → `LONGBLOB`; sized `varbinary` > 65535 → `MEDIUMBLOB`
- MySQL blob tiers no longer flatten to `BLOB` on round-trip — preserved verbatim
- Oversized `varchar` → `MEDIUMTEXT`/`LONGTEXT` by worst-case utf8mb4 byte capacity (old `TEXT` choice only holds 16383 chars); unbounded pg `varchar` → `LONGTEXT`

Closes #108.

## Test plan
- [x] Unit tests for every tier boundary + source-dialect gate
- [x] Live end-to-end: mssql→mysql legacy LOBs land as longtext/longblob; mysql→mysql round-trips all blob tiers
- [x] `go test ./... -short` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)