### PR TITLE
Persist a deterministic run manifest with version fingerprints (#64)

### DIFF
--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -11,6 +11,14 @@ import (
 	pgddl "smt/internal/driver/postgres"
 )
 
+// RendererVersion identifies the deterministic renderer's output contract.
+// Bump it whenever a change can alter the rendered DDL for the same input
+// (a new type mapping, default rewrite, identifier rule, etc.) so persisted
+// run manifests distinguish artifacts produced by different renderer logic.
+// It is the single "renderer + type-mapper version" token #64 fingerprints
+// on — type mapping and DDL rendering are one deterministic unit here.
+const RendererVersion = "1"
+
 type Renderer struct {
 	target            string
 	schema            string

--- a/internal/orchestrator/ddl_plan.go
+++ b/internal/orchestrator/ddl_plan.go
@@ -117,7 +117,7 @@ func (o *Orchestrator) renderDDLPlan(ctx context.Context, runID string) (schemad
 	// Record the deterministic inputs (versions + fingerprints) that produced
 	// this plan, next to schema.sql. Both the create-preview and apply paths
 	// render through here, so the manifest covers both (#64).
-	if err := o.writeRunManifest(runID, renderer, plan.SQL()); err != nil {
+	if err := o.writeRunManifest(ctx, runID, renderer, plan.SQL()); err != nil {
 		return schemadiff.Plan{}, fmt.Errorf("writing run manifest: %w", err)
 	}
 

--- a/internal/orchestrator/ddl_plan.go
+++ b/internal/orchestrator/ddl_plan.go
@@ -114,6 +114,13 @@ func (o *Orchestrator) renderDDLPlan(ctx context.Context, runID string) (schemad
 		plan.Statements = append(plan.Statements, stmts...)
 	}
 
+	// Record the deterministic inputs (versions + fingerprints) that produced
+	// this plan, next to schema.sql. Both the create-preview and apply paths
+	// render through here, so the manifest covers both (#64).
+	if err := o.writeRunManifest(runID, renderer, plan.SQL()); err != nil {
+		return schemadiff.Plan{}, fmt.Errorf("writing run manifest: %w", err)
+	}
+
 	return plan, nil
 }
 

--- a/internal/orchestrator/manifest.go
+++ b/internal/orchestrator/manifest.go
@@ -12,15 +12,21 @@ package orchestrator
 //     entries instead of replaying them.
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 
 	"smt/internal/ddl"
+	"smt/internal/driver"
 	"smt/internal/version"
 )
 
-// manifestArtifactName is the filename of the run manifest within the run dir.
+// manifestArtifactName is the filename of the run manifest. It lives in the
+// same ddl/ directory as schema.sql so the two travel together.
 const manifestArtifactName = "manifest.json"
 
 type runManifest struct {
@@ -38,9 +44,13 @@ type runManifest struct {
 }
 
 // writeRunManifest fingerprints the source schema and the rendered SQL and
-// writes the manifest into the run directory.
-func (o *Orchestrator) writeRunManifest(runID string, r createDDLRenderer, planSQL string) error {
-	srcFP, err := fingerprintJSON(o.tables)
+// writes the manifest into the ddl/ run directory beside schema.sql.
+func (o *Orchestrator) writeRunManifest(ctx context.Context, runID string, r createDDLRenderer, planSQL string) error {
+	snap, err := o.canonicalSourceSnapshot(ctx)
+	if err != nil {
+		return fmt.Errorf("building source fingerprint snapshot: %w", err)
+	}
+	srcFP, err := fingerprintJSON(snap)
 	if err != nil {
 		return err
 	}
@@ -57,7 +67,57 @@ func (o *Orchestrator) writeRunManifest(runID string, r createDDLRenderer, planS
 		SourceFingerprint: srcFP,
 		PlanFingerprint:   fingerprintBytes([]byte(planSQL)),
 	}
-	return o.writeJSONArtifact(runID, manifestArtifactName, m)
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	dir := o.ddlArtifactDir(runID)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, manifestArtifactName), append(data, '\n'), 0600)
+}
+
+// canonicalSourceSnapshot returns a copy of the in-scope source tables loaded
+// with exactly the constraint metadata that drives the rendered plan — the
+// per-table render helpers load indexes/FKs/checks into goroutine-local
+// copies, so o.tables alone carries only columns/PKs. Non-DDL statistics
+// (row counts, sample values) are zeroed so the fingerprint tracks schema
+// shape, not table contents. Only the enabled create_* categories are loaded,
+// keeping the fingerprint aligned with what the plan actually contains.
+func (o *Orchestrator) canonicalSourceSnapshot(ctx context.Context) ([]driver.Table, error) {
+	out := make([]driver.Table, len(o.tables))
+	for i := range o.tables {
+		t := o.tables[i] // value copy; Load* mutate the copy, not o.tables
+		if o.config.Migration.CreateIndexes {
+			if err := o.source.LoadIndexes(ctx, &t); err != nil {
+				return nil, fmt.Errorf("loading indexes for %s: %w", t.Name, err)
+			}
+		}
+		if o.config.Migration.CreateForeignKeys {
+			if err := o.source.LoadForeignKeys(ctx, &t); err != nil {
+				return nil, fmt.Errorf("loading FKs for %s: %w", t.Name, err)
+			}
+		}
+		if o.config.Migration.CreateCheckConstraints {
+			if err := o.source.LoadCheckConstraints(ctx, &t); err != nil {
+				return nil, fmt.Errorf("loading checks for %s: %w", t.Name, err)
+			}
+		}
+		canonicalizeForFingerprint(&t)
+		out[i] = t
+	}
+	return out, nil
+}
+
+// canonicalizeForFingerprint zeroes the non-DDL fields so the fingerprint
+// reflects schema shape rather than table data or transient stats.
+func canonicalizeForFingerprint(t *driver.Table) {
+	t.RowCount = 0
+	t.EstimatedRowSize = 0
+	for j := range t.Columns {
+		t.Columns[j].SampleValues = nil
+	}
 }
 
 // fingerprintJSON returns "sha256:<hex>" over the stable JSON encoding of v.

--- a/internal/orchestrator/manifest.go
+++ b/internal/orchestrator/manifest.go
@@ -1,0 +1,75 @@
+package orchestrator
+
+// Run manifest (#64): a small JSON artifact written next to schema.sql that
+// records exactly which deterministic inputs produced the plan — SMT version,
+// renderer version, dialects, type policy, and content fingerprints of both
+// the source schema and the rendered SQL. Two purposes:
+//
+//   - inspection: a user can see which renderer logic and source schema a
+//     given schema.sql came from, and whether either changed between runs;
+//   - invalidation: a downstream artifact cache can key on RendererVersion +
+//     SourceFingerprint so a renderer bump or source change misses stale
+//     entries instead of replaying them.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+
+	"smt/internal/ddl"
+	"smt/internal/version"
+)
+
+// manifestArtifactName is the filename of the run manifest within the run dir.
+const manifestArtifactName = "manifest.json"
+
+type runManifest struct {
+	SMTVersion        string `json:"smt_version"`
+	RendererVersion   string `json:"renderer_version"`
+	SourceDialect     string `json:"source_dialect"`
+	TargetDialect     string `json:"target_dialect"`
+	TargetSchema      string `json:"target_schema"`
+	UnknownTypePolicy string `json:"unknown_type_policy"`
+	AIReviewEnabled   bool   `json:"ai_review_enabled"`
+	AIReviewMode      string `json:"ai_review_mode,omitempty"`
+	TableCount        int    `json:"table_count"`
+	SourceFingerprint string `json:"source_schema_fingerprint"`
+	PlanFingerprint   string `json:"plan_fingerprint"`
+}
+
+// writeRunManifest fingerprints the source schema and the rendered SQL and
+// writes the manifest into the run directory.
+func (o *Orchestrator) writeRunManifest(runID string, r createDDLRenderer, planSQL string) error {
+	srcFP, err := fingerprintJSON(o.tables)
+	if err != nil {
+		return err
+	}
+	m := runManifest{
+		SMTVersion:        version.Version,
+		RendererVersion:   ddl.RendererVersion,
+		SourceDialect:     r.sourceType,
+		TargetDialect:     r.targetType,
+		TargetSchema:      r.targetSchema,
+		UnknownTypePolicy: r.unknownTypePolicy,
+		AIReviewEnabled:   r.aiReviewEnabled,
+		AIReviewMode:      r.aiReviewMode,
+		TableCount:        len(o.tables),
+		SourceFingerprint: srcFP,
+		PlanFingerprint:   fingerprintBytes([]byte(planSQL)),
+	}
+	return o.writeJSONArtifact(runID, manifestArtifactName, m)
+}
+
+// fingerprintJSON returns "sha256:<hex>" over the stable JSON encoding of v.
+func fingerprintJSON(v any) (string, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return fingerprintBytes(data), nil
+}
+
+func fingerprintBytes(b []byte) string {
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/orchestrator/manifest_test.go
+++ b/internal/orchestrator/manifest_test.go
@@ -1,0 +1,43 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+
+	"smt/internal/driver"
+)
+
+// Fingerprints must be stable for identical input and change when the input
+// changes — the property the #64 manifest relies on for inspection and cache
+// invalidation.
+func TestFingerprintStableAndSensitive(t *testing.T) {
+	a := []driver.Table{{Name: "Users", Columns: []driver.Column{{Name: "Id", DataType: "int"}}}}
+	b := []driver.Table{{Name: "Users", Columns: []driver.Column{{Name: "Id", DataType: "int"}}}}
+	c := []driver.Table{{Name: "Users", Columns: []driver.Column{{Name: "Id", DataType: "bigint"}}}}
+
+	fa, err := fingerprintJSON(a)
+	if err != nil {
+		t.Fatalf("fingerprintJSON: %v", err)
+	}
+	fb, _ := fingerprintJSON(b)
+	fc, _ := fingerprintJSON(c)
+
+	if fa != fb {
+		t.Errorf("identical input produced different fingerprints:\n %s\n %s", fa, fb)
+	}
+	if fa == fc {
+		t.Error("differing input (int vs bigint) produced the same fingerprint")
+	}
+	if !strings.HasPrefix(fa, "sha256:") {
+		t.Errorf("fingerprint missing sha256: prefix: %q", fa)
+	}
+}
+
+func TestFingerprintBytes(t *testing.T) {
+	if fingerprintBytes([]byte("x")) == fingerprintBytes([]byte("y")) {
+		t.Error("distinct bytes hashed to the same fingerprint")
+	}
+	if fingerprintBytes([]byte("same")) != fingerprintBytes([]byte("same")) {
+		t.Error("identical bytes hashed to different fingerprints")
+	}
+}

--- a/internal/orchestrator/manifest_test.go
+++ b/internal/orchestrator/manifest_test.go
@@ -31,6 +31,46 @@ func TestFingerprintStableAndSensitive(t *testing.T) {
 	if !strings.HasPrefix(fa, "sha256:") {
 		t.Errorf("fingerprint missing sha256: prefix: %q", fa)
 	}
+
+	// The canonical snapshot loads indexes/FKs/checks, so the fingerprint
+	// must move when any of those change — the gap that prompted hashing
+	// the full snapshot rather than columns/PKs alone.
+	withIdx := []driver.Table{{
+		Name:    "Users",
+		Columns: []driver.Column{{Name: "Id", DataType: "int"}},
+		Indexes: []driver.Index{{Name: "ix_users_id", Columns: []string{"Id"}}},
+	}}
+	withFK := []driver.Table{{
+		Name:        "Users",
+		Columns:     []driver.Column{{Name: "Id", DataType: "int"}},
+		ForeignKeys: []driver.ForeignKey{{Name: "fk", Columns: []string{"Id"}, RefTable: "Orgs", RefColumns: []string{"Id"}}},
+	}}
+	fIdx, _ := fingerprintJSON(withIdx)
+	fFK, _ := fingerprintJSON(withFK)
+	if fIdx == fa {
+		t.Error("adding an index did not change the fingerprint")
+	}
+	if fFK == fa {
+		t.Error("adding a foreign key did not change the fingerprint")
+	}
+}
+
+// Non-DDL stats (row counts, sample values) must not perturb the fingerprint,
+// so it tracks schema shape rather than table contents.
+func TestCanonicalizeForFingerprintIgnoresStats(t *testing.T) {
+	base := driver.Table{Name: "T", Columns: []driver.Column{{Name: "c", DataType: "int"}}}
+	noisy := driver.Table{
+		Name:             "T",
+		RowCount:         9999,
+		EstimatedRowSize: 128,
+		Columns:          []driver.Column{{Name: "c", DataType: "int", SampleValues: []string{"1", "2"}}},
+	}
+	canonicalizeForFingerprint(&noisy)
+	fb, _ := fingerprintJSON([]driver.Table{base})
+	fn, _ := fingerprintJSON([]driver.Table{noisy})
+	if fb != fn {
+		t.Errorf("row-count/sample-value stats leaked into the fingerprint:\n %s\n %s", fb, fn)
+	}
 }
 
 func TestFingerprintBytes(t *testing.T) {

--- a/internal/orchestrator/so2010_acceptance_test.go
+++ b/internal/orchestrator/so2010_acceptance_test.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -28,6 +30,7 @@ import (
 	"time"
 
 	"smt/internal/config"
+	"smt/internal/ddl"
 	"smt/internal/driver"
 	"smt/internal/pool"
 )
@@ -124,6 +127,10 @@ ai_review:
 	if err := orch.Run(ctx); err != nil {
 		t.Fatalf("orchestrator Run (no-AI create+apply): %v", err)
 	}
+
+	// The run must have persisted a deterministic manifest (#64) recording
+	// the renderer version + fingerprints that produced schema.sql.
+	assertManifestWritten(t, dataDir)
 
 	// Introspect both sides through the deterministic readers and compare.
 	srcCfg := cfg.Source
@@ -397,6 +404,39 @@ func containsCI(haystack []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+// assertManifestWritten finds the run manifest under dataDir and checks it
+// records the current renderer version and a plan fingerprint (#64).
+func assertManifestWritten(t *testing.T, dataDir string) {
+	t.Helper()
+	var found string
+	_ = filepath.WalkDir(dataDir, func(path string, d fs.DirEntry, err error) error {
+		if err == nil && !d.IsDir() && d.Name() == "manifest.json" {
+			found = path
+		}
+		return nil
+	})
+	if found == "" {
+		t.Fatal("no manifest.json artifact written by the run (#64)")
+	}
+	blob, err := os.ReadFile(found)
+	if err != nil {
+		t.Fatalf("reading manifest: %v", err)
+	}
+	var m runManifest
+	if err := json.Unmarshal(blob, &m); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v", err)
+	}
+	if m.RendererVersion != ddl.RendererVersion {
+		t.Errorf("manifest renderer_version=%q, want %q", m.RendererVersion, ddl.RendererVersion)
+	}
+	if !strings.HasPrefix(m.PlanFingerprint, "sha256:") || !strings.HasPrefix(m.SourceFingerprint, "sha256:") {
+		t.Errorf("manifest fingerprints malformed: plan=%q source=%q", m.PlanFingerprint, m.SourceFingerprint)
+	}
+	if m.AIReviewEnabled {
+		t.Error("manifest reports ai_review_enabled=true in the no-AI acceptance run")
+	}
 }
 
 func countWithPK(tables []driver.Table) int {


### PR DESCRIPTION
## Summary
Every create-preview and apply run writes `manifest.json` next to `schema.sql` recording the deterministic inputs that produced the plan: SMT version, renderer version, source/target dialect, target schema, unknown-type policy, AI-review posture, table count, and sha256 fingerprints of both the source schema and the rendered SQL.

- New `ddl.RendererVersion` — one token for the renderer + type-mapper output contract, bumped when rendered DDL can change for the same input. A downstream artifact cache can key on `RendererVersion + source_schema_fingerprint` so a renderer bump or source change misses stale entries.
- Written from `renderDDLPlan`, the single path both preview and apply share.

Closes #64.

## Test plan
- [x] Unit tests pin fingerprint stability + sensitivity (`sha256:` form, int vs bigint differ)
- [x] Live: identical source produced byte-identical fingerprints across two runs; manifest has all fields
- [x] SO2010 acceptance test now asserts the manifest (renderer version, well-formed fingerprints, ai_review off)
- [x] `go test ./... -short` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)