### PR TITLE
Warn on deprecated ai_verify / ai_verifier_model config aliases (#67)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -632,6 +632,16 @@ func (c *Config) applyDefaults() error {
 	if c.SchemaGeneration.UnknownTypePolicy == "" {
 		c.SchemaGeneration.UnknownTypePolicy = "fail"
 	}
+	// migration.ai_verify / ai_verifier_model are deprecated aliases for the
+	// ai_review block. They still resolve (below), but warn so users migrate
+	// off them. Gated on key presence so an omitted key never warns; an
+	// explicit ai_review value always wins over the alias.
+	if c.hasMigrationKey("ai_verify") {
+		logging.Warn("config: migration.ai_verify is deprecated; use ai_review.enabled instead")
+	}
+	if c.hasMigrationKey("ai_verifier_model") {
+		logging.Warn("config: migration.ai_verifier_model is deprecated; use ai_review.model instead")
+	}
 	if c.AIReview.Enabled == nil {
 		enabled := c.Migration.AIVerify
 		c.AIReview.Enabled = &enabled

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,11 +1,13 @@
 package config
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"smt/internal/logging"
 	"smt/internal/secrets"
 )
 
@@ -1508,5 +1510,124 @@ func TestValidateRejectsPartialTargetConnection(t *testing.T) {
 	both.Target.Database = "targetdb"
 	if err := both.validate(); err != nil {
 		t.Fatalf("validate() rejected complete target connection: %v", err)
+	}
+}
+
+// #67 — migration.ai_verify / ai_verifier_model are deprecated aliases for
+// the ai_review block. Using them must warn (so users migrate off), an
+// omitted key must stay silent, and an explicit ai_review value must win
+// over the alias.
+func TestDeprecatedAIVerifyAliasWarns(t *testing.T) {
+	const base = `
+source:
+  type: mssql
+  host: localhost
+  port: 1433
+  database: source
+  user: user
+  password: pass
+target:
+  type: postgres
+  host: localhost
+  port: 5432
+  database: target
+  schema: public
+  user: user
+  password: pass
+`
+	cases := []struct {
+		name      string
+		extra     string
+		wantWarn  []string
+		wantNoLog []string
+	}{
+		{
+			name:      "no aliases stays silent",
+			extra:     "",
+			wantNoLog: []string{"ai_verify", "ai_verifier_model"},
+		},
+		{
+			name:     "ai_verify true warns",
+			extra:    "migration:\n  ai_verify: true\n",
+			wantWarn: []string{"migration.ai_verify is deprecated"},
+		},
+		{
+			name:     "ai_verify false still warns (explicit use)",
+			extra:    "migration:\n  ai_verify: false\n",
+			wantWarn: []string{"migration.ai_verify is deprecated"},
+		},
+		{
+			name:     "ai_verifier_model warns",
+			extra:    "migration:\n  ai_verifier_model: strong\n",
+			wantWarn: []string{"migration.ai_verifier_model is deprecated"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(secrets.SecretsFileEnvVar, filepath.Join(t.TempDir(), "missing.yaml"))
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(configPath, []byte(base+tc.extra), 0600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			var buf bytes.Buffer
+			logging.SetOutput(&buf)
+			defer logging.SetOutput(nil)
+
+			if _, err := Load(configPath); err != nil {
+				t.Fatalf("Load() error: %v", err)
+			}
+			out := buf.String()
+			for _, want := range tc.wantWarn {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected warning %q, log was:\n%s", want, out)
+				}
+			}
+			for _, no := range tc.wantNoLog {
+				if strings.Contains(out, no) {
+					t.Errorf("did not expect %q in log, log was:\n%s", no, out)
+				}
+			}
+		})
+	}
+}
+
+// #67 — an explicit ai_review.enabled must take precedence over the
+// deprecated ai_verify alias, regardless of the alias value.
+func TestAIReviewWinsOverDeprecatedAlias(t *testing.T) {
+	t.Setenv(secrets.SecretsFileEnvVar, filepath.Join(t.TempDir(), "missing.yaml"))
+	const cfgYAML = `
+source:
+  type: mssql
+  host: localhost
+  port: 1433
+  database: source
+  user: user
+  password: pass
+target:
+  type: postgres
+  host: localhost
+  port: 5432
+  database: target
+  schema: public
+  user: user
+  password: pass
+migration:
+  ai_verify: true
+ai_review:
+  enabled: false
+`
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(cfgYAML), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.AIReview.Enabled == nil || *cfg.AIReview.Enabled {
+		t.Errorf("explicit ai_review.enabled=false should win over ai_verify=true, got %v", cfg.AIReview.Enabled)
 	}
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -88,10 +88,16 @@ func SetLevel(level Level) {
 	defaultLogger.level = level
 }
 
-// SetOutput sets the output destination for logging
+// SetOutput sets the output destination for logging. Passing nil resets the
+// destination to the default (os.Stdout) rather than leaving a nil writer
+// that would panic on the next log call — callers (notably tests) use
+// SetOutput(nil) to mean "restore the default".
 func SetOutput(w io.Writer) {
 	defaultLogger.mu.Lock()
 	defer defaultLogger.mu.Unlock()
+	if w == nil {
+		w = os.Stdout
+	}
 	defaultLogger.output = w
 }
 

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -189,3 +189,19 @@ func TestJSONLogLevels(t *testing.T) {
 		})
 	}
 }
+
+// SetOutput(nil) must reset to the default rather than leave a nil writer
+// that panics on the next log call. Config loading relies on this when
+// tests restore output via defer SetOutput(nil).
+func TestSetOutputNilResetsToDefault(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	SetOutput(nil) // reset
+
+	// Must not panic — writes to the restored default, not a nil writer.
+	Warn("after reset %d", 1)
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output to the old buffer after reset, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Config loading now emits a deprecation warning when `migration.ai_verify` or `migration.ai_verifier_model` is present, pointing users at `ai_review.enabled` / `ai_review.model`. The aliases still resolve; an explicit `ai_review` value continues to win.
- Gated on YAML key presence so an omitted key stays silent and an explicit `ai_verify: false` still warns (it's still deprecated usage).
- Drive-by fix: `logging.SetOutput(nil)` left a nil writer that panicked on the next log call. The two production callers always pass non-nil; only tests pass nil to mean "reset". `SetOutput(nil)` now resets to the documented default (`os.Stdout`).

Closes #67. (The retry-loop removal this issue also mentioned already landed in #77/#97.)

## Test plan
- [x] Table test: omitted key silent, `ai_verify: true/false` warns, `ai_verifier_model` warns
- [x] Explicit `ai_review.enabled: false` wins over `ai_verify: true`
- [x] `SetOutput(nil)` reset no longer panics
- [x] `go test ./... -short` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)