### PR TITLE
Add target introspection + drift detection (smt drift) (#69)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Storage: `internal/checkpoint/snapshots.go` adds a `schema_snapshots` table to t
 CLI flow:
 - `smt snapshot` — extract source, save to state DB
 - `smt sync` — diff vs latest snapshot, deterministically render SQL, write to `migration.sql` (default) or apply with `--apply`
+- `smt drift` — introspect the live **target** and report drift between the source-derived (desired) schema and the existing target (#69). Read-only; cross-dialect column equivalence via `driver.CompareColumns`, so `varchar(20)` ≡ `character varying(20)`. Classifies missing / extra / changed tables and columns (`schemadiff.ComputeDrift`). Exit 0 = in sync, 3 = drift; `--fail-on-destructive-only` exits 0 for additive-only drift (useful as a CI gate).
 
 ### Config + secrets split
 

--- a/cmd/smt/drift.go
+++ b/cmd/smt/drift.go
@@ -63,7 +63,12 @@ func runDrift(c *cli.Context) error {
 	if err := loadAllConstraints(ctx, orch.Source(), desired); err != nil {
 		return err
 	}
-	normalizeTableNames(desired, cfg.Target.Type)
+	// Fold every desired identifier — table, column, AND index/FK column lists
+	// and referenced tables — to the target's on-disk convention so constraint
+	// comparisons line up with the introspected (already-normalized) target.
+	desired = schemadiff.NormalizeIdentifiers(desired, func(name string) string {
+		return driver.NormalizeIdentifier(cfg.Target.Type, name)
+	})
 
 	// Existing: introspect the live target through a reader on the target
 	// connection.
@@ -108,15 +113,6 @@ func targetAsSource(cfg *config.Config) *config.SourceConfig {
 		SSLMode:         cfg.Target.SSLMode,
 		TrustServerCert: cfg.Target.TrustServerCert,
 		Encrypt:         cfg.Target.Encrypt,
-	}
-}
-
-func normalizeTableNames(tables []driver.Table, targetType string) {
-	for i := range tables {
-		tables[i].Name = driver.NormalizeIdentifier(targetType, tables[i].Name)
-		for j := range tables[i].Columns {
-			tables[i].Columns[j].Name = driver.NormalizeIdentifier(targetType, tables[i].Columns[j].Name)
-		}
 	}
 }
 

--- a/cmd/smt/drift.go
+++ b/cmd/smt/drift.go
@@ -112,7 +112,7 @@ func runDrift(c *cli.Context) error {
 	// no scope set, the target is left whole so genuine extra tables are still
 	// detected.
 	if len(include) > 0 || len(exclude) > 0 {
-		existing = filterToManagedSet(existing, desired)
+		existing = filterToManagedSet(existing, desired, include, exclude)
 	}
 	if err := loadConstraintsGated(ctx, targetReader, existing, opts); err != nil {
 		return err
@@ -164,24 +164,39 @@ func matchesAnyExact(name string, patterns []string) bool {
 	return false
 }
 
-// filterToManagedSet keeps only the existing (target) tables whose name matches
-// an in-scope desired table by normalized name, comparing case-insensitively.
-// This scopes the target to the managed set via membership rather than
-// re-running the source-cased patterns against already-normalized target
-// names. Under include/exclude, out-of-scope target tables are simply not
-// compared (so they're neither flagged extra nor mistaken for managed).
-func filterToManagedSet(existing, desired []driver.Table) []driver.Table {
+// filterToManagedSet scopes the target tables under include/exclude. A target
+// table is kept when it is either a managed table — its normalized name matches
+// an in-scope desired table — or a genuine in-scope extra: not present in the
+// source but still matching the scope rules (so e.g. include_tables: ["*"]
+// still surfaces a target-only table as extra). Out-of-scope target tables are
+// dropped so they're not mistaken for drift. Managed-table matching is by
+// normalized-name membership (no case/glob ambiguity); the in-scope check for
+// extras matches the target name against the patterns the same way create/sync
+// do (case-sensitive filepath.Match).
+func filterToManagedSet(existing, desired []driver.Table, include, exclude []string) []driver.Table {
 	managed := make(map[string]bool, len(desired))
 	for _, t := range desired {
 		managed[strings.ToLower(t.Name)] = true
 	}
 	out := make([]driver.Table, 0, len(existing))
 	for _, t := range existing {
-		if managed[strings.ToLower(t.Name)] {
+		if managed[strings.ToLower(t.Name)] || inScope(t.Name, include, exclude) {
 			out = append(out, t)
 		}
 	}
 	return out
+}
+
+// inScope reports whether a table name passes the include/exclude rules, with
+// create/sync semantics (exclude wins; include, when set, is an allowlist).
+func inScope(name string, include, exclude []string) bool {
+	if matchesAnyExact(name, exclude) {
+		return false
+	}
+	if len(include) > 0 && !matchesAnyExact(name, include) {
+		return false
+	}
+	return true
 }
 
 // loadConstraintsGated loads only the constraint kinds that are managed

--- a/cmd/smt/drift.go
+++ b/cmd/smt/drift.go
@@ -142,5 +142,20 @@ func printDriftReport(d schemadiff.Drift) {
 		for _, delta := range td.ColumnDeltas {
 			fmt.Printf("                ~ %s\n", delta)
 		}
+		for _, ix := range td.MissingIndexes {
+			fmt.Printf("                + index on (%s) missing on target\n", ix)
+		}
+		for _, ix := range td.ExtraIndexes {
+			fmt.Printf("                - index on (%s) extra on target\n", ix)
+		}
+		for _, fk := range td.MissingForeignKeys {
+			fmt.Printf("                + foreign key %s missing on target\n", fk)
+		}
+		for _, fk := range td.ExtraForeignKeys {
+			fmt.Printf("                - foreign key %s extra on target\n", fk)
+		}
+		if td.CheckDrift != "" {
+			fmt.Printf("                ~ check constraints: %s\n", td.CheckDrift)
+		}
 	}
 }

--- a/cmd/smt/drift.go
+++ b/cmd/smt/drift.go
@@ -77,16 +77,19 @@ func runDrift(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("introspecting source: %w", err)
 	}
-	desired = filterTablesByScope(desired, cfg.Migration.IncludeTables, cfg.Migration.ExcludeTables)
+	norm := func(name string) string { return driver.NormalizeIdentifier(targetDialect, name) }
+	// Filter on SOURCE names with the source-cased patterns (globs intact).
+	desired = filterTablesByScope(desired, cfg.Migration.IncludeTables, cfg.Migration.ExcludeTables, norm)
 	if err := loadConstraintsGated(ctx, orch.Source(), desired, opts); err != nil {
 		return err
 	}
 	// Fold every desired identifier — table, column, AND index/FK column lists
 	// and referenced tables — to the target's on-disk convention so constraint
-	// comparisons line up with the introspected (already-normalized) target.
-	desired = schemadiff.NormalizeIdentifiers(desired, func(name string) string {
-		return driver.NormalizeIdentifier(targetDialect, name)
-	})
+	// comparisons line up with the introspected (already-normalized) target,
+	// then resolve schema references to the target schema so cross-schema FK
+	// signatures compare equal.
+	desired = schemadiff.NormalizeIdentifiers(desired, norm)
+	desired = schemadiff.RetargetSchema(desired, cfg.Target.Schema)
 
 	// Existing: introspect the live target through a reader on the target
 	// connection.
@@ -102,10 +105,13 @@ func runDrift(c *cli.Context) error {
 	}
 	// Scope the target the same way: only compare tables the source manages,
 	// so unrelated objects living in the target schema aren't flagged extra.
-	existing = filterTablesByScope(existing, cfg.Migration.IncludeTables, cfg.Migration.ExcludeTables)
+	// The target names are already normalized, so the filter also tries the
+	// normalized form of each literal pattern (see filterTablesByScope).
+	existing = filterTablesByScope(existing, cfg.Migration.IncludeTables, cfg.Migration.ExcludeTables, norm)
 	if err := loadConstraintsGated(ctx, targetReader, existing, opts); err != nil {
 		return err
 	}
+	existing = schemadiff.RetargetSchema(existing, cfg.Target.Schema)
 
 	drift := schemadiff.ComputeDrift(desired, existing, sourceDialect, targetDialect, opts)
 	printDriftReport(drift)
@@ -123,19 +129,22 @@ func runDrift(c *cli.Context) error {
 // targetAsSource adapts the target connection into a SourceConfig so the same
 // deterministic reader path can introspect it.
 // filterTablesByScope applies the migration include/exclude rules the same way
-// the orchestrator does (exclude wins; include, when set, is an allowlist),
-// matching case-insensitively so source-cased patterns line up with both
-// source-cased and target-normalized table names.
-func filterTablesByScope(tables []driver.Table, include, exclude []string) []driver.Table {
+// the orchestrator does (exclude wins; include, when set, is an allowlist).
+// It matches a name against each pattern case-insensitively (with glob
+// support), and additionally tries the target-normalized form of literal
+// patterns via norm — so a literal pattern like "Order Items" still matches a
+// target table the dialect slugged to "order_items". Globs are not normalized
+// (normalization would mangle `*`/`?`), so they keep plain CI semantics.
+func filterTablesByScope(tables []driver.Table, include, exclude []string, norm func(string) string) []driver.Table {
 	if len(include) == 0 && len(exclude) == 0 {
 		return tables
 	}
 	out := make([]driver.Table, 0, len(tables))
 	for _, t := range tables {
-		if matchesAnyCI(t.Name, exclude) {
+		if matchesAnyScoped(t.Name, exclude, norm) {
 			continue
 		}
-		if len(include) > 0 && !matchesAnyCI(t.Name, include) {
+		if len(include) > 0 && !matchesAnyScoped(t.Name, include, norm) {
 			continue
 		}
 		out = append(out, t)
@@ -143,10 +152,15 @@ func filterTablesByScope(tables []driver.Table, include, exclude []string) []dri
 	return out
 }
 
-func matchesAnyCI(name string, patterns []string) bool {
+func matchesAnyScoped(name string, patterns []string, norm func(string) string) bool {
 	lower := strings.ToLower(name)
 	for _, p := range patterns {
 		if ok, _ := filepath.Match(strings.ToLower(p), lower); ok {
+			return true
+		}
+		// Literal (glob-free) patterns: also match the dialect-normalized
+		// form, so a name that needed slugging on the target still matches.
+		if norm != nil && !strings.ContainsAny(p, "*?[") && norm(p) == name {
 			return true
 		}
 	}

--- a/cmd/smt/drift.go
+++ b/cmd/smt/drift.go
@@ -54,6 +54,12 @@ func runDrift(c *cli.Context) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
+	// Canonicalize dialect aliases (sqlserver→mssql, pg→postgres, …) before
+	// they drive identifier normalization and cross-dialect column comparison,
+	// which both key off the canonical driver name.
+	sourceDialect := driver.Canonicalize(cfg.Source.Type)
+	targetDialect := driver.Canonicalize(cfg.Target.Type)
+
 	// Honor the same scope `create`/`sync` use: only the create_* object kinds
 	// that are managed participate in drift, so a config that intentionally
 	// leaves indexes/FKs/checks unmanaged doesn't report them as drift.
@@ -79,7 +85,7 @@ func runDrift(c *cli.Context) error {
 	// and referenced tables — to the target's on-disk convention so constraint
 	// comparisons line up with the introspected (already-normalized) target.
 	desired = schemadiff.NormalizeIdentifiers(desired, func(name string) string {
-		return driver.NormalizeIdentifier(cfg.Target.Type, name)
+		return driver.NormalizeIdentifier(targetDialect, name)
 	})
 
 	// Existing: introspect the live target through a reader on the target
@@ -101,7 +107,7 @@ func runDrift(c *cli.Context) error {
 		return err
 	}
 
-	drift := schemadiff.ComputeDrift(desired, existing, cfg.Source.Type, cfg.Target.Type, opts)
+	drift := schemadiff.ComputeDrift(desired, existing, sourceDialect, targetDialect, opts)
 	printDriftReport(drift)
 
 	if drift.IsEmpty() {

--- a/cmd/smt/drift.go
+++ b/cmd/smt/drift.go
@@ -13,6 +13,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -52,6 +54,15 @@ func runDrift(c *cli.Context) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
+	// Honor the same scope `create`/`sync` use: only the create_* object kinds
+	// that are managed participate in drift, so a config that intentionally
+	// leaves indexes/FKs/checks unmanaged doesn't report them as drift.
+	opts := schemadiff.DriftOptions{
+		CompareIndexes:     cfg.Migration.CreateIndexes,
+		CompareForeignKeys: cfg.Migration.CreateForeignKeys,
+		CompareChecks:      cfg.Migration.CreateCheckConstraints,
+	}
+
 	// Desired: the current source schema, with identifiers normalized to the
 	// target's on-disk convention so names line up with the introspected
 	// target (mssql "Posts" -> pg "posts").
@@ -60,7 +71,8 @@ func runDrift(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("introspecting source: %w", err)
 	}
-	if err := loadAllConstraints(ctx, orch.Source(), desired); err != nil {
+	desired = filterTablesByScope(desired, cfg.Migration.IncludeTables, cfg.Migration.ExcludeTables)
+	if err := loadConstraintsGated(ctx, orch.Source(), desired, opts); err != nil {
 		return err
 	}
 	// Fold every desired identifier — table, column, AND index/FK column lists
@@ -82,11 +94,14 @@ func runDrift(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("introspecting target: %w", err)
 	}
-	if err := loadAllConstraints(ctx, targetReader, existing); err != nil {
+	// Scope the target the same way: only compare tables the source manages,
+	// so unrelated objects living in the target schema aren't flagged extra.
+	existing = filterTablesByScope(existing, cfg.Migration.IncludeTables, cfg.Migration.ExcludeTables)
+	if err := loadConstraintsGated(ctx, targetReader, existing, opts); err != nil {
 		return err
 	}
 
-	drift := schemadiff.ComputeDrift(desired, existing, cfg.Source.Type, cfg.Target.Type)
+	drift := schemadiff.ComputeDrift(desired, existing, cfg.Source.Type, cfg.Target.Type, opts)
 	printDriftReport(drift)
 
 	if drift.IsEmpty() {
@@ -101,6 +116,62 @@ func runDrift(c *cli.Context) error {
 
 // targetAsSource adapts the target connection into a SourceConfig so the same
 // deterministic reader path can introspect it.
+// filterTablesByScope applies the migration include/exclude rules the same way
+// the orchestrator does (exclude wins; include, when set, is an allowlist),
+// matching case-insensitively so source-cased patterns line up with both
+// source-cased and target-normalized table names.
+func filterTablesByScope(tables []driver.Table, include, exclude []string) []driver.Table {
+	if len(include) == 0 && len(exclude) == 0 {
+		return tables
+	}
+	out := make([]driver.Table, 0, len(tables))
+	for _, t := range tables {
+		if matchesAnyCI(t.Name, exclude) {
+			continue
+		}
+		if len(include) > 0 && !matchesAnyCI(t.Name, include) {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+func matchesAnyCI(name string, patterns []string) bool {
+	lower := strings.ToLower(name)
+	for _, p := range patterns {
+		if ok, _ := filepath.Match(strings.ToLower(p), lower); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// loadConstraintsGated loads only the constraint kinds that are managed
+// (per the create_* flags carried in opts), so unmanaged object kinds are
+// neither introspected nor compared.
+func loadConstraintsGated(ctx context.Context, src constraintLoader, tables []driver.Table, opts schemadiff.DriftOptions) error {
+	for i := range tables {
+		t := &tables[i]
+		if opts.CompareIndexes {
+			if err := src.LoadIndexes(ctx, t); err != nil {
+				return fmt.Errorf("loading indexes for %s: %w", t.Name, err)
+			}
+		}
+		if opts.CompareForeignKeys {
+			if err := src.LoadForeignKeys(ctx, t); err != nil {
+				return fmt.Errorf("loading FKs for %s: %w", t.Name, err)
+			}
+		}
+		if opts.CompareChecks {
+			if err := src.LoadCheckConstraints(ctx, t); err != nil {
+				return fmt.Errorf("loading checks for %s: %w", t.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
 func targetAsSource(cfg *config.Config) *config.SourceConfig {
 	return &config.SourceConfig{
 		Type:            cfg.Target.Type,
@@ -129,6 +200,9 @@ func printDriftReport(d schemadiff.Drift) {
 	}
 	for _, td := range d.ChangedTables {
 		fmt.Printf("  [changed]   table %s\n", td.Name)
+		if td.PKDrift != "" {
+			fmt.Printf("                ~ primary key: %s\n", td.PKDrift)
+		}
 		for _, c := range td.MissingColumns {
 			fmt.Printf("                + column %s missing on target\n", c)
 		}

--- a/cmd/smt/drift.go
+++ b/cmd/smt/drift.go
@@ -78,8 +78,11 @@ func runDrift(c *cli.Context) error {
 		return fmt.Errorf("introspecting source: %w", err)
 	}
 	norm := func(name string) string { return driver.NormalizeIdentifier(targetDialect, name) }
-	// Filter on SOURCE names with the source-cased patterns (globs intact).
-	desired = filterTablesByScope(desired, cfg.Migration.IncludeTables, cfg.Migration.ExcludeTables, norm)
+	// Filter the SOURCE side with exactly the semantics create/sync use —
+	// case-sensitive filepath.Match on the original source names — so drift's
+	// scope is identical to what the migration manages.
+	include, exclude := cfg.Migration.IncludeTables, cfg.Migration.ExcludeTables
+	desired = filterDesiredScope(desired, include, exclude)
 	if err := loadConstraintsGated(ctx, orch.Source(), desired, opts); err != nil {
 		return err
 	}
@@ -102,11 +105,15 @@ func runDrift(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("introspecting target: %w", err)
 	}
-	// Scope the target the same way: only compare tables the source manages,
-	// so unrelated objects living in the target schema aren't flagged extra.
-	// The target names are already normalized, so the filter also tries the
-	// normalized form of each literal pattern (see filterTablesByScope).
-	existing = filterTablesByScope(existing, cfg.Migration.IncludeTables, cfg.Migration.ExcludeTables, norm)
+	// Scope the target to the same managed set: when include/exclude is in
+	// effect, keep only target tables whose name matches an in-scope desired
+	// table (by normalized name) — membership, not pattern matching, so there's
+	// no case/glob ambiguity against the already-normalized target names. With
+	// no scope set, the target is left whole so genuine extra tables are still
+	// detected.
+	if len(include) > 0 || len(exclude) > 0 {
+		existing = filterToManagedSet(existing, desired)
+	}
 	if err := loadConstraintsGated(ctx, targetReader, existing, opts); err != nil {
 		return err
 	}
@@ -126,23 +133,21 @@ func runDrift(c *cli.Context) error {
 
 // targetAsSource adapts the target connection into a SourceConfig so the same
 // deterministic reader path can introspect it.
-// filterTablesByScope applies the migration include/exclude rules the same way
-// the orchestrator does (exclude wins; include, when set, is an allowlist).
-// It matches a name against each pattern case-insensitively (with glob
-// support), and additionally tries the target-normalized form of literal
-// patterns via norm — so a literal pattern like "Order Items" still matches a
-// target table the dialect slugged to "order_items". Globs are not normalized
-// (normalization would mangle `*`/`?`), so they keep plain CI semantics.
-func filterTablesByScope(tables []driver.Table, include, exclude []string, norm func(string) string) []driver.Table {
+// filterDesiredScope applies the migration include/exclude rules with exactly
+// the semantics the orchestrator's create/sync use: exclude wins, include
+// (when set) is an allowlist, and patterns are matched case-sensitively with
+// filepath.Match on the original source names. Keeping this identical to the
+// migration path means drift's scope is the migration's scope.
+func filterDesiredScope(tables []driver.Table, include, exclude []string) []driver.Table {
 	if len(include) == 0 && len(exclude) == 0 {
 		return tables
 	}
 	out := make([]driver.Table, 0, len(tables))
 	for _, t := range tables {
-		if matchesAnyScoped(t.Name, exclude, norm) {
+		if matchesAnyExact(t.Name, exclude) {
 			continue
 		}
-		if len(include) > 0 && !matchesAnyScoped(t.Name, include, norm) {
+		if len(include) > 0 && !matchesAnyExact(t.Name, include) {
 			continue
 		}
 		out = append(out, t)
@@ -150,19 +155,33 @@ func filterTablesByScope(tables []driver.Table, include, exclude []string, norm 
 	return out
 }
 
-func matchesAnyScoped(name string, patterns []string, norm func(string) string) bool {
-	lower := strings.ToLower(name)
+func matchesAnyExact(name string, patterns []string) bool {
 	for _, p := range patterns {
-		if ok, _ := filepath.Match(strings.ToLower(p), lower); ok {
-			return true
-		}
-		// Literal (glob-free) patterns: also match the dialect-normalized
-		// form, so a name that needed slugging on the target still matches.
-		if norm != nil && !strings.ContainsAny(p, "*?[") && norm(p) == name {
+		if ok, _ := filepath.Match(p, name); ok {
 			return true
 		}
 	}
 	return false
+}
+
+// filterToManagedSet keeps only the existing (target) tables whose name matches
+// an in-scope desired table by normalized name, comparing case-insensitively.
+// This scopes the target to the managed set via membership rather than
+// re-running the source-cased patterns against already-normalized target
+// names. Under include/exclude, out-of-scope target tables are simply not
+// compared (so they're neither flagged extra nor mistaken for managed).
+func filterToManagedSet(existing, desired []driver.Table) []driver.Table {
+	managed := make(map[string]bool, len(desired))
+	for _, t := range desired {
+		managed[strings.ToLower(t.Name)] = true
+	}
+	out := make([]driver.Table, 0, len(existing))
+	for _, t := range existing {
+		if managed[strings.ToLower(t.Name)] {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 // loadConstraintsGated loads only the constraint kinds that are managed

--- a/cmd/smt/drift.go
+++ b/cmd/smt/drift.go
@@ -85,11 +85,10 @@ func runDrift(c *cli.Context) error {
 	}
 	// Fold every desired identifier — table, column, AND index/FK column lists
 	// and referenced tables — to the target's on-disk convention so constraint
-	// comparisons line up with the introspected (already-normalized) target,
-	// then resolve schema references to the target schema so cross-schema FK
-	// signatures compare equal.
+	// comparisons line up with the introspected (already-normalized) target.
+	// FK referenced-schema comparison is schema-relative inside ComputeDrift,
+	// so no schema retargeting is needed here.
 	desired = schemadiff.NormalizeIdentifiers(desired, norm)
-	desired = schemadiff.RetargetSchema(desired, cfg.Target.Schema)
 
 	// Existing: introspect the live target through a reader on the target
 	// connection.
@@ -111,7 +110,6 @@ func runDrift(c *cli.Context) error {
 	if err := loadConstraintsGated(ctx, targetReader, existing, opts); err != nil {
 		return err
 	}
-	existing = schemadiff.RetargetSchema(existing, cfg.Target.Schema)
 
 	drift := schemadiff.ComputeDrift(desired, existing, sourceDialect, targetDialect, opts)
 	printDriftReport(drift)

--- a/cmd/smt/drift.go
+++ b/cmd/smt/drift.go
@@ -78,6 +78,13 @@ func runDrift(c *cli.Context) error {
 		return fmt.Errorf("introspecting source: %w", err)
 	}
 	norm := func(name string) string { return driver.NormalizeIdentifier(targetDialect, name) }
+	// allSourceNorm is every source table's normalized name — used to tell an
+	// out-of-scope source table (which exists on the target but isn't managed)
+	// apart from a genuine target-only extra.
+	allSourceNorm := make(map[string]bool, len(desired))
+	for _, t := range desired {
+		allSourceNorm[strings.ToLower(norm(t.Name))] = true
+	}
 	// Filter the SOURCE side with exactly the semantics create/sync use —
 	// case-sensitive filepath.Match on the original source names — so drift's
 	// scope is identical to what the migration manages.
@@ -87,11 +94,11 @@ func runDrift(c *cli.Context) error {
 		return err
 	}
 	// Fold every desired identifier — table, column, AND index/FK column lists
-	// and referenced tables — to the target's on-disk convention so constraint
-	// comparisons line up with the introspected (already-normalized) target.
-	// FK referenced-schema comparison is schema-relative inside ComputeDrift,
-	// so no schema retargeting is needed here.
+	// and referenced tables — to the target's on-disk convention, then collapse
+	// schema references to the target schema exactly as create/sync do, so FK
+	// signatures match what was generated on the target.
 	desired = schemadiff.NormalizeIdentifiers(desired, norm)
+	desired = schemadiff.RetargetSchema(desired, cfg.Target.Schema)
 
 	// Existing: introspect the live target through a reader on the target
 	// connection.
@@ -105,14 +112,15 @@ func runDrift(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("introspecting target: %w", err)
 	}
-	// Scope the target to the same managed set: when include/exclude is in
-	// effect, keep only target tables whose name matches an in-scope desired
-	// table (by normalized name) — membership, not pattern matching, so there's
-	// no case/glob ambiguity against the already-normalized target names. With
-	// no scope set, the target is left whole so genuine extra tables are still
-	// detected.
+	// Scope the target to the same managed set when include/exclude is in
+	// effect. A target table is kept iff it is managed (its normalized name is
+	// in the filtered desired set) or a genuine target-only extra (its
+	// normalized name is not any source table's). An out-of-scope source table
+	// that happens to exist on the target — e.g. an excluded one — is dropped.
+	// All matching is by normalized-name membership, so there's no case/glob
+	// ambiguity against the already-normalized target names.
 	if len(include) > 0 || len(exclude) > 0 {
-		existing = filterToManagedSet(existing, desired, include, exclude)
+		existing = filterToManagedSet(existing, desired, allSourceNorm)
 	}
 	if err := loadConstraintsGated(ctx, targetReader, existing, opts); err != nil {
 		return err
@@ -164,39 +172,25 @@ func matchesAnyExact(name string, patterns []string) bool {
 	return false
 }
 
-// filterToManagedSet scopes the target tables under include/exclude. A target
-// table is kept when it is either a managed table — its normalized name matches
-// an in-scope desired table — or a genuine in-scope extra: not present in the
-// source but still matching the scope rules (so e.g. include_tables: ["*"]
-// still surfaces a target-only table as extra). Out-of-scope target tables are
-// dropped so they're not mistaken for drift. Managed-table matching is by
-// normalized-name membership (no case/glob ambiguity); the in-scope check for
-// extras matches the target name against the patterns the same way create/sync
-// do (case-sensitive filepath.Match).
-func filterToManagedSet(existing, desired []driver.Table, include, exclude []string) []driver.Table {
+// filterToManagedSet scopes the target tables. desired holds the managed
+// (in-scope, normalized) source tables; allSourceNorm holds EVERY source
+// table's normalized name. A target table is kept iff it is managed, or it is
+// a genuine target-only extra (not any source table). A target table that
+// corresponds to a source table which was filtered out of scope (e.g. an
+// excluded one) is dropped, so excluded tables aren't reported as drift.
+func filterToManagedSet(existing, desired []driver.Table, allSourceNorm map[string]bool) []driver.Table {
 	managed := make(map[string]bool, len(desired))
 	for _, t := range desired {
 		managed[strings.ToLower(t.Name)] = true
 	}
 	out := make([]driver.Table, 0, len(existing))
 	for _, t := range existing {
-		if managed[strings.ToLower(t.Name)] || inScope(t.Name, include, exclude) {
+		lt := strings.ToLower(t.Name)
+		if managed[lt] || !allSourceNorm[lt] {
 			out = append(out, t)
 		}
 	}
 	return out
-}
-
-// inScope reports whether a table name passes the include/exclude rules, with
-// create/sync semantics (exclude wins; include, when set, is an allowlist).
-func inScope(name string, include, exclude []string) bool {
-	if matchesAnyExact(name, exclude) {
-		return false
-	}
-	if len(include) > 0 && !matchesAnyExact(name, include) {
-		return false
-	}
-	return true
 }
 
 // loadConstraintsGated loads only the constraint kinds that are managed

--- a/cmd/smt/drift.go
+++ b/cmd/smt/drift.go
@@ -1,0 +1,146 @@
+package main
+
+// `smt drift` — read-only target drift detection (#69). It introspects the
+// EXISTING target schema and compares it against the DESIRED schema derived
+// from the current source, reporting tables/columns that are missing on the
+// target, present only on the target (extra), or changed. Cross-dialect type
+// equivalence is handled by the deterministic comparator, so an mssql
+// varchar(20) does not "drift" against a pg character varying(20).
+//
+// Nothing is modified. Exit status: 0 = in sync, 3 = drift detected, non-zero
+// (cli error) = connection/introspection failure. Useful as a CI gate.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/urfave/cli/v2"
+
+	"smt/internal/config"
+	"smt/internal/driver"
+	"smt/internal/logging"
+	"smt/internal/orchestrator"
+	"smt/internal/pool"
+	"smt/internal/schemadiff"
+)
+
+func driftCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "drift",
+		Usage: "Report schema drift between the source-derived schema and the live target (read-only)",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{Name: "fail-on-destructive-only", Usage: "Exit non-zero only when drift requires drops (extra tables/columns); additive drift exits 0"},
+		},
+		Action: runDrift,
+	}
+}
+
+func runDrift(c *cli.Context) error {
+	cfg, profileName, configPath, err := loadConfig(c)
+	if err != nil {
+		return err
+	}
+
+	orch, err := orchestrator.NewWithOptions(cfg, orchestrator.Options{StateFile: c.String("state-file")})
+	if err != nil {
+		return err
+	}
+	defer orch.Close()
+	orch.SetRunContext(profileName, configPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	// Desired: the current source schema, with identifiers normalized to the
+	// target's on-disk convention so names line up with the introspected
+	// target (mssql "Posts" -> pg "posts").
+	logging.Info("introspecting source schema (%s)", cfg.Source.Schema)
+	desired, err := orch.Source().ExtractSchema(ctx, cfg.Source.Schema)
+	if err != nil {
+		return fmt.Errorf("introspecting source: %w", err)
+	}
+	if err := loadAllConstraints(ctx, orch.Source(), desired); err != nil {
+		return err
+	}
+	normalizeTableNames(desired, cfg.Target.Type)
+
+	// Existing: introspect the live target through a reader on the target
+	// connection.
+	logging.Info("introspecting target schema (%s)", cfg.Target.Schema)
+	targetReader, err := pool.NewSourcePool(targetAsSource(cfg), 4)
+	if err != nil {
+		return fmt.Errorf("opening target reader: %w", err)
+	}
+	defer targetReader.Close()
+	existing, err := targetReader.ExtractSchema(ctx, cfg.Target.Schema)
+	if err != nil {
+		return fmt.Errorf("introspecting target: %w", err)
+	}
+	if err := loadAllConstraints(ctx, targetReader, existing); err != nil {
+		return err
+	}
+
+	drift := schemadiff.ComputeDrift(desired, existing, cfg.Source.Type, cfg.Target.Type)
+	printDriftReport(drift)
+
+	if drift.IsEmpty() {
+		return nil
+	}
+	if c.Bool("fail-on-destructive-only") && !drift.HasDestructiveDrift() {
+		return nil
+	}
+	// cli.Exit sets the process exit code without printing a Go error trace.
+	return cli.Exit("", 3)
+}
+
+// targetAsSource adapts the target connection into a SourceConfig so the same
+// deterministic reader path can introspect it.
+func targetAsSource(cfg *config.Config) *config.SourceConfig {
+	return &config.SourceConfig{
+		Type:            cfg.Target.Type,
+		Host:            cfg.Target.Host,
+		Port:            cfg.Target.Port,
+		Database:        cfg.Target.Database,
+		User:            cfg.Target.User,
+		Password:        cfg.Target.Password,
+		Schema:          cfg.Target.Schema,
+		SSLMode:         cfg.Target.SSLMode,
+		TrustServerCert: cfg.Target.TrustServerCert,
+		Encrypt:         cfg.Target.Encrypt,
+	}
+}
+
+func normalizeTableNames(tables []driver.Table, targetType string) {
+	for i := range tables {
+		tables[i].Name = driver.NormalizeIdentifier(targetType, tables[i].Name)
+		for j := range tables[i].Columns {
+			tables[i].Columns[j].Name = driver.NormalizeIdentifier(targetType, tables[i].Columns[j].Name)
+		}
+	}
+}
+
+func printDriftReport(d schemadiff.Drift) {
+	fmt.Printf("Drift: %s\n", d.Summary())
+	if d.IsEmpty() {
+		return
+	}
+	for _, t := range d.MissingTables {
+		fmt.Printf("  [missing]   table %s — present in source, absent on target\n", t)
+	}
+	for _, t := range d.ExtraTables {
+		fmt.Printf("  [extra]     table %s — on target, not in source (drop is destructive)\n", t)
+	}
+	for _, td := range d.ChangedTables {
+		fmt.Printf("  [changed]   table %s\n", td.Name)
+		for _, c := range td.MissingColumns {
+			fmt.Printf("                + column %s missing on target\n", c)
+		}
+		for _, c := range td.ExtraColumns {
+			fmt.Printf("                - column %s extra on target (drop is destructive)\n", c)
+		}
+		for _, delta := range td.ColumnDeltas {
+			fmt.Printf("                ~ %s\n", delta)
+		}
+	}
+}

--- a/cmd/smt/drift_test.go
+++ b/cmd/smt/drift_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"smt/internal/config"
+	"smt/internal/driver"
 )
 
 // targetAsSource must carry the connection details the target reader needs,
@@ -27,5 +28,22 @@ func TestTargetAsSource_CopiesConnection(t *testing.T) {
 		sc.User != "sa" || sc.Password != "pw" || sc.Schema != "dbo" || !sc.TrustServerCert ||
 		sc.Encrypt == nil || !*sc.Encrypt {
 		t.Errorf("targetAsSource dropped a connection field: %+v", sc)
+	}
+}
+
+// Dialect aliases must canonicalize before driving comparison/normalization,
+// so sqlserver/pg configs don't produce false drift.
+func TestDriftDialectCanonicalization(t *testing.T) {
+	cases := map[string]string{
+		"sqlserver":  "mssql",
+		"pg":         "postgres",
+		"postgresql": "postgres",
+		"mariadb":    "mysql",
+		"mssql":      "mssql",
+	}
+	for in, want := range cases {
+		if got := driver.Canonicalize(in); got != want {
+			t.Errorf("Canonicalize(%q) = %q, want %q", in, got, want)
+		}
 	}
 }

--- a/cmd/smt/drift_test.go
+++ b/cmd/smt/drift_test.go
@@ -48,26 +48,47 @@ func TestDriftDialectCanonicalization(t *testing.T) {
 	}
 }
 
-// A literal include/exclude pattern that the target dialect slugs (spaces →
-// underscores) must still match the normalized target table name.
-func TestFilterTablesByScope_NormalizedLiteral(t *testing.T) {
-	norm := func(s string) string { return driver.NormalizeIdentifier("postgres", s) }
-	// Target table is already normalized to "order_items".
-	tables := []driver.Table{{Name: "order_items"}, {Name: "orders"}}
+// filterDesiredScope must match create/sync exactly: case-sensitive
+// filepath.Match on the original source names (exclude wins; include is an
+// allowlist).
+func TestFilterDesiredScope_MatchesOrchestrator(t *testing.T) {
+	tables := []driver.Table{{Name: "Orders"}, {Name: "AuditLog"}, {Name: "Items"}}
 
-	// Exclude the literal source name "Order Items" — must drop order_items.
-	got := filterTablesByScope(tables, nil, []string{"Order Items"}, norm)
-	if len(got) != 1 || got[0].Name != "orders" {
-		t.Errorf("literal slug-needing exclude failed: %+v", got)
+	// Exclude glob — case-sensitive, like the orchestrator.
+	got := filterDesiredScope(tables, nil, []string{"Audit*"})
+	if len(got) != 2 || got[0].Name != "Orders" || got[1].Name != "Items" {
+		t.Errorf("exclude Audit* = %+v, want [Orders Items]", got)
 	}
-	// Include the literal name — must keep only order_items.
-	got = filterTablesByScope(tables, []string{"Order Items"}, nil, norm)
-	if len(got) != 1 || got[0].Name != "order_items" {
-		t.Errorf("literal slug-needing include failed: %+v", got)
+	// Case-sensitive: lowercase pattern must NOT match the capitalized name.
+	got = filterDesiredScope(tables, nil, []string{"audit*"})
+	if len(got) != 3 {
+		t.Errorf("case-sensitive exclude should not match AuditLog: %+v", got)
 	}
-	// A glob still works via plain CI matching.
-	got = filterTablesByScope(tables, []string{"order*"}, nil, norm)
+	// Include allowlist.
+	got = filterDesiredScope(tables, []string{"Orders"}, nil)
+	if len(got) != 1 || got[0].Name != "Orders" {
+		t.Errorf("include [Orders] = %+v", got)
+	}
+	// No scope → unchanged.
+	if got := filterDesiredScope(tables, nil, nil); len(got) != 3 {
+		t.Errorf("no scope should pass through, got %+v", got)
+	}
+}
+
+// filterToManagedSet scopes the target to managed tables by normalized-name
+// membership (case-insensitive), so out-of-scope target tables aren't compared.
+func TestFilterToManagedSet(t *testing.T) {
+	desired := []driver.Table{{Name: "orders"}, {Name: "items"}} // normalized names
+	existing := []driver.Table{{Name: "orders"}, {Name: "ORDERS_BAK"}, {Name: "items"}, {Name: "audit_log"}}
+	got := filterToManagedSet(existing, desired)
 	if len(got) != 2 {
-		t.Errorf("glob include should match both: %+v", got)
+		t.Fatalf("managed set should keep only orders+items, got %+v", got)
+	}
+	names := map[string]bool{}
+	for _, t := range got {
+		names[t.Name] = true
+	}
+	if !names["orders"] || !names["items"] {
+		t.Errorf("managed set missing expected tables: %+v", got)
 	}
 }

--- a/cmd/smt/drift_test.go
+++ b/cmd/smt/drift_test.go
@@ -47,3 +47,27 @@ func TestDriftDialectCanonicalization(t *testing.T) {
 		}
 	}
 }
+
+// A literal include/exclude pattern that the target dialect slugs (spaces →
+// underscores) must still match the normalized target table name.
+func TestFilterTablesByScope_NormalizedLiteral(t *testing.T) {
+	norm := func(s string) string { return driver.NormalizeIdentifier("postgres", s) }
+	// Target table is already normalized to "order_items".
+	tables := []driver.Table{{Name: "order_items"}, {Name: "orders"}}
+
+	// Exclude the literal source name "Order Items" — must drop order_items.
+	got := filterTablesByScope(tables, nil, []string{"Order Items"}, norm)
+	if len(got) != 1 || got[0].Name != "orders" {
+		t.Errorf("literal slug-needing exclude failed: %+v", got)
+	}
+	// Include the literal name — must keep only order_items.
+	got = filterTablesByScope(tables, []string{"Order Items"}, nil, norm)
+	if len(got) != 1 || got[0].Name != "order_items" {
+		t.Errorf("literal slug-needing include failed: %+v", got)
+	}
+	// A glob still works via plain CI matching.
+	got = filterTablesByScope(tables, []string{"order*"}, nil, norm)
+	if len(got) != 2 {
+		t.Errorf("glob include should match both: %+v", got)
+	}
+}

--- a/cmd/smt/drift_test.go
+++ b/cmd/smt/drift_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"smt/internal/config"
+	"smt/internal/driver"
+)
+
+// normalizeTableNames must fold source identifiers to the target's on-disk
+// convention so desired names line up with the introspected target (PG
+// lowercases; MSSQL/MySQL pass through).
+func TestNormalizeTableNames_Postgres(t *testing.T) {
+	tables := []driver.Table{
+		{Name: "Posts", Columns: []driver.Column{{Name: "Id"}, {Name: "Title"}}},
+	}
+	normalizeTableNames(tables, "postgres")
+	if tables[0].Name != "posts" {
+		t.Errorf("table name = %q, want posts", tables[0].Name)
+	}
+	if tables[0].Columns[0].Name != "id" || tables[0].Columns[1].Name != "title" {
+		t.Errorf("column names not normalized: %+v", tables[0].Columns)
+	}
+}
+
+// targetAsSource must carry the connection details the target reader needs,
+// including the MSSQL TLS knobs, so introspecting an MSSQL target works the
+// same as a source.
+func TestTargetAsSource_CopiesConnection(t *testing.T) {
+	enc := true
+	cfg := &config.Config{}
+	cfg.Target.Type = "mssql"
+	cfg.Target.Host = "tgt-host"
+	cfg.Target.Port = 1433
+	cfg.Target.Database = "TgtDB"
+	cfg.Target.User = "sa"
+	cfg.Target.Password = "pw"
+	cfg.Target.Schema = "dbo"
+	cfg.Target.TrustServerCert = true
+	cfg.Target.Encrypt = &enc
+
+	sc := targetAsSource(cfg)
+	if sc.Type != "mssql" || sc.Host != "tgt-host" || sc.Port != 1433 || sc.Database != "TgtDB" ||
+		sc.User != "sa" || sc.Password != "pw" || sc.Schema != "dbo" || !sc.TrustServerCert ||
+		sc.Encrypt == nil || !*sc.Encrypt {
+		t.Errorf("targetAsSource dropped a connection field: %+v", sc)
+	}
+}

--- a/cmd/smt/drift_test.go
+++ b/cmd/smt/drift_test.go
@@ -4,24 +4,7 @@ import (
 	"testing"
 
 	"smt/internal/config"
-	"smt/internal/driver"
 )
-
-// normalizeTableNames must fold source identifiers to the target's on-disk
-// convention so desired names line up with the introspected target (PG
-// lowercases; MSSQL/MySQL pass through).
-func TestNormalizeTableNames_Postgres(t *testing.T) {
-	tables := []driver.Table{
-		{Name: "Posts", Columns: []driver.Column{{Name: "Id"}, {Name: "Title"}}},
-	}
-	normalizeTableNames(tables, "postgres")
-	if tables[0].Name != "posts" {
-		t.Errorf("table name = %q, want posts", tables[0].Name)
-	}
-	if tables[0].Columns[0].Name != "id" || tables[0].Columns[1].Name != "title" {
-		t.Errorf("column names not normalized: %+v", tables[0].Columns)
-	}
-}
 
 // targetAsSource must carry the connection details the target reader needs,
 // including the MSSQL TLS knobs, so introspecting an MSSQL target works the

--- a/cmd/smt/drift_test.go
+++ b/cmd/smt/drift_test.go
@@ -75,20 +75,33 @@ func TestFilterDesiredScope_MatchesOrchestrator(t *testing.T) {
 	}
 }
 
-// filterToManagedSet scopes the target to managed tables by normalized-name
-// membership (case-insensitive), so out-of-scope target tables aren't compared.
+// filterToManagedSet keeps managed tables (by normalized-name membership) and
+// in-scope target-only extras, dropping out-of-scope target tables.
 func TestFilterToManagedSet(t *testing.T) {
 	desired := []driver.Table{{Name: "orders"}, {Name: "items"}} // normalized names
-	existing := []driver.Table{{Name: "orders"}, {Name: "ORDERS_BAK"}, {Name: "items"}, {Name: "audit_log"}}
-	got := filterToManagedSet(existing, desired)
+	existing := []driver.Table{{Name: "orders"}, {Name: "items"}, {Name: "legacy"}}
+
+	// include ["*"] is a no-op for create/sync, so a target-only "legacy"
+	// table must still surface (it's in scope) for extra detection.
+	got := filterToManagedSet(existing, desired, []string{"*"}, nil)
+	if len(got) != 3 {
+		t.Errorf("include [*] should keep managed + in-scope extra: %+v", got)
+	}
+
+	// exclude ["legacy"] drops the target-only table from scope.
+	got = filterToManagedSet(existing, desired, nil, []string{"legacy"})
+	for _, tb := range got {
+		if tb.Name == "legacy" {
+			t.Errorf("excluded table should be dropped: %+v", got)
+		}
+	}
 	if len(got) != 2 {
-		t.Fatalf("managed set should keep only orders+items, got %+v", got)
+		t.Errorf("exclude [legacy] should keep only managed: %+v", got)
 	}
-	names := map[string]bool{}
-	for _, t := range got {
-		names[t.Name] = true
-	}
-	if !names["orders"] || !names["items"] {
-		t.Errorf("managed set missing expected tables: %+v", got)
+
+	// include allowlist that doesn't cover the extra → extra not surfaced.
+	got = filterToManagedSet(existing, desired, []string{"orders", "items"}, nil)
+	if len(got) != 2 {
+		t.Errorf("include allowlist should drop out-of-scope legacy: %+v", got)
 	}
 }

--- a/cmd/smt/drift_test.go
+++ b/cmd/smt/drift_test.go
@@ -75,33 +75,31 @@ func TestFilterDesiredScope_MatchesOrchestrator(t *testing.T) {
 	}
 }
 
-// filterToManagedSet keeps managed tables (by normalized-name membership) and
-// in-scope target-only extras, dropping out-of-scope target tables.
+// filterToManagedSet keeps managed tables and genuine target-only extras,
+// dropping target tables that correspond to an out-of-scope (e.g. excluded)
+// source table.
 func TestFilterToManagedSet(t *testing.T) {
-	desired := []driver.Table{{Name: "orders"}, {Name: "items"}} // normalized names
-	existing := []driver.Table{{Name: "orders"}, {Name: "items"}, {Name: "legacy"}}
-
-	// include ["*"] is a no-op for create/sync, so a target-only "legacy"
-	// table must still surface (it's in scope) for extra detection.
-	got := filterToManagedSet(existing, desired, []string{"*"}, nil)
-	if len(got) != 3 {
-		t.Errorf("include [*] should keep managed + in-scope extra: %+v", got)
+	// Source has orders, items, auditlog; auditlog is excluded → not in desired.
+	desired := []driver.Table{{Name: "orders"}, {Name: "items"}} // managed (normalized)
+	allSource := map[string]bool{"orders": true, "items": true, "auditlog": true}
+	existing := []driver.Table{
+		{Name: "orders"},   // managed
+		{Name: "items"},    // managed
+		{Name: "auditlog"}, // excluded source table on target → drop
+		{Name: "legacy"},   // target-only, not a source table → keep (extra)
 	}
-
-	// exclude ["legacy"] drops the target-only table from scope.
-	got = filterToManagedSet(existing, desired, nil, []string{"legacy"})
+	got := filterToManagedSet(existing, desired, allSource)
+	names := map[string]bool{}
 	for _, tb := range got {
-		if tb.Name == "legacy" {
-			t.Errorf("excluded table should be dropped: %+v", got)
-		}
+		names[tb.Name] = true
 	}
-	if len(got) != 2 {
-		t.Errorf("exclude [legacy] should keep only managed: %+v", got)
+	if names["auditlog"] {
+		t.Error("excluded source table on target must be dropped from drift scope")
 	}
-
-	// include allowlist that doesn't cover the extra → extra not surfaced.
-	got = filterToManagedSet(existing, desired, []string{"orders", "items"}, nil)
-	if len(got) != 2 {
-		t.Errorf("include allowlist should drop out-of-scope legacy: %+v", got)
+	if !names["orders"] || !names["items"] {
+		t.Error("managed tables must be kept")
+	}
+	if !names["legacy"] {
+		t.Error("genuine target-only table must be kept for extra detection")
 	}
 }

--- a/cmd/smt/main.go
+++ b/cmd/smt/main.go
@@ -125,6 +125,7 @@ func commands() []*cli.Command {
 	return []*cli.Command{
 		createCommand(),
 		syncCommand(),
+		driftCommand(),
 		snapshotCommand(),
 		healthCheckCommand(),
 		initSecretsCommand(),

--- a/cmd/smt/main.go
+++ b/cmd/smt/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -32,6 +33,17 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
+		// A command that returns a cli.ExitCoder (e.g. `smt drift` signaling
+		// "drift detected" with cli.Exit("", 3)) owns its exit code and is not
+		// an error condition — exit with that code and print its message only
+		// if it carries one, without the generic Error/Exit-code banner.
+		var coder cli.ExitCoder
+		if errors.As(err, &coder) {
+			if msg := err.Error(); msg != "" {
+				fmt.Fprintln(os.Stderr, msg)
+			}
+			os.Exit(coder.ExitCode())
+		}
 		code := exitcodes.FromError(err)
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Exit code %d (%s)\n", code, exitcodes.Description(code))

--- a/internal/driver/verify_compare.go
+++ b/internal/driver/verify_compare.go
@@ -507,14 +507,17 @@ func defaultExpressionClass(expr string) string {
 	if strings.HasPrefix(norm, "n'") && strings.HasSuffix(norm, "'") {
 		norm = norm[1:]
 	}
-	// Strip a trailing "at time zone '<tz>'" wrapper. PG renders MSSQL
+	// Strip a trailing "at time zone 'utc'" wrapper only. PG renders MSSQL
 	// GETUTCDATE() / SYSUTCDATETIME() as `CURRENT_TIMESTAMP AT TIME ZONE
-	// 'UTC'`, which is still a current-datetime default — the TZ conversion
-	// is a class detail checked separately via cmpTZClass on data_type.
-	// Without this, a freshly-created target round-trips its own default and
-	// the comparator would flag it as drift (current_dt vs other:...).
+	// 'UTC'`, which is still a current-datetime (UTC) default — the TZ
+	// conversion is a class detail checked separately via cmpTZClass on
+	// data_type. A NON-UTC zone (e.g. 'America/Chicago') changes the inserted
+	// value, so it must stay part of the class and not collapse to a bare
+	// current_timestamp.
 	if i := strings.Index(norm, " at time zone "); i >= 0 {
-		norm = strings.TrimSpace(norm[:i])
+		if zone := strings.TrimSpace(norm[i+len(" at time zone "):]); zone == "'utc'" {
+			norm = strings.TrimSpace(norm[:i])
+		}
 	}
 
 	// "Now-style" function families. Split into three classes by what the

--- a/internal/driver/verify_compare.go
+++ b/internal/driver/verify_compare.go
@@ -132,6 +132,15 @@ func cmpMaxLength(src, tgt Column, srcDialect, tgtDialect string) *ColumnDelta {
 	if isBinaryFamilyType(src.DataType) && strings.EqualFold(strings.TrimSpace(tgt.DataType), "bytea") {
 		return nil
 	}
+	// A MySQL ENUM/SET maps to an unbounded target type (pg text) on a
+	// non-MySQL target; the enum's reported max_length is the longest member,
+	// not a user bound, so length must not flag there. Scoped to an unbounded
+	// target so a same-dialect ENUM→ENUM still compares length (and an
+	// ENUM→TEXT change on a MySQL target keeps its length signal). The enum
+	// VALUE list itself is a #62 follow-up, not compared here.
+	if isEnumSetType(src.DataType) && lobDataTypes[strings.ToLower(strings.TrimSpace(tgt.DataType))] {
+		return nil
+	}
 	// MySQL's LOB tiers ARE user-meaningful capacity choices when both
 	// sides speak them: LONGTEXT → TEXT silently rejects values above
 	// 64KiB, so a same-family tier change must flag even though both types
@@ -209,18 +218,11 @@ func normMaxLength(n int) int {
 // fixed capacity (65535, 16777215, ...), pg text/bytea report NULL → 0.
 // None of those numbers round-trip across dialects even when the mapping
 // is perfectly faithful, so they all collapse to the unbounded class.
-//
-// enum/set are included because their reported max_length is the longest
-// member value, not a user-chosen bound — and SMT maps a MySQL ENUM/SET to
-// an unbounded target type (pg text) on non-MySQL targets, so the length
-// must not flag. (The enum VALUE list, when both sides are MySQL, is a
-// separate concern not covered by length comparison.)
 var lobDataTypes = map[string]bool{
 	"text": true, "ntext": true, "image": true,
 	"tinytext": true, "mediumtext": true, "longtext": true,
 	"blob": true, "tinyblob": true, "mediumblob": true, "longblob": true,
 	"bytea": true, "xml": true,
-	"enum": true, "set": true,
 }
 
 // effectiveMaxLength is normMaxLength with LOB awareness: LOB types compare
@@ -230,6 +232,16 @@ func effectiveMaxLength(c Column) int {
 		return 0
 	}
 	return normMaxLength(c.MaxLength)
+}
+
+// isEnumSetType reports whether the type is a MySQL ENUM or SET.
+func isEnumSetType(dt string) bool {
+	switch strings.ToLower(strings.TrimSpace(dt)) {
+	case "enum", "set":
+		return true
+	default:
+		return false
+	}
 }
 
 // isBinaryFamilyType reports whether the type stores raw bytes (sized or

--- a/internal/driver/verify_compare.go
+++ b/internal/driver/verify_compare.go
@@ -133,12 +133,14 @@ func cmpMaxLength(src, tgt Column, srcDialect, tgtDialect string) *ColumnDelta {
 		return nil
 	}
 	// A MySQL ENUM/SET maps to an unbounded target type (pg text) on a
-	// non-MySQL target; the enum's reported max_length is the longest member,
-	// not a user bound, so length must not flag there. Scoped to an unbounded
-	// target so a same-dialect ENUM→ENUM still compares length (and an
-	// ENUM→TEXT change on a MySQL target keeps its length signal). The enum
-	// VALUE list itself is a #62 follow-up, not compared here.
-	if isEnumSetType(src.DataType) && lobDataTypes[strings.ToLower(strings.TrimSpace(tgt.DataType))] {
+	// NON-MySQL target; the enum's reported max_length is the longest member,
+	// not a user bound, so length must not flag there. Gated on a non-MySQL
+	// target so a same-dialect ENUM→ENUM still compares length AND an
+	// ENUM→TEXT change on a MySQL target keeps its length signal (the only
+	// delta that reveals the enum constraint was lost). The enum VALUE list
+	// itself is a #62 follow-up, not compared here.
+	if isEnumSetType(src.DataType) && !isMySQLDialect(tgtDialect) &&
+		lobDataTypes[strings.ToLower(strings.TrimSpace(tgt.DataType))] {
 		return nil
 	}
 	// MySQL's LOB tiers ARE user-meaningful capacity choices when both
@@ -232,6 +234,16 @@ func effectiveMaxLength(c Column) int {
 		return 0
 	}
 	return normMaxLength(c.MaxLength)
+}
+
+// isMySQLDialect reports whether the dialect is MySQL/MariaDB.
+func isMySQLDialect(dialect string) bool {
+	switch strings.ToLower(strings.TrimSpace(dialect)) {
+	case "mysql", "mariadb":
+		return true
+	default:
+		return false
+	}
 }
 
 // isEnumSetType reports whether the type is a MySQL ENUM or SET.

--- a/internal/driver/verify_compare.go
+++ b/internal/driver/verify_compare.go
@@ -16,8 +16,15 @@ package driver
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
+
+// fspNowArgPattern matches a bare function name with a single numeric
+// (fractional-seconds) argument, e.g. "current_timestamp(6)" or "now(3)",
+// capturing the function name so the precision arg can be dropped for
+// default-class comparison.
+var fspNowArgPattern = regexp.MustCompile(`^([a-z_]+)\([0-9]+\)$`)
 
 // ColumnDelta records a single per-(column, criterion) mismatch from
 // CompareColumns. Format() renders it in the same wire shape #53's prompt
@@ -202,11 +209,18 @@ func normMaxLength(n int) int {
 // fixed capacity (65535, 16777215, ...), pg text/bytea report NULL → 0.
 // None of those numbers round-trip across dialects even when the mapping
 // is perfectly faithful, so they all collapse to the unbounded class.
+//
+// enum/set are included because their reported max_length is the longest
+// member value, not a user-chosen bound — and SMT maps a MySQL ENUM/SET to
+// an unbounded target type (pg text) on non-MySQL targets, so the length
+// must not flag. (The enum VALUE list, when both sides are MySQL, is a
+// separate concern not covered by length comparison.)
 var lobDataTypes = map[string]bool{
 	"text": true, "ntext": true, "image": true,
 	"tinytext": true, "mediumtext": true, "longtext": true,
 	"blob": true, "tinyblob": true, "mediumblob": true, "longblob": true,
 	"bytea": true, "xml": true,
+	"enum": true, "set": true,
 }
 
 // effectiveMaxLength is normMaxLength with LOB awareness: LOB types compare
@@ -518,6 +532,15 @@ func defaultExpressionClass(expr string) string {
 		if zone := strings.TrimSpace(norm[i+len(" at time zone "):]); zone == "'utc'" {
 			norm = strings.TrimSpace(norm[:i])
 		}
+	}
+	// Strip a fractional-seconds precision argument from a now-function:
+	// CURRENT_TIMESTAMP(6) ≡ CURRENT_TIMESTAMP, NOW(3) ≡ NOW(). The precision
+	// is a column-level detail (DatetimePrecision), not a default class — MySQL
+	// reports `CURRENT_TIMESTAMP(6)` while a PG target renders bare
+	// `CURRENT_TIMESTAMP`. Only a bare function-name with a numeric arg is
+	// reduced, so literals and multi-arg calls are untouched.
+	if m := fspNowArgPattern.FindStringSubmatch(norm); m != nil {
+		norm = m[1]
 	}
 
 	// "Now-style" function families. Split into three classes by what the

--- a/internal/driver/verify_compare.go
+++ b/internal/driver/verify_compare.go
@@ -507,6 +507,15 @@ func defaultExpressionClass(expr string) string {
 	if strings.HasPrefix(norm, "n'") && strings.HasSuffix(norm, "'") {
 		norm = norm[1:]
 	}
+	// Strip a trailing "at time zone '<tz>'" wrapper. PG renders MSSQL
+	// GETUTCDATE() / SYSUTCDATETIME() as `CURRENT_TIMESTAMP AT TIME ZONE
+	// 'UTC'`, which is still a current-datetime default — the TZ conversion
+	// is a class detail checked separately via cmpTZClass on data_type.
+	// Without this, a freshly-created target round-trips its own default and
+	// the comparator would flag it as drift (current_dt vs other:...).
+	if i := strings.Index(norm, " at time zone "); i >= 0 {
+		norm = strings.TrimSpace(norm[:i])
+	}
 
 	// "Now-style" function families. Split into three classes by what the
 	// function actually returns: full date+time (current_dt), date-only

--- a/internal/driver/verify_compare.go
+++ b/internal/driver/verify_compare.go
@@ -536,6 +536,7 @@ func defaultExpressionClass(expr string) string {
 	case "current_timestamp", "now()", "now",
 		"getdate()", "getdate", "getutcdate()", "getutcdate",
 		"sysdatetime()", "sysdatetime",
+		"sysutcdatetime()", "sysutcdatetime",
 		"sysdatetimeoffset()", "sysdatetimeoffset",
 		"systimestamp",
 		"localtimestamp", "localtimestamp()":

--- a/internal/driver/verify_compare_test.go
+++ b/internal/driver/verify_compare_test.go
@@ -680,3 +680,16 @@ func hasCriterion(ds []ColumnDelta, crit string) bool {
 	}
 	return false
 }
+
+// ENUM→TEXT keeps its length signal on a MySQL target (the enum constraint
+// was lost) but is exempt cross-dialect (faithful enum→pg text mapping).
+func TestCompareColumns_EnumToTextMySQLTargetFlags(t *testing.T) {
+	src := []Column{{Name: "s", DataType: "enum", MaxLength: 8}}
+	tgtText := []Column{{Name: "s", DataType: "text", MaxLength: 0}}
+	if !hasCriterion(CompareColumns(src, tgtText, "mysql", "mysql"), "max_length") {
+		t.Error("enum→text on a mysql target should flag (enum constraint lost)")
+	}
+	if hasCriterion(CompareColumns(src, tgtText, "mysql", "postgres"), "max_length") {
+		t.Error("enum→text cross-dialect (pg) should not flag")
+	}
+}

--- a/internal/driver/verify_compare_test.go
+++ b/internal/driver/verify_compare_test.go
@@ -598,3 +598,20 @@ func TestDefaultExpressionClass_UTCNowEquivalence(t *testing.T) {
 		}
 	}
 }
+
+// Only the UTC AT TIME ZONE form collapses to current_dt; a non-UTC zone
+// changes the value and must stay a distinct class so it doesn't match a
+// plain UTC now-default.
+func TestDefaultExpressionClass_NonUTCZonePreserved(t *testing.T) {
+	utc := defaultExpressionClass("CURRENT_TIMESTAMP AT TIME ZONE 'UTC'")
+	chicago := defaultExpressionClass("CURRENT_TIMESTAMP AT TIME ZONE 'America/Chicago'")
+	if utc != "current_dt" {
+		t.Errorf("UTC form should be current_dt, got %q", utc)
+	}
+	if chicago == "current_dt" {
+		t.Error("non-UTC zone must not collapse to current_dt")
+	}
+	if utc == chicago {
+		t.Error("UTC and non-UTC AT TIME ZONE defaults must classify differently")
+	}
+}

--- a/internal/driver/verify_compare_test.go
+++ b/internal/driver/verify_compare_test.go
@@ -625,3 +625,32 @@ func TestDefaultExpressionClass_SysUTCDatetime(t *testing.T) {
 		}
 	}
 }
+
+// MySQL ENUM/SET → unbounded target (pg text) must not flag a length delta:
+// the enum's reported max_length is the longest member, not a user bound.
+func TestCompareColumns_EnumToTextNoLengthDrift(t *testing.T) {
+	src := []Column{{Name: "status", DataType: "enum", MaxLength: 8}}
+	tgt := []Column{{Name: "status", DataType: "text", MaxLength: 0}}
+	for _, d := range CompareColumns(src, tgt, "mysql", "postgres") {
+		if d.Criterion == "max_length" {
+			t.Errorf("enum→text should not flag max_length: %s", d.String())
+		}
+	}
+}
+
+// CURRENT_TIMESTAMP(6) (MySQL fsp) ≡ CURRENT_TIMESTAMP — the precision is a
+// column detail, not a default class, so it must not flag a default delta.
+func TestDefaultExpressionClass_NowFspArgStripped(t *testing.T) {
+	for _, f := range []string{"current_timestamp(6)", "CURRENT_TIMESTAMP(3)", "now(6)", "(current_timestamp(6))"} {
+		if got := defaultExpressionClass(f); got != "current_dt" {
+			t.Errorf("defaultExpressionClass(%q) = %q, want current_dt", f, got)
+		}
+	}
+	src := []Column{{Name: "at", DataType: "datetime", DefaultExpression: "CURRENT_TIMESTAMP(6)"}}
+	tgt := []Column{{Name: "at", DataType: "timestamp", DefaultExpression: "CURRENT_TIMESTAMP"}}
+	for _, d := range CompareColumns(src, tgt, "mysql", "postgres") {
+		if d.Criterion == "default" {
+			t.Errorf("CURRENT_TIMESTAMP(6)→CURRENT_TIMESTAMP should not flag default: %s", d.String())
+		}
+	}
+}

--- a/internal/driver/verify_compare_test.go
+++ b/internal/driver/verify_compare_test.go
@@ -615,3 +615,13 @@ func TestDefaultExpressionClass_NonUTCZonePreserved(t *testing.T) {
 		t.Error("UTC and non-UTC AT TIME ZONE defaults must classify differently")
 	}
 }
+
+// SYSUTCDATETIME() (MSSQL UTC now) must classify as current_dt so it matches
+// the PG `CURRENT_TIMESTAMP AT TIME ZONE 'UTC'` SMT renders from it.
+func TestDefaultExpressionClass_SysUTCDatetime(t *testing.T) {
+	for _, f := range []string{"sysutcdatetime()", "SYSUTCDATETIME()", "(sysutcdatetime())"} {
+		if got := defaultExpressionClass(f); got != "current_dt" {
+			t.Errorf("defaultExpressionClass(%q) = %q, want current_dt", f, got)
+		}
+	}
+}

--- a/internal/driver/verify_compare_test.go
+++ b/internal/driver/verify_compare_test.go
@@ -570,3 +570,31 @@ func TestCompareColumns_MySQLLOBTiers(t *testing.T) {
 		})
 	}
 }
+
+// PG renders MSSQL GETUTCDATE()/SYSUTCDATETIME() as CURRENT_TIMESTAMP AT TIME
+// ZONE 'UTC'. Both are current-datetime defaults; the comparator must treat
+// them as equivalent so a freshly-created target doesn't report drift.
+func TestDefaultExpressionClass_UTCNowEquivalence(t *testing.T) {
+	utcForms := []string{
+		"getutcdate()",
+		"(getutcdate())",
+		"CURRENT_TIMESTAMP AT TIME ZONE 'UTC'",
+		"(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')",
+		"(CURRENT_TIMESTAMP AT TIME ZONE 'UTC'::text)",
+		"current_timestamp",
+	}
+	for _, f := range utcForms {
+		if got := defaultExpressionClass(f); got != "current_dt" {
+			t.Errorf("defaultExpressionClass(%q) = %q, want current_dt", f, got)
+		}
+	}
+	// A source getutcdate() column vs a target rendered as the PG UTC form
+	// must not flag a default delta.
+	src := []Column{{Name: "at", DataType: "datetime2", DefaultExpression: "(getutcdate())"}}
+	tgt := []Column{{Name: "at", DataType: "timestamp", DefaultExpression: "(CURRENT_TIMESTAMP AT TIME ZONE 'UTC'::text)"}}
+	for _, d := range CompareColumns(src, tgt, "mssql", "postgres") {
+		if d.Criterion == "default" {
+			t.Errorf("unexpected default delta for UTC-now round-trip: %s", d.String())
+		}
+	}
+}

--- a/internal/driver/verify_compare_test.go
+++ b/internal/driver/verify_compare_test.go
@@ -654,3 +654,29 @@ func TestDefaultExpressionClass_NowFspArgStripped(t *testing.T) {
 		}
 	}
 }
+
+// enum/set exemption is scoped to an unbounded target: ENUM→TEXT cross-dialect
+// doesn't flag length, but a same-dialect ENUM→ENUM still compares length.
+func TestCompareColumns_EnumExemptionScoped(t *testing.T) {
+	// enum → pg text: exempt, no length flag.
+	if d := CompareColumns(
+		[]Column{{Name: "s", DataType: "enum", MaxLength: 8}},
+		[]Column{{Name: "s", DataType: "text", MaxLength: 0}}, "mysql", "postgres"); hasCriterion(d, "max_length") {
+		t.Error("enum→text should not flag max_length")
+	}
+	// enum → enum (mysql→mysql) with different length still flags.
+	if d := CompareColumns(
+		[]Column{{Name: "s", DataType: "enum", MaxLength: 3}},
+		[]Column{{Name: "s", DataType: "enum", MaxLength: 8}}, "mysql", "mysql"); !hasCriterion(d, "max_length") {
+		t.Error("enum→enum length difference should flag (value-set proxy)")
+	}
+}
+
+func hasCriterion(ds []ColumnDelta, crit string) bool {
+	for _, d := range ds {
+		if d.Criterion == crit {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -1,0 +1,184 @@
+package schemadiff
+
+// Target-aware drift detection (#69). The snapshot-based Compute() diffs the
+// source against its own stored history; it cannot tell whether the target
+// actually matches what the source implies. ComputeDrift closes that gap by
+// comparing the DESIRED target schema (derived from the current source) against
+// the EXISTING target schema (introspected live), classifying each difference
+// as missing / extra / changed.
+//
+// Cross-dialect column comparison is the crux: a source `varchar(20)` and a
+// target `character varying(20)` are equivalent even though their data_type
+// strings differ, so column drift is judged by driver.CompareColumns (the same
+// deterministic equivalence rules the optional AI reviewer uses), not by raw
+// string equality.
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"smt/internal/driver"
+)
+
+// Drift is the classified difference between the desired and existing target
+// schemas. It is read-only intelligence — callers decide what to do with it.
+type Drift struct {
+	// MissingTables are desired (in source) but absent on the target — they
+	// would need creation. Stable, sorted by normalized name.
+	MissingTables []string
+	// ExtraTables exist on the target but are not in the source. Dropping one
+	// is destructive, so they are reported, never acted on here.
+	ExtraTables []string
+	// ChangedTables exist on both sides but differ in columns.
+	ChangedTables []TableDrift
+}
+
+// TableDrift captures per-table column drift for a table present on both sides.
+type TableDrift struct {
+	Name string
+	// MissingColumns are in the source but absent on the target.
+	MissingColumns []string
+	// ExtraColumns exist on the target but not in the source. Dropping one is
+	// destructive.
+	ExtraColumns []string
+	// ColumnDeltas are columns present on both sides whose metadata differs
+	// (type class, length, precision, nullability, identity, default class).
+	// Each entry is a human-readable description from the deterministic
+	// comparator.
+	ColumnDeltas []string
+}
+
+// IsEmpty reports whether the target matches the desired schema.
+func (d Drift) IsEmpty() bool {
+	return len(d.MissingTables) == 0 && len(d.ExtraTables) == 0 && len(d.ChangedTables) == 0
+}
+
+// Summary returns a one-line description of the drift.
+func (d Drift) Summary() string {
+	if d.IsEmpty() {
+		return "no drift: target matches the source-derived schema"
+	}
+	parts := make([]string, 0, 3)
+	if n := len(d.MissingTables); n > 0 {
+		parts = append(parts, plural(n, "missing table", "missing tables"))
+	}
+	if n := len(d.ExtraTables); n > 0 {
+		parts = append(parts, plural(n, "extra table", "extra tables"))
+	}
+	if n := len(d.ChangedTables); n > 0 {
+		parts = append(parts, plural(n, "changed table", "changed tables"))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// HasDestructiveDrift reports whether reconciling the target to the source
+// would require dropping objects (extra tables or columns). Useful for a
+// CI drift gate that wants to distinguish additive drift from destructive.
+func (d Drift) HasDestructiveDrift() bool {
+	if len(d.ExtraTables) > 0 {
+		return true
+	}
+	for _, t := range d.ChangedTables {
+		if len(t.ExtraColumns) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// ComputeDrift compares the desired target schema (the current source tables,
+// in source-dialect metadata) against the existing target schema (introspected
+// from the live target, in target-dialect metadata). Tables and columns are
+// matched case-insensitively by name; the caller is responsible for having
+// normalized desired identifiers to the target's on-disk convention so the
+// names line up (see Diff.Normalize / driver.NormalizeIdentifier).
+//
+// sourceDialect/targetDialect drive the cross-dialect column comparison.
+func ComputeDrift(desired, existing []driver.Table, sourceDialect, targetDialect string) Drift {
+	desiredByName := indexByLowerName(desired)
+	existingByName := indexByLowerName(existing)
+
+	var d Drift
+	for _, name := range sortedLowerKeys(desiredByName) {
+		want := desiredByName[name]
+		have, ok := existingByName[name]
+		if !ok {
+			d.MissingTables = append(d.MissingTables, name)
+			continue
+		}
+		if td, changed := tableDrift(want, have, sourceDialect, targetDialect); changed {
+			d.ChangedTables = append(d.ChangedTables, td)
+		}
+	}
+	for _, name := range sortedLowerKeys(existingByName) {
+		if _, ok := desiredByName[name]; !ok {
+			d.ExtraTables = append(d.ExtraTables, name)
+		}
+	}
+	return d
+}
+
+func tableDrift(want, have driver.Table, sourceDialect, targetDialect string) (TableDrift, bool) {
+	td := TableDrift{Name: strings.ToLower(have.Name)}
+
+	wantCols := lowerColNames(want.Columns)
+
+	// Extra columns (on target, not desired) — reported separately because
+	// CompareColumns is intentionally source-driven and ignores them.
+	for _, c := range have.Columns {
+		if !wantCols[strings.ToLower(c.Name)] {
+			td.ExtraColumns = append(td.ExtraColumns, strings.ToLower(c.Name))
+		}
+	}
+
+	// Missing columns + per-column metadata drift via the deterministic
+	// cross-dialect comparator. "missing" deltas become MissingColumns; the
+	// rest become ColumnDeltas.
+	for _, delta := range driver.CompareColumns(want.Columns, have.Columns, sourceDialect, targetDialect) {
+		if delta.Criterion == "missing" {
+			td.MissingColumns = append(td.MissingColumns, strings.ToLower(delta.Column))
+			continue
+		}
+		td.ColumnDeltas = append(td.ColumnDeltas, delta.String())
+	}
+
+	sort.Strings(td.MissingColumns)
+	sort.Strings(td.ExtraColumns)
+	sort.Strings(td.ColumnDeltas)
+
+	changed := len(td.MissingColumns) > 0 || len(td.ExtraColumns) > 0 || len(td.ColumnDeltas) > 0
+	return td, changed
+}
+
+func indexByLowerName(tables []driver.Table) map[string]driver.Table {
+	out := make(map[string]driver.Table, len(tables))
+	for _, t := range tables {
+		out[strings.ToLower(t.Name)] = t
+	}
+	return out
+}
+
+func sortedLowerKeys(m map[string]driver.Table) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func lowerColNames(cols []driver.Column) map[string]bool {
+	out := make(map[string]bool, len(cols))
+	for _, c := range cols {
+		out[strings.ToLower(c.Name)] = true
+	}
+	return out
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return "1 " + one
+	}
+	return strconv.Itoa(n) + " " + many
+}

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -125,6 +125,29 @@ func deepCopyTable(t driver.Table) driver.Table {
 	return t
 }
 
+// RetargetSchema returns a deep copy of tables with every schema reference
+// (the table's own Schema and each foreign key's RefSchema) set to
+// targetSchema. SMT migrates source.X to target.Y, so a same-schema FK on the
+// source resolves to the target schema; aligning both sides lets FK drift
+// signatures (which include the referenced schema) compare equal instead of
+// flagging a source-vs-target schema-name difference. The input is not
+// mutated. A pass-through when targetSchema is empty.
+func RetargetSchema(tables []driver.Table, targetSchema string) []driver.Table {
+	if strings.TrimSpace(targetSchema) == "" {
+		return tables
+	}
+	out := make([]driver.Table, len(tables))
+	for i := range tables {
+		t := deepCopyTable(tables[i])
+		t.Schema = targetSchema
+		for j := range t.ForeignKeys {
+			t.ForeignKeys[j].RefSchema = targetSchema
+		}
+		out[i] = t
+	}
+	return out
+}
+
 // IsEmpty reports whether the target matches the desired schema.
 func (d Drift) IsEmpty() bool {
 	return len(d.MissingTables) == 0 && len(d.ExtraTables) == 0 && len(d.ChangedTables) == 0
@@ -366,7 +389,11 @@ func fkKeys(fks []driver.ForeignKey) []string {
 			}
 			pairs[i] = strings.ToLower(c) + ":" + ref
 		}
-		out = append(out, strings.Join(pairs, ",")+"->"+strings.ToLower(fk.RefTable)+
+		ref := strings.ToLower(fk.RefTable)
+		if s := strings.TrimSpace(fk.RefSchema); s != "" {
+			ref = strings.ToLower(s) + "." + ref
+		}
+		out = append(out, strings.Join(pairs, ",")+"->"+ref+
 			"|"+normAction(fk.OnDelete)+"|"+normAction(fk.OnUpdate))
 	}
 	return out

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -228,15 +228,23 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, op
 	// cross-dialect equivalences the comparator already understands
 	// (bit→boolean, uniqueidentifier→char(36), json→jsonb) don't false-flag.
 	//
-	// Known limitations, all rooted in the lack of cross-dialect expression /
-	// concrete-type normalization (#62): a SAME-family type change the
+	// The flag fires only when BOTH sides resolve to a known class and the
+	// classes differ. A ONE-SIDED class (e.g. source numeric `int` vs a target
+	// the classifier doesn't cover, like `uuid` or pg `bit`/`bit varying`) is
+	// deliberately NOT flagged: the unrecognized side is exactly where legit
+	// cross-dialect equivalences live (uniqueidentifier→char(36), uuid→char(36)
+	// that CompareColumns handles specially), so flagging "known vs unknown"
+	// would false-positive on those. Catching those one-sided cases correctly
+	// needs the canonical concrete-type model (#62).
+	//
+	// Other known limitations, same #62 root: a SAME-family type change the
 	// comparator treats as equivalent (integer→bigint, varchar(20)→char(20))
 	// is not flagged, and per-column EXPRESSION/value details whose text
 	// differs across dialects — a changed computed expression body, MySQL
 	// ENUM/SET value lists, ON UPDATE expressions, spatial SRID — are not
 	// compared either. Drift catches presence/structure (computed Y/N + storage
 	// class, type family, length/precision/nullability/identity/TZ/default)
-	// today; expression-level equivalence is follow-up work.
+	// today; expression-level and concrete-type equivalence is follow-up work.
 	haveByName := make(map[string]driver.Column, len(have.Columns))
 	for _, c := range have.Columns {
 		haveByName[strings.ToLower(c.Name)] = c

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -34,7 +34,7 @@ type Drift struct {
 	ChangedTables []TableDrift
 }
 
-// TableDrift captures per-table column drift for a table present on both sides.
+// TableDrift captures per-table drift for a table present on both sides.
 type TableDrift struct {
 	Name string
 	// MissingColumns are in the source but absent on the target.
@@ -47,6 +47,25 @@ type TableDrift struct {
 	// Each entry is a human-readable description from the deterministic
 	// comparator.
 	ColumnDeltas []string
+	// MissingIndexes / ExtraIndexes are secondary-index column sets present on
+	// only one side (matched by column set, not name, since the renderer
+	// normalizes index names per dialect).
+	MissingIndexes []string
+	ExtraIndexes   []string
+	// MissingForeignKeys / ExtraForeignKeys are FK signatures ("(cols)->ref")
+	// present on only one side.
+	MissingForeignKeys []string
+	ExtraForeignKeys   []string
+	// CheckDrift is non-empty when the target has fewer CHECK constraints than
+	// the source (a likely dropped check). Predicate text is rewritten
+	// cross-dialect, so checks are compared by count, not text.
+	CheckDrift string
+}
+
+func (td TableDrift) hasChanges() bool {
+	return len(td.MissingColumns) > 0 || len(td.ExtraColumns) > 0 || len(td.ColumnDeltas) > 0 ||
+		len(td.MissingIndexes) > 0 || len(td.ExtraIndexes) > 0 ||
+		len(td.MissingForeignKeys) > 0 || len(td.ExtraForeignKeys) > 0 || td.CheckDrift != ""
 }
 
 // IsEmpty reports whether the target matches the desired schema.
@@ -143,12 +162,78 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string) (T
 		td.ColumnDeltas = append(td.ColumnDeltas, delta.String())
 	}
 
+	// Secondary indexes, matched by column set (names are renderer-normalized
+	// per dialect, so they don't compare across engines).
+	td.MissingIndexes, td.ExtraIndexes = diffKeys(indexKeys(want.Indexes), indexKeys(have.Indexes))
+	// Foreign keys, matched by local column set + referenced table.
+	td.MissingForeignKeys, td.ExtraForeignKeys = diffKeys(fkKeys(want.ForeignKeys), fkKeys(have.ForeignKeys))
+	// CHECK constraints: predicate text is rewritten cross-dialect, so a
+	// faithful target may carry textually different predicates. Only flag a
+	// likely drop — the target having fewer checks than the source.
+	if len(have.CheckConstraints) < len(want.CheckConstraints) {
+		td.CheckDrift = "source has " + strconv.Itoa(len(want.CheckConstraints)) +
+			" check constraint(s), target has " + strconv.Itoa(len(have.CheckConstraints))
+	}
+
 	sort.Strings(td.MissingColumns)
 	sort.Strings(td.ExtraColumns)
 	sort.Strings(td.ColumnDeltas)
 
-	changed := len(td.MissingColumns) > 0 || len(td.ExtraColumns) > 0 || len(td.ColumnDeltas) > 0
-	return td, changed
+	return td, td.hasChanges()
+}
+
+// indexKeys returns the order-insensitive column-set key of each index.
+func indexKeys(idxs []driver.Index) []string {
+	out := make([]string, 0, len(idxs))
+	for _, ix := range idxs {
+		out = append(out, colSet(ix.Columns))
+	}
+	return out
+}
+
+// fkKeys returns a "(localcols)->reftable" signature for each foreign key.
+func fkKeys(fks []driver.ForeignKey) []string {
+	out := make([]string, 0, len(fks))
+	for _, fk := range fks {
+		out = append(out, colSet(fk.Columns)+"->"+strings.ToLower(fk.RefTable))
+	}
+	return out
+}
+
+// diffKeys returns the keys present only in want (missing on target) and only
+// in have (extra on target), each sorted.
+func diffKeys(want, have []string) (missing, extra []string) {
+	haveSet := make(map[string]bool, len(have))
+	for _, k := range have {
+		haveSet[k] = true
+	}
+	wantSet := make(map[string]bool, len(want))
+	for _, k := range want {
+		wantSet[k] = true
+	}
+	for _, k := range want {
+		if !haveSet[k] {
+			missing = append(missing, k)
+		}
+	}
+	for _, k := range have {
+		if !wantSet[k] {
+			extra = append(extra, k)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	return missing, extra
+}
+
+// colSet is an order-insensitive, case-insensitive key for a column list.
+func colSet(cols []string) string {
+	lowered := make([]string, len(cols))
+	for i, c := range cols {
+		lowered[i] = strings.ToLower(c)
+	}
+	sort.Strings(lowered)
+	return strings.Join(lowered, ",")
 }
 
 func indexByLowerName(tables []driver.Table) map[string]driver.Table {

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -228,12 +228,15 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, op
 	// cross-dialect equivalences the comparator already understands
 	// (bit→boolean, uniqueidentifier→char(36), json→jsonb) don't false-flag.
 	//
-	// Known limitation: a SAME-family change the comparator also treats as
-	// equivalent — e.g. integer→bigint, or varchar(20)→char(20) — is NOT
-	// flagged. Distinguishing those from genuine cross-dialect equivalences
-	// needs a canonical concrete-type model (#62); until that lands, drift
-	// catches family-level and length/precision/nullability/identity/TZ/
-	// default changes but not same-family width promotions.
+	// Known limitations, all rooted in the lack of cross-dialect expression /
+	// concrete-type normalization (#62): a SAME-family type change the
+	// comparator treats as equivalent (integer→bigint, varchar(20)→char(20))
+	// is not flagged, and per-column EXPRESSION/value details whose text
+	// differs across dialects — a changed computed expression body, MySQL
+	// ENUM/SET value lists, ON UPDATE expressions, spatial SRID — are not
+	// compared either. Drift catches presence/structure (computed Y/N + storage
+	// class, type family, length/precision/nullability/identity/TZ/default)
+	// today; expression-level equivalence is follow-up work.
 	haveByName := make(map[string]driver.Column, len(have.Columns))
 	for _, c := range have.Columns {
 		haveByName[strings.ToLower(c.Name)] = c
@@ -243,10 +246,24 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, op
 		if !ok {
 			continue
 		}
+		name := strings.ToLower(sc.Name)
 		sf, tf := strictTypeFamily(sc.DataType), strictTypeFamily(tc.DataType)
 		if sf != "" && tf != "" && sf != tf {
 			td.ColumnDeltas = append(td.ColumnDeltas,
-				strings.ToLower(sc.Name)+" type class: source="+sf+" target="+tf)
+				name+" type class: source="+sf+" target="+tf)
+		}
+		// Generated/computed status and storage class are cross-dialect
+		// structural facts CompareColumns doesn't cover: a column that's
+		// generated in the source must stay generated on the target, and a
+		// STORED/PERSISTED column must not become VIRTUAL (or vice versa).
+		// The expression TEXT itself differs cross-dialect (like CHECK
+		// predicates), so only presence + storage class are compared here.
+		if sc.IsComputed != tc.IsComputed {
+			td.ColumnDeltas = append(td.ColumnDeltas,
+				name+" computed: source="+boolStr(sc.IsComputed)+" target="+boolStr(tc.IsComputed))
+		} else if sc.IsComputed && sc.ComputedPersisted != tc.ComputedPersisted {
+			td.ColumnDeltas = append(td.ColumnDeltas,
+				name+" computed storage: source persisted="+boolStr(sc.ComputedPersisted)+" target persisted="+boolStr(tc.ComputedPersisted))
 		}
 	}
 
@@ -305,12 +322,33 @@ func indexKeys(idxs []driver.Index) []string {
 	out := make([]string, 0, len(idxs))
 	for _, ix := range idxs {
 		key := orderedCols(ix.Columns)
+		// Covering-index INCLUDE columns are part of the index's identity:
+		// dropping them changes what the index covers. Identifiers, so they
+		// normalize cleanly across dialects.
+		if len(ix.IncludeCols) > 0 {
+			key += "/include:" + orderedCols(ix.IncludeCols)
+		}
+		// A filtered/partial index differs from an unfiltered one on the same
+		// columns. The predicate text is cross-dialect-divergent (like CHECK
+		// predicates), so fold in only whether a filter is present — a coarse
+		// signal that still catches "filter added/removed" without
+		// false-flagging an equivalent predicate rewritten per dialect.
+		if strings.TrimSpace(ix.Filter) != "" {
+			key += "/filtered"
+		}
 		if ix.IsUnique {
 			key = "unique:" + key
 		}
 		out = append(out, key)
 	}
 	return out
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
 }
 
 // fkKeys returns a signature for each foreign key built from its ordered

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -125,6 +125,31 @@ func deepCopyTable(t driver.Table) driver.Table {
 	return t
 }
 
+// RetargetSchema returns a deep copy of tables with every schema reference —
+// the table's own Schema and each foreign key's RefSchema — set to
+// targetSchema. create/sync do this (Diff.WithTargetSchema) because SMT
+// migrates everything into one target schema, collapsing even a source
+// cross-schema FK to the target schema. Drift must apply the same collapse to
+// the DESIRED side so its FK signatures match what was actually generated on
+// the target; the existing (introspected) side is left untouched so a genuine
+// cross-schema reference on the target still drifts. Input is not mutated;
+// pass-through when targetSchema is empty.
+func RetargetSchema(tables []driver.Table, targetSchema string) []driver.Table {
+	if strings.TrimSpace(targetSchema) == "" {
+		return tables
+	}
+	out := make([]driver.Table, len(tables))
+	for i := range tables {
+		t := deepCopyTable(tables[i])
+		t.Schema = targetSchema
+		for j := range t.ForeignKeys {
+			t.ForeignKeys[j].RefSchema = targetSchema
+		}
+		out[i] = t
+	}
+	return out
+}
+
 // IsEmpty reports whether the target matches the desired schema.
 func (d Drift) IsEmpty() bool {
 	return len(d.MissingTables) == 0 && len(d.ExtraTables) == 0 && len(d.ChangedTables) == 0

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -248,28 +248,24 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, op
 	// CompareColumns checks length/precision/nullability/identity/TZ/default
 	// but not the general type family, so an `int` → `text` change (both with
 	// no length/default/identity) slips through. Flag a high-confidence family
-	// mismatch on matched columns. Conservative on purpose: only the strict
-	// families (numeric/string/temporal/binary) participate, so legitimate
-	// cross-dialect equivalences the comparator already understands
-	// (bit→boolean, uniqueidentifier→char(36), json→jsonb) don't false-flag.
+	// mismatch on matched columns. Deliberately conservative — only the strict
+	// families participate, and a flag fires ONLY when BOTH sides resolve to a
+	// known, differing family. This avoids false positives on a freshly created
+	// target, which is the bar drift must clear: SMT's own mappings must read
+	// as "no drift." Cases left to the comparator's existing equivalence rules
+	// (and therefore NOT family-flagged) include bit/boolean (mssql bit → pg
+	// boolean, mysql tinyint(1) → pg smallint — SMT maps these differently per
+	// target, so "boolean" is not a portable family here), uuid (uniqueidentifier
+	// → char(36)), and json/xml.
 	//
-	// The flag fires only when BOTH sides resolve to a known class and the
-	// classes differ. A ONE-SIDED class (e.g. source numeric `int` vs a target
-	// the classifier doesn't cover, like `uuid` or pg `bit`/`bit varying`) is
-	// deliberately NOT flagged: the unrecognized side is exactly where legit
-	// cross-dialect equivalences live (uniqueidentifier→char(36), uuid→char(36)
-	// that CompareColumns handles specially), so flagging "known vs unknown"
-	// would false-positive on those. Catching those one-sided cases correctly
-	// needs the canonical concrete-type model (#62).
-	//
-	// Other known limitations, same #62 root: a SAME-family type change the
-	// comparator treats as equivalent (integer→bigint, varchar(20)→char(20))
-	// is not flagged, and per-column EXPRESSION/value details whose text
-	// differs across dialects — a changed computed expression body, MySQL
+	// Known limitations, all rooted in the lack of a canonical concrete-type /
+	// expression model (#62): a SAME-family type change (integer→bigint,
+	// varchar(20)→char(20)), a one-sided class change involving an unrecognized
+	// type (int→uuid, bit→integer), and per-column EXPRESSION/value details
+	// whose text differs across dialects — computed-expression bodies, MySQL
 	// ENUM/SET value lists, ON UPDATE expressions, spatial SRID — are not
-	// compared either. Drift catches presence/structure (computed Y/N + storage
-	// class, type family, length/precision/nullability/identity/TZ/default)
-	// today; expression-level and concrete-type equivalence is follow-up work.
+	// compared. Drift catches presence/structure (computed Y/N + storage class,
+	// type family, length/precision/nullability/identity/TZ/default) today.
 	haveByName := make(map[string]driver.Column, len(have.Columns))
 	for _, c := range have.Columns {
 		haveByName[strings.ToLower(c.Name)] = c
@@ -280,7 +276,7 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, op
 			continue
 		}
 		name := strings.ToLower(sc.Name)
-		if sf, tf := columnTypeClass(sc, sourceDialect), columnTypeClass(tc, targetDialect); sf != "" && tf != "" && sf != tf {
+		if sf, tf := strictTypeFamily(sc.DataType), strictTypeFamily(tc.DataType); sf != "" && tf != "" && sf != tf {
 			td.ColumnDeltas = append(td.ColumnDeltas,
 				name+" type class: source="+sf+" target="+tf)
 		}
@@ -293,7 +289,13 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, op
 		if sc.IsComputed != tc.IsComputed {
 			td.ColumnDeltas = append(td.ColumnDeltas,
 				name+" computed: source="+boolStr(sc.IsComputed)+" target="+boolStr(tc.IsComputed))
-		} else if sc.IsComputed && sc.ComputedPersisted != tc.ComputedPersisted {
+		} else if sc.IsComputed && sc.ComputedPersisted != tc.ComputedPersisted && targetSupportsVirtualComputed(targetDialect) {
+			// Storage class is only meaningful drift when the target can
+			// actually represent both: PostgreSQL generated columns are always
+			// STORED, so its reader reports every computed column persisted —
+			// comparing a source VIRTUAL column against it would false-drift on
+			// a faithfully created target. MySQL (VIRTUAL/STORED) and MSSQL
+			// (PERSISTED or not) can represent both.
 			td.ColumnDeltas = append(td.ColumnDeltas,
 				name+" computed storage: source persisted="+boolStr(sc.ComputedPersisted)+" target persisted="+boolStr(tc.ComputedPersisted))
 		}
@@ -379,6 +381,19 @@ func indexKeys(idxs []driver.Index) []string {
 	return out
 }
 
+// targetSupportsVirtualComputed reports whether the dialect can represent both
+// a VIRTUAL (non-persisted) and a STORED/PERSISTED computed column. PostgreSQL
+// only has STORED generated columns, so its storage class isn't a faithful
+// round-trip of a VIRTUAL source and must not be compared as drift.
+func targetSupportsVirtualComputed(dialect string) bool {
+	switch strings.ToLower(strings.TrimSpace(dialect)) {
+	case "mysql", "mariadb", "mssql", "sqlserver":
+		return true
+	default:
+		return false
+	}
+}
+
 func boolStr(b bool) string {
 	if b {
 		return "true"
@@ -416,38 +431,6 @@ func fkKeys(fks []driver.ForeignKey, ownerSchema string) []string {
 			"|"+normAction(fk.OnDelete)+"|"+normAction(fk.OnUpdate))
 	}
 	return out
-}
-
-// columnTypeClass returns the high-confidence type class of a column —
-// "boolean" or one of strictTypeFamily's families — used to flag an
-// incompatible cross-class change (boolean→integer, integer→text) that
-// CompareColumns doesn't catch. Boolean is its own class so bit↔boolean↔
-// tinyint(1) stay equivalent; uuid/json/xml/unknown return "" so the
-// comparator's existing equivalence rules apply unchallenged.
-func columnTypeClass(c driver.Column, dialect string) string {
-	if isBooleanType(c, dialect) {
-		return "boolean"
-	}
-	return strictTypeFamily(c.DataType)
-}
-
-// isBooleanType reports whether a column is the boolean class. Dialect-aware
-// because "bit" means different things: MSSQL/MySQL BIT is a boolean, but
-// PostgreSQL bit / bit varying is a fixed-length bit STRING, not boolean.
-// pg boolean is spelled "boolean"; MySQL tinyint(1) is the boolean convention
-// (plain tinyint is numeric).
-func isBooleanType(c driver.Column, dialect string) bool {
-	dt := strings.ToLower(strings.TrimSpace(c.DataType))
-	switch dt {
-	case "boolean", "bool":
-		return true
-	case "bit":
-		return strings.ToLower(strings.TrimSpace(dialect)) != "postgres"
-	case "tinyint":
-		return c.DisplayWidth == 1
-	default:
-		return false
-	}
 }
 
 // strictTypeFamily classifies a data type into one of the families where a

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -283,6 +283,16 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, op
 			td.ColumnDeltas = append(td.ColumnDeltas,
 				name+" type class: source="+sf+" target="+tf)
 		}
+		// MySQL UNSIGNED is a structured flag (Column.IsUnsigned) the readers
+		// populate and the renderer preserves. INT UNSIGNED → INT halves the
+		// positive range, so a same-dialect change must drift. Only compared
+		// MySQL→MySQL: cross-dialect, unsigned is absorbed into a wider target
+		// type (mysql int unsigned → pg bigint), where the target legitimately
+		// carries no unsigned flag and a comparison would false-flag.
+		if isMySQLDialect(sourceDialect) && isMySQLDialect(targetDialect) && sc.IsUnsigned != tc.IsUnsigned {
+			td.ColumnDeltas = append(td.ColumnDeltas,
+				name+" unsigned: source="+boolStr(sc.IsUnsigned)+" target="+boolStr(tc.IsUnsigned))
+		}
 		// Generated/computed status and storage class are cross-dialect
 		// structural facts CompareColumns doesn't cover: a column that's
 		// generated in the source must stay generated on the target, and a
@@ -391,6 +401,15 @@ func indexKeys(idxs []driver.Index) []string {
 func targetSupportsVirtualComputed(dialect string) bool {
 	switch strings.ToLower(strings.TrimSpace(dialect)) {
 	case "mysql", "mariadb", "mssql", "sqlserver":
+		return true
+	default:
+		return false
+	}
+}
+
+func isMySQLDialect(dialect string) bool {
+	switch strings.ToLower(strings.TrimSpace(dialect)) {
+	case "mysql", "mariadb":
 		return true
 	default:
 		return false

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -261,11 +261,14 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, op
 	// Known limitations, all rooted in the lack of a canonical concrete-type /
 	// expression model (#62): a SAME-family type change (integer→bigint,
 	// varchar(20)→char(20)), a one-sided class change involving an unrecognized
-	// type (int→uuid, bit→integer), and per-column EXPRESSION/value details
-	// whose text differs across dialects — computed-expression bodies, MySQL
-	// ENUM/SET value lists, ON UPDATE expressions, spatial SRID — are not
-	// compared. Drift catches presence/structure (computed Y/N + storage class,
-	// type family, length/precision/nullability/identity/TZ/default) today.
+	// type (int→uuid, bit→integer), a datetime fractional-seconds change
+	// (DATETIME(6)→DATETIME(0)) — comparing it cleanly needs target-max-fsp
+	// awareness to not false-flag a legit clamp like mssql datetime2(7)→pg
+	// timestamp(6) — a same-dialect ENUM→TEXT change or ENUM value-list change,
+	// and per-column EXPRESSION/value details whose text differs across dialects
+	// (computed-expression bodies, ON UPDATE expressions, spatial SRID). Drift
+	// catches presence/structure (computed Y/N + storage class, type family,
+	// length/nullability/identity/TZ/default) today.
 	haveByName := make(map[string]driver.Column, len(have.Columns))
 	for _, c := range have.Columns {
 		haveByName[strings.ToLower(c.Name)] = c

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -125,29 +125,6 @@ func deepCopyTable(t driver.Table) driver.Table {
 	return t
 }
 
-// RetargetSchema returns a deep copy of tables with every schema reference
-// (the table's own Schema and each foreign key's RefSchema) set to
-// targetSchema. SMT migrates source.X to target.Y, so a same-schema FK on the
-// source resolves to the target schema; aligning both sides lets FK drift
-// signatures (which include the referenced schema) compare equal instead of
-// flagging a source-vs-target schema-name difference. The input is not
-// mutated. A pass-through when targetSchema is empty.
-func RetargetSchema(tables []driver.Table, targetSchema string) []driver.Table {
-	if strings.TrimSpace(targetSchema) == "" {
-		return tables
-	}
-	out := make([]driver.Table, len(tables))
-	for i := range tables {
-		t := deepCopyTable(tables[i])
-		t.Schema = targetSchema
-		for j := range t.ForeignKeys {
-			t.ForeignKeys[j].RefSchema = targetSchema
-		}
-		out[i] = t
-	}
-	return out
-}
-
 // IsEmpty reports whether the target matches the desired schema.
 func (d Drift) IsEmpty() bool {
 	return len(d.MissingTables) == 0 && len(d.ExtraTables) == 0 && len(d.ChangedTables) == 0
@@ -270,8 +247,7 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, op
 			continue
 		}
 		name := strings.ToLower(sc.Name)
-		sf, tf := strictTypeFamily(sc.DataType), strictTypeFamily(tc.DataType)
-		if sf != "" && tf != "" && sf != tf {
+		if sf, tf := columnTypeClass(sc), columnTypeClass(tc); sf != "" && tf != "" && sf != tf {
 			td.ColumnDeltas = append(td.ColumnDeltas,
 				name+" type class: source="+sf+" target="+tf)
 		}
@@ -302,7 +278,8 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, op
 		td.MissingIndexes, td.ExtraIndexes = diffKeys(indexKeys(want.Indexes), indexKeys(have.Indexes))
 	}
 	if opts.CompareForeignKeys {
-		td.MissingForeignKeys, td.ExtraForeignKeys = diffKeys(fkKeys(want.ForeignKeys), fkKeys(have.ForeignKeys))
+		td.MissingForeignKeys, td.ExtraForeignKeys = diffKeys(
+			fkKeys(want.ForeignKeys, want.Schema), fkKeys(have.ForeignKeys, have.Schema))
 	}
 	// CHECK constraints: predicate text is rewritten cross-dialect, so a
 	// faithful target may carry textually different predicates. Only flag a
@@ -375,10 +352,17 @@ func boolStr(b bool) string {
 }
 
 // fkKeys returns a signature for each foreign key built from its ordered
-// local→referenced column pairs, referenced table, and referential actions —
-// so a target FK that changes ON DELETE/UPDATE or points at different
-// referenced columns no longer matches.
-func fkKeys(fks []driver.ForeignKey) []string {
+// local→referenced column pairs, referenced table+schema, and referential
+// actions — so a target FK that changes ON DELETE/UPDATE, points at different
+// referenced columns, or references a different schema no longer matches.
+//
+// The referenced schema is encoded RELATIVE to the FK's owning table: a
+// same-schema reference (empty RefSchema or equal to ownerSchema) becomes
+// "self", so the common case compares equal across dialects without
+// retargeting (source "dbo" and target "public" both read as "self"), while a
+// genuine cross-schema reference keeps its literal schema and drifts if it
+// changes.
+func fkKeys(fks []driver.ForeignKey, ownerSchema string) []string {
 	out := make([]string, 0, len(fks))
 	for _, fk := range fks {
 		pairs := make([]string, len(fk.Columns))
@@ -389,20 +373,47 @@ func fkKeys(fks []driver.ForeignKey) []string {
 			}
 			pairs[i] = strings.ToLower(c) + ":" + ref
 		}
-		ref := strings.ToLower(fk.RefTable)
-		if s := strings.TrimSpace(fk.RefSchema); s != "" {
-			ref = strings.ToLower(s) + "." + ref
+		schema := "self"
+		if s := strings.TrimSpace(fk.RefSchema); s != "" && !strings.EqualFold(s, ownerSchema) {
+			schema = strings.ToLower(s)
 		}
-		out = append(out, strings.Join(pairs, ",")+"->"+ref+
+		out = append(out, strings.Join(pairs, ",")+"->"+schema+"."+strings.ToLower(fk.RefTable)+
 			"|"+normAction(fk.OnDelete)+"|"+normAction(fk.OnUpdate))
 	}
 	return out
 }
 
+// columnTypeClass returns the high-confidence type class of a column —
+// "boolean" or one of strictTypeFamily's families — used to flag an
+// incompatible cross-class change (boolean→integer, integer→text) that
+// CompareColumns doesn't catch. Boolean is its own class so bit↔boolean↔
+// tinyint(1) stay equivalent; uuid/json/xml/unknown return "" so the
+// comparator's existing equivalence rules apply unchallenged.
+func columnTypeClass(c driver.Column) string {
+	if isBooleanType(c) {
+		return "boolean"
+	}
+	return strictTypeFamily(c.DataType)
+}
+
+// isBooleanType reports whether a column is the boolean class across dialects:
+// pg boolean, MSSQL bit, and MySQL tinyint(1) (DisplayWidth captured by the
+// reader). Plain tinyint (no display width) is numeric, not boolean.
+func isBooleanType(c driver.Column) bool {
+	switch strings.ToLower(strings.TrimSpace(c.DataType)) {
+	case "boolean", "bool", "bit":
+		return true
+	case "tinyint":
+		return c.DisplayWidth == 1
+	default:
+		return false
+	}
+}
+
 // strictTypeFamily classifies a data type into one of the families where a
 // cross-family change is unambiguously incompatible (numeric/string/temporal/
 // binary). Types with known cross-dialect equivalences that span families —
-// boolean (bit↔boolean↔tinyint(1)), uuid (uniqueidentifier↔char(36)), json,
+// boolean (handled by isBooleanType), uuid (uniqueidentifier↔char(36)), json,
 // xml — and anything unrecognized return "" so they are left to the
 // deterministic comparator and never produce a false family mismatch.
 func strictTypeFamily(dataType string) string {

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -247,7 +247,7 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, op
 			continue
 		}
 		name := strings.ToLower(sc.Name)
-		if sf, tf := columnTypeClass(sc), columnTypeClass(tc); sf != "" && tf != "" && sf != tf {
+		if sf, tf := columnTypeClass(sc, sourceDialect), columnTypeClass(tc, targetDialect); sf != "" && tf != "" && sf != tf {
 			td.ColumnDeltas = append(td.ColumnDeltas,
 				name+" type class: source="+sf+" target="+tf)
 		}
@@ -282,9 +282,11 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, op
 			fkKeys(want.ForeignKeys, want.Schema), fkKeys(have.ForeignKeys, have.Schema))
 	}
 	// CHECK constraints: predicate text is rewritten cross-dialect, so a
-	// faithful target may carry textually different predicates. Only flag a
-	// likely drop — the target having fewer checks than the source.
-	if opts.CompareChecks && len(have.CheckConstraints) < len(want.CheckConstraints) {
+	// faithful target may carry textually different predicates — only the
+	// COUNT is compared. A mismatch in either direction is drift: fewer on the
+	// target means a check was dropped; more means a target-only check that can
+	// reject rows the source allows.
+	if opts.CompareChecks && len(have.CheckConstraints) != len(want.CheckConstraints) {
 		td.CheckDrift = "source has " + strconv.Itoa(len(want.CheckConstraints)) +
 			" check constraint(s), target has " + strconv.Itoa(len(have.CheckConstraints))
 	}
@@ -389,20 +391,25 @@ func fkKeys(fks []driver.ForeignKey, ownerSchema string) []string {
 // CompareColumns doesn't catch. Boolean is its own class so bit↔boolean↔
 // tinyint(1) stay equivalent; uuid/json/xml/unknown return "" so the
 // comparator's existing equivalence rules apply unchallenged.
-func columnTypeClass(c driver.Column) string {
-	if isBooleanType(c) {
+func columnTypeClass(c driver.Column, dialect string) string {
+	if isBooleanType(c, dialect) {
 		return "boolean"
 	}
 	return strictTypeFamily(c.DataType)
 }
 
-// isBooleanType reports whether a column is the boolean class across dialects:
-// pg boolean, MSSQL bit, and MySQL tinyint(1) (DisplayWidth captured by the
-// reader). Plain tinyint (no display width) is numeric, not boolean.
-func isBooleanType(c driver.Column) bool {
-	switch strings.ToLower(strings.TrimSpace(c.DataType)) {
-	case "boolean", "bool", "bit":
+// isBooleanType reports whether a column is the boolean class. Dialect-aware
+// because "bit" means different things: MSSQL/MySQL BIT is a boolean, but
+// PostgreSQL bit / bit varying is a fixed-length bit STRING, not boolean.
+// pg boolean is spelled "boolean"; MySQL tinyint(1) is the boolean convention
+// (plain tinyint is numeric).
+func isBooleanType(c driver.Column, dialect string) bool {
+	dt := strings.ToLower(strings.TrimSpace(c.DataType))
+	switch dt {
+	case "boolean", "bool":
 		return true
+	case "bit":
+		return strings.ToLower(strings.TrimSpace(dialect)) != "postgres"
 	case "tinyint":
 		return c.DisplayWidth == 1
 	default:

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -47,13 +47,16 @@ type TableDrift struct {
 	// Each entry is a human-readable description from the deterministic
 	// comparator.
 	ColumnDeltas []string
-	// MissingIndexes / ExtraIndexes are secondary-index column sets present on
-	// only one side (matched by column set, not name, since the renderer
-	// normalizes index names per dialect).
+	// MissingIndexes / ExtraIndexes are secondary indexes present on only one
+	// side, keyed by ordered column list (+ a unique: prefix) rather than
+	// name, since the renderer normalizes index names per dialect. Column
+	// order is significant, so (a,b) and (b,a) are distinct.
 	MissingIndexes []string
 	ExtraIndexes   []string
-	// MissingForeignKeys / ExtraForeignKeys are FK signatures ("(cols)->ref")
-	// present on only one side.
+	// MissingForeignKeys / ExtraForeignKeys are FKs present on only one side,
+	// keyed by ordered local→referenced column pairs, referenced table, and
+	// referential actions — so a changed ON DELETE/UPDATE or referenced
+	// column drifts.
 	MissingForeignKeys []string
 	ExtraForeignKeys   []string
 	// CheckDrift is non-empty when the target has fewer CHECK constraints than
@@ -66,6 +69,40 @@ func (td TableDrift) hasChanges() bool {
 	return len(td.MissingColumns) > 0 || len(td.ExtraColumns) > 0 || len(td.ColumnDeltas) > 0 ||
 		len(td.MissingIndexes) > 0 || len(td.ExtraIndexes) > 0 ||
 		len(td.MissingForeignKeys) > 0 || len(td.ExtraForeignKeys) > 0 || td.CheckDrift != ""
+}
+
+// NormalizeIdentifiers returns a deep copy of tables with every identifier
+// (table, column, PK, index columns, FK columns / referenced table /
+// referenced columns, check names) folded through norm — so source-form
+// identifiers line up with a target whose dialect rewrites names (e.g. PG
+// lowercasing "Order ID" to "order_id"). Callers normalize the desired schema
+// with the target's rule before ComputeDrift so constraint comparisons don't
+// see false drift. The input is not mutated.
+func NormalizeIdentifiers(tables []driver.Table, norm func(string) string) []driver.Table {
+	out := make([]driver.Table, len(tables))
+	for i := range tables {
+		out[i] = normalizeTable(deepCopyTable(tables[i]), norm)
+	}
+	return out
+}
+
+// deepCopyTable copies the slices normalizeTable mutates so normalization
+// can't reach back into the caller's tables.
+func deepCopyTable(t driver.Table) driver.Table {
+	t.Columns = append([]driver.Column(nil), t.Columns...)
+	t.PrimaryKey = append([]string(nil), t.PrimaryKey...)
+	t.Indexes = append([]driver.Index(nil), t.Indexes...)
+	for i := range t.Indexes {
+		t.Indexes[i].Columns = append([]string(nil), t.Indexes[i].Columns...)
+		t.Indexes[i].IncludeCols = append([]string(nil), t.Indexes[i].IncludeCols...)
+	}
+	t.ForeignKeys = append([]driver.ForeignKey(nil), t.ForeignKeys...)
+	for i := range t.ForeignKeys {
+		t.ForeignKeys[i].Columns = append([]string(nil), t.ForeignKeys[i].Columns...)
+		t.ForeignKeys[i].RefColumns = append([]string(nil), t.ForeignKeys[i].RefColumns...)
+	}
+	t.CheckConstraints = append([]driver.CheckConstraint(nil), t.CheckConstraints...)
+	return t
 }
 
 // IsEmpty reports whether the target matches the desired schema.
@@ -162,6 +199,29 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string) (T
 		td.ColumnDeltas = append(td.ColumnDeltas, delta.String())
 	}
 
+	// CompareColumns checks length/precision/nullability/identity/TZ/default
+	// but not the general type family, so an `int` → `text` change (both with
+	// no length/default/identity) slips through. Flag a high-confidence family
+	// mismatch on matched columns. Conservative on purpose: only the strict
+	// families (numeric/string/temporal/binary) participate, so legitimate
+	// cross-dialect equivalences the comparator already understands
+	// (bit→boolean, uniqueidentifier→char(36), json→jsonb) don't false-flag.
+	haveByName := make(map[string]driver.Column, len(have.Columns))
+	for _, c := range have.Columns {
+		haveByName[strings.ToLower(c.Name)] = c
+	}
+	for _, sc := range want.Columns {
+		tc, ok := haveByName[strings.ToLower(sc.Name)]
+		if !ok {
+			continue
+		}
+		sf, tf := strictTypeFamily(sc.DataType), strictTypeFamily(tc.DataType)
+		if sf != "" && tf != "" && sf != tf {
+			td.ColumnDeltas = append(td.ColumnDeltas,
+				strings.ToLower(sc.Name)+" type class: source="+sf+" target="+tf)
+		}
+	}
+
 	// Secondary indexes, matched by column set (names are renderer-normalized
 	// per dialect, so they don't compare across engines).
 	td.MissingIndexes, td.ExtraIndexes = diffKeys(indexKeys(want.Indexes), indexKeys(have.Indexes))
@@ -182,22 +242,91 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string) (T
 	return td, td.hasChanges()
 }
 
-// indexKeys returns the order-insensitive column-set key of each index.
+// indexKeys returns an ordered column-list key for each index. Column ORDER
+// is significant for an index (a, b) ≠ (b, a) for query planning, so the
+// columns are NOT sorted — only lowercased. Uniqueness is folded in so a
+// UNIQUE index does not match a non-unique one on the same columns.
 func indexKeys(idxs []driver.Index) []string {
 	out := make([]string, 0, len(idxs))
 	for _, ix := range idxs {
-		out = append(out, colSet(ix.Columns))
+		key := orderedCols(ix.Columns)
+		if ix.IsUnique {
+			key = "unique:" + key
+		}
+		out = append(out, key)
 	}
 	return out
 }
 
-// fkKeys returns a "(localcols)->reftable" signature for each foreign key.
+// fkKeys returns a signature for each foreign key built from its ordered
+// local→referenced column pairs, referenced table, and referential actions —
+// so a target FK that changes ON DELETE/UPDATE or points at different
+// referenced columns no longer matches.
 func fkKeys(fks []driver.ForeignKey) []string {
 	out := make([]string, 0, len(fks))
 	for _, fk := range fks {
-		out = append(out, colSet(fk.Columns)+"->"+strings.ToLower(fk.RefTable))
+		pairs := make([]string, len(fk.Columns))
+		for i, c := range fk.Columns {
+			ref := ""
+			if i < len(fk.RefColumns) {
+				ref = strings.ToLower(fk.RefColumns[i])
+			}
+			pairs[i] = strings.ToLower(c) + ":" + ref
+		}
+		out = append(out, strings.Join(pairs, ",")+"->"+strings.ToLower(fk.RefTable)+
+			"|"+normAction(fk.OnDelete)+"|"+normAction(fk.OnUpdate))
 	}
 	return out
+}
+
+// strictTypeFamily classifies a data type into one of the families where a
+// cross-family change is unambiguously incompatible (numeric/string/temporal/
+// binary). Types with known cross-dialect equivalences that span families —
+// boolean (bit↔boolean↔tinyint(1)), uuid (uniqueidentifier↔char(36)), json,
+// xml — and anything unrecognized return "" so they are left to the
+// deterministic comparator and never produce a false family mismatch.
+func strictTypeFamily(dataType string) string {
+	switch strings.ToLower(strings.TrimSpace(dataType)) {
+	case "tinyint", "smallint", "mediumint", "int", "integer", "bigint",
+		"int2", "int4", "int8", "serial", "bigserial", "smallserial",
+		"decimal", "numeric", "number", "money", "smallmoney",
+		"float", "double", "double precision", "real", "float4", "float8":
+		return "numeric"
+	case "char", "nchar", "character", "bpchar", "varchar", "nvarchar",
+		"character varying", "text", "ntext", "tinytext", "mediumtext",
+		"longtext", "enum", "set":
+		return "string"
+	case "date", "time", "timetz", "datetime", "datetime2", "smalldatetime",
+		"timestamp", "timestamptz", "datetimeoffset",
+		"timestamp without time zone", "timestamp with time zone",
+		"time without time zone", "time with time zone":
+		return "temporal"
+	case "binary", "varbinary", "image", "bytea", "rowversion",
+		"blob", "tinyblob", "mediumblob", "longblob":
+		return "binary"
+	default:
+		return ""
+	}
+}
+
+// orderedCols joins columns lowercased but order-preserved.
+func orderedCols(cols []string) string {
+	lowered := make([]string, len(cols))
+	for i, c := range cols {
+		lowered[i] = strings.ToLower(c)
+	}
+	return strings.Join(lowered, ",")
+}
+
+// normAction folds the no-op referential-action spellings to one token so a
+// source NO ACTION matches a target reporting the default differently.
+func normAction(a string) string {
+	switch strings.ToUpper(strings.TrimSpace(a)) {
+	case "", "NO ACTION", "RESTRICT":
+		return "noaction"
+	default:
+		return strings.ToLower(strings.Join(strings.Fields(a), " "))
+	}
 }
 
 // diffKeys returns the keys present only in want (missing on target) and only
@@ -224,16 +353,6 @@ func diffKeys(want, have []string) (missing, extra []string) {
 	sort.Strings(missing)
 	sort.Strings(extra)
 	return missing, extra
-}
-
-// colSet is an order-insensitive, case-insensitive key for a column list.
-func colSet(cols []string) string {
-	lowered := make([]string, len(cols))
-	for i, c := range cols {
-		lowered[i] = strings.ToLower(c)
-	}
-	sort.Strings(lowered)
-	return strings.Join(lowered, ",")
 }
 
 func indexByLowerName(tables []driver.Table) map[string]driver.Table {

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -63,12 +63,32 @@ type TableDrift struct {
 	// the source (a likely dropped check). Predicate text is rewritten
 	// cross-dialect, so checks are compared by count, not text.
 	CheckDrift string
+	// PKDrift is non-empty when the primary key column set differs (dropped,
+	// added, or re-keyed). The index loaders exclude PK-backed indexes, so the
+	// PK is compared here, not via MissingIndexes/ExtraIndexes.
+	PKDrift string
 }
 
 func (td TableDrift) hasChanges() bool {
 	return len(td.MissingColumns) > 0 || len(td.ExtraColumns) > 0 || len(td.ColumnDeltas) > 0 ||
 		len(td.MissingIndexes) > 0 || len(td.ExtraIndexes) > 0 ||
-		len(td.MissingForeignKeys) > 0 || len(td.ExtraForeignKeys) > 0 || td.CheckDrift != ""
+		len(td.MissingForeignKeys) > 0 || len(td.ExtraForeignKeys) > 0 ||
+		td.CheckDrift != "" || td.PKDrift != ""
+}
+
+// DriftOptions gates which object kinds ComputeDrift compares, so a config
+// that intentionally leaves indexes / FKs / checks unmanaged
+// (create_indexes/create_foreign_keys/create_check_constraints = false) does
+// not see those reported as drift. All default to true via DefaultDriftOptions.
+type DriftOptions struct {
+	CompareIndexes     bool
+	CompareForeignKeys bool
+	CompareChecks      bool
+}
+
+// DefaultDriftOptions compares every dimension.
+func DefaultDriftOptions() DriftOptions {
+	return DriftOptions{CompareIndexes: true, CompareForeignKeys: true, CompareChecks: true}
 }
 
 // NormalizeIdentifiers returns a deep copy of tables with every identifier
@@ -151,7 +171,8 @@ func (d Drift) HasDestructiveDrift() bool {
 // names line up (see Diff.Normalize / driver.NormalizeIdentifier).
 //
 // sourceDialect/targetDialect drive the cross-dialect column comparison.
-func ComputeDrift(desired, existing []driver.Table, sourceDialect, targetDialect string) Drift {
+// opts gates which object kinds are compared (see DriftOptions).
+func ComputeDrift(desired, existing []driver.Table, sourceDialect, targetDialect string, opts DriftOptions) Drift {
 	desiredByName := indexByLowerName(desired)
 	existingByName := indexByLowerName(existing)
 
@@ -163,7 +184,7 @@ func ComputeDrift(desired, existing []driver.Table, sourceDialect, targetDialect
 			d.MissingTables = append(d.MissingTables, name)
 			continue
 		}
-		if td, changed := tableDrift(want, have, sourceDialect, targetDialect); changed {
+		if td, changed := tableDrift(want, have, sourceDialect, targetDialect, opts); changed {
 			d.ChangedTables = append(d.ChangedTables, td)
 		}
 	}
@@ -175,7 +196,7 @@ func ComputeDrift(desired, existing []driver.Table, sourceDialect, targetDialect
 	return d
 }
 
-func tableDrift(want, have driver.Table, sourceDialect, targetDialect string) (TableDrift, bool) {
+func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, opts DriftOptions) (TableDrift, bool) {
 	td := TableDrift{Name: strings.ToLower(have.Name)}
 
 	wantCols := lowerColNames(want.Columns)
@@ -206,6 +227,13 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string) (T
 	// families (numeric/string/temporal/binary) participate, so legitimate
 	// cross-dialect equivalences the comparator already understands
 	// (bit→boolean, uniqueidentifier→char(36), json→jsonb) don't false-flag.
+	//
+	// Known limitation: a SAME-family change the comparator also treats as
+	// equivalent — e.g. integer→bigint, or varchar(20)→char(20) — is NOT
+	// flagged. Distinguishing those from genuine cross-dialect equivalences
+	// needs a canonical concrete-type model (#62); until that lands, drift
+	// catches family-level and length/precision/nullability/identity/TZ/
+	// default changes but not same-family width promotions.
 	haveByName := make(map[string]driver.Column, len(have.Columns))
 	for _, c := range have.Columns {
 		haveByName[strings.ToLower(c.Name)] = c
@@ -222,15 +250,24 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string) (T
 		}
 	}
 
-	// Secondary indexes, matched by column set (names are renderer-normalized
-	// per dialect, so they don't compare across engines).
-	td.MissingIndexes, td.ExtraIndexes = diffKeys(indexKeys(want.Indexes), indexKeys(have.Indexes))
-	// Foreign keys, matched by local column set + referenced table.
-	td.MissingForeignKeys, td.ExtraForeignKeys = diffKeys(fkKeys(want.ForeignKeys), fkKeys(have.ForeignKeys))
+	// Primary key: the index loaders exclude PK-backed indexes, so a dropped
+	// or re-keyed PK is invisible to the index comparison and must be checked
+	// directly. Compared as a column set (order is not semantically part of
+	// the key).
+	if !sameColSetCI(want.PrimaryKey, have.PrimaryKey) {
+		td.PKDrift = "source PK (" + joinLowerSorted(want.PrimaryKey) + ") vs target PK (" + joinLowerSorted(have.PrimaryKey) + ")"
+	}
+
+	if opts.CompareIndexes {
+		td.MissingIndexes, td.ExtraIndexes = diffKeys(indexKeys(want.Indexes), indexKeys(have.Indexes))
+	}
+	if opts.CompareForeignKeys {
+		td.MissingForeignKeys, td.ExtraForeignKeys = diffKeys(fkKeys(want.ForeignKeys), fkKeys(have.ForeignKeys))
+	}
 	// CHECK constraints: predicate text is rewritten cross-dialect, so a
 	// faithful target may carry textually different predicates. Only flag a
 	// likely drop — the target having fewer checks than the source.
-	if len(have.CheckConstraints) < len(want.CheckConstraints) {
+	if opts.CompareChecks && len(have.CheckConstraints) < len(want.CheckConstraints) {
 		td.CheckDrift = "source has " + strconv.Itoa(len(want.CheckConstraints)) +
 			" check constraint(s), target has " + strconv.Itoa(len(have.CheckConstraints))
 	}
@@ -240,6 +277,24 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string) (T
 	sort.Strings(td.ColumnDeltas)
 
 	return td, td.hasChanges()
+}
+
+// sameColSetCI reports whether two column lists hold the same set of names,
+// case-insensitively and order-independently.
+func sameColSetCI(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	return joinLowerSorted(a) == joinLowerSorted(b)
+}
+
+func joinLowerSorted(in []string) string {
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = strings.ToLower(s)
+	}
+	sort.Strings(out)
+	return strings.Join(out, ",")
 }
 
 // indexKeys returns an ordered column-list key for each index. Column ORDER

--- a/internal/schemadiff/drift_test.go
+++ b/internal/schemadiff/drift_test.go
@@ -1,0 +1,135 @@
+package schemadiff
+
+import (
+	"strings"
+	"testing"
+
+	"smt/internal/driver"
+)
+
+func dcol(name, dt string, opts ...func(*driver.Column)) driver.Column {
+	c := driver.Column{Name: name, DataType: dt, IsNullable: true}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+func dtbl(name string, cols ...driver.Column) driver.Table {
+	return driver.Table{Name: name, Columns: cols}
+}
+
+// Identical schemas (cross-dialect equivalent types) must report no drift:
+// mssql varchar(20) ≡ pg character varying(20), datetime2 ≡ timestamp, etc.
+func TestComputeDrift_NoFalsePositiveCrossDialect(t *testing.T) {
+	desired := []driver.Table{
+		dtbl("Users",
+			dcol("Id", "int", func(c *driver.Column) { c.IsIdentity = true; c.IsNullable = false }),
+			dcol("Name", "varchar", func(c *driver.Column) { c.MaxLength = 20; c.IsNullable = false }),
+			dcol("CreatedAt", "datetime2"),
+		),
+	}
+	existing := []driver.Table{
+		dtbl("users",
+			dcol("id", "integer", func(c *driver.Column) { c.IsIdentity = true; c.IsNullable = false }),
+			dcol("name", "character varying", func(c *driver.Column) { c.MaxLength = 20; c.IsNullable = false }),
+			dcol("createdat", "timestamp without time zone"),
+		),
+	}
+	d := ComputeDrift(desired, existing, "mssql", "postgres")
+	if !d.IsEmpty() {
+		t.Fatalf("expected no drift for equivalent schemas, got: missing=%v extra=%v changed=%+v",
+			d.MissingTables, d.ExtraTables, d.ChangedTables)
+	}
+	if d.Summary() != "no drift: target matches the source-derived schema" {
+		t.Errorf("unexpected summary: %q", d.Summary())
+	}
+}
+
+func TestComputeDrift_MissingAndExtraTables(t *testing.T) {
+	desired := []driver.Table{dtbl("Orders", dcol("Id", "int")), dtbl("Items", dcol("Id", "int"))}
+	existing := []driver.Table{dtbl("orders", dcol("id", "integer")), dtbl("legacy", dcol("id", "integer"))}
+
+	d := ComputeDrift(desired, existing, "mssql", "postgres")
+	if len(d.MissingTables) != 1 || d.MissingTables[0] != "items" {
+		t.Errorf("missing tables = %v, want [items]", d.MissingTables)
+	}
+	if len(d.ExtraTables) != 1 || d.ExtraTables[0] != "legacy" {
+		t.Errorf("extra tables = %v, want [legacy]", d.ExtraTables)
+	}
+	if !d.HasDestructiveDrift() {
+		t.Error("an extra target table is destructive drift")
+	}
+}
+
+func TestComputeDrift_ColumnLevel(t *testing.T) {
+	desired := []driver.Table{dtbl("Users",
+		dcol("Id", "int", func(c *driver.Column) { c.IsNullable = false }),
+		dcol("Email", "varchar", func(c *driver.Column) { c.MaxLength = 100 }),
+		dcol("Age", "int"),
+	)}
+	existing := []driver.Table{dtbl("users",
+		dcol("id", "integer", func(c *driver.Column) { c.IsNullable = false }),
+		// Email missing on target.
+		dcol("age", "integer"),
+		// Extra target column not in source.
+		dcol("legacy_flag", "boolean"),
+	)}
+
+	d := ComputeDrift(desired, existing, "mssql", "postgres")
+	if len(d.ChangedTables) != 1 {
+		t.Fatalf("expected 1 changed table, got %d: %+v", len(d.ChangedTables), d.ChangedTables)
+	}
+	td := d.ChangedTables[0]
+	if len(td.MissingColumns) != 1 || td.MissingColumns[0] != "email" {
+		t.Errorf("missing columns = %v, want [email]", td.MissingColumns)
+	}
+	if len(td.ExtraColumns) != 1 || td.ExtraColumns[0] != "legacy_flag" {
+		t.Errorf("extra columns = %v, want [legacy_flag]", td.ExtraColumns)
+	}
+	if !d.HasDestructiveDrift() {
+		t.Error("an extra target column is destructive drift")
+	}
+}
+
+// A type/length/nullability change on a matched column surfaces as a
+// ColumnDelta, not a missing/extra column.
+func TestComputeDrift_ColumnMetadataDelta(t *testing.T) {
+	desired := []driver.Table{dtbl("Users", dcol("Code", "varchar", func(c *driver.Column) { c.MaxLength = 20; c.IsNullable = false }))}
+	existing := []driver.Table{dtbl("users", dcol("code", "character varying", func(c *driver.Column) { c.MaxLength = 10; c.IsNullable = false }))}
+
+	d := ComputeDrift(desired, existing, "mssql", "postgres")
+	if len(d.ChangedTables) != 1 {
+		t.Fatalf("expected 1 changed table, got %d", len(d.ChangedTables))
+	}
+	td := d.ChangedTables[0]
+	if len(td.ColumnDeltas) == 0 {
+		t.Fatal("expected a column delta for the length change")
+	}
+	joined := strings.Join(td.ColumnDeltas, " ")
+	if !strings.Contains(joined, "max_length") {
+		t.Errorf("column delta did not mention max_length: %v", td.ColumnDeltas)
+	}
+	if len(td.MissingColumns) != 0 || len(td.ExtraColumns) != 0 {
+		t.Errorf("metadata change misclassified as missing/extra: %+v", td)
+	}
+	if d.HasDestructiveDrift() {
+		t.Error("a length change is not destructive drift (no drops)")
+	}
+}
+
+// Output ordering must be deterministic for stable reports / CI diffs.
+func TestComputeDrift_StableOrdering(t *testing.T) {
+	desired := []driver.Table{dtbl("Bravo", dcol("Id", "int")), dtbl("Alpha", dcol("Id", "int")), dtbl("Charlie", dcol("Id", "int"))}
+	existing := []driver.Table{}
+	first := ComputeDrift(desired, existing, "mssql", "postgres").MissingTables
+	for i := 0; i < 10; i++ {
+		got := ComputeDrift(desired, existing, "mssql", "postgres").MissingTables
+		if strings.Join(got, ",") != strings.Join(first, ",") {
+			t.Fatalf("unstable ordering: %v vs %v", got, first)
+		}
+	}
+	if strings.Join(first, ",") != "alpha,bravo,charlie" {
+		t.Errorf("missing tables not sorted: %v", first)
+	}
+}

--- a/internal/schemadiff/drift_test.go
+++ b/internal/schemadiff/drift_test.go
@@ -493,3 +493,23 @@ func TestComputeDrift_TargetOnlyCheck(t *testing.T) {
 		t.Fatalf("target-only CHECK should drift, got %+v", d.ChangedTables)
 	}
 }
+
+// RetargetSchema collapses table + FK schema references to the target schema
+// (mirroring create/sync) without mutating the input.
+func TestRetargetSchema(t *testing.T) {
+	in := []driver.Table{{
+		Name: "Orders", Schema: "dbo",
+		ForeignKeys: []driver.ForeignKey{{Name: "fk", RefSchema: "other", RefTable: "C"}},
+	}}
+	out := RetargetSchema(in, "public")
+	if out[0].Schema != "public" || out[0].ForeignKeys[0].RefSchema != "public" {
+		t.Errorf("RetargetSchema did not collapse to target schema: %+v", out[0])
+	}
+	if in[0].Schema != "dbo" || in[0].ForeignKeys[0].RefSchema != "other" {
+		t.Errorf("RetargetSchema mutated its input: %+v", in[0])
+	}
+	// Empty target schema → pass-through (values unchanged).
+	if got := RetargetSchema(in, ""); got[0].Schema != "dbo" {
+		t.Errorf("empty target schema should pass through, got %q", got[0].Schema)
+	}
+}

--- a/internal/schemadiff/drift_test.go
+++ b/internal/schemadiff/drift_test.go
@@ -340,18 +340,35 @@ func TestComputeDrift_ComputedColumn(t *testing.T) {
 		t.Errorf("missing computed delta: %v", d.ChangedTables[0].ColumnDeltas)
 	}
 
-	// Both computed but storage class changed (persisted → virtual).
+	// Both computed but storage class changed (persisted → virtual). Use an
+	// MSSQL target, which can represent both — a PG target can't (always
+	// STORED), so storage is not compared there (see the PG-virtual case below).
 	desired[0].Columns[0].IsComputed, existing[0].Columns[0].IsComputed = true, true
 	existing[0].Columns[0].ComputedPersisted = false
-	d = ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
+	d = ComputeDrift(desired, existing, "mssql", "mssql", DefaultDriftOptions())
 	if len(d.ChangedTables) != 1 || !strings.Contains(strings.Join(d.ChangedTables[0].ColumnDeltas, " "), "storage") {
-		t.Errorf("storage-class change should drift, got %+v", d.ChangedTables)
+		t.Errorf("storage-class change should drift on an mssql target, got %+v", d.ChangedTables)
 	}
 
 	// Both computed, same storage → no drift.
 	existing[0].Columns[0].ComputedPersisted = true
-	if d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions()); !d.IsEmpty() {
+	if d := ComputeDrift(desired, existing, "mssql", "mssql", DefaultDriftOptions()); !d.IsEmpty() {
 		t.Errorf("equivalent computed columns should not drift, got %+v", d.ChangedTables)
+	}
+}
+
+// PostgreSQL generated columns are always STORED, so a source VIRTUAL computed
+// column landing as STORED on a freshly created PG target is NOT drift — the
+// storage class must not be compared for PG targets (#115 review).
+func TestComputeDrift_PostgresVirtualComputedNoDrift(t *testing.T) {
+	desired := []driver.Table{{Name: "T", Columns: []driver.Column{
+		{Name: "margin", DataType: "decimal", IsComputed: true, ComputedExpression: "a-b", ComputedPersisted: false}, // VIRTUAL source
+	}}}
+	existing := []driver.Table{{Name: "t", Columns: []driver.Column{
+		{Name: "margin", DataType: "numeric", IsComputed: true, ComputedExpression: "a-b", ComputedPersisted: true}, // PG forces STORED
+	}}}
+	if d := ComputeDrift(desired, existing, "mysql", "postgres", DefaultDriftOptions()); !d.IsEmpty() {
+		t.Errorf("PG STORED of a VIRTUAL source must not drift, got %+v", d.ChangedTables)
 	}
 }
 
@@ -417,65 +434,6 @@ func TestComputeDrift_FKRefSchemaRelative(t *testing.T) {
 	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
 	if len(d.ChangedTables) != 1 || len(d.ChangedTables[0].MissingForeignKeys) == 0 {
 		t.Fatalf("cross-schema FK drift should be detected, got %+v", d.ChangedTables)
-	}
-}
-
-// Boolean→non-boolean type changes must drift while bit↔boolean↔tinyint(1)
-// stay equivalent.
-func TestComputeDrift_BooleanTypeClass(t *testing.T) {
-	bcol := func(name, dt string, width int) driver.Column {
-		return driver.Column{Name: name, DataType: dt, DisplayWidth: width, IsNullable: true}
-	}
-	// bit → integer: boolean vs numeric → drift.
-	d := ComputeDrift(
-		[]driver.Table{{Name: "T", Columns: []driver.Column{bcol("flag", "bit", 0)}}},
-		[]driver.Table{{Name: "t", Columns: []driver.Column{bcol("flag", "integer", 0)}}},
-		"mssql", "postgres", DefaultDriftOptions())
-	if len(d.ChangedTables) != 1 || !strings.Contains(strings.Join(d.ChangedTables[0].ColumnDeltas, " "), "boolean") {
-		t.Fatalf("bit→integer should drift on type class, got %+v", d.ChangedTables)
-	}
-
-	// bit → boolean and tinyint(1) → boolean: equivalent, no drift.
-	for _, src := range []driver.Column{bcol("flag", "bit", 0), bcol("flag", "tinyint", 1)} {
-		dd := ComputeDrift(
-			[]driver.Table{{Name: "T", Columns: []driver.Column{src}}},
-			[]driver.Table{{Name: "t", Columns: []driver.Column{bcol("flag", "boolean", 0)}}},
-			"mysql", "postgres", DefaultDriftOptions())
-		if !dd.IsEmpty() {
-			t.Errorf("%s→boolean should not drift, got %+v", src.DataType, dd.ChangedTables)
-		}
-	}
-
-	// Plain tinyint (no display width) is numeric, not boolean → vs boolean drifts.
-	d = ComputeDrift(
-		[]driver.Table{{Name: "T", Columns: []driver.Column{bcol("n", "tinyint", 0)}}},
-		[]driver.Table{{Name: "t", Columns: []driver.Column{bcol("n", "boolean", 0)}}},
-		"mysql", "postgres", DefaultDriftOptions())
-	if d.IsEmpty() {
-		t.Error("plain tinyint→boolean should drift (numeric vs boolean)")
-	}
-}
-
-// PG bit/bit varying is a bit-STRING, not boolean — an MSSQL bit (boolean)
-// drifting to a PG bit column must flag a type-class change. MSSQL bit stays
-// boolean (so bit→pg boolean is fine, bit→pg bit is drift).
-func TestComputeDrift_PostgresBitNotBoolean(t *testing.T) {
-	// mssql bit (boolean) → pg bit (bit-string): boolean vs "" ... pg bit is
-	// not a strict family either, so to make the drift visible we compare the
-	// classes directly through ComputeDrift with a numeric target.
-	if isBooleanType(driver.Column{DataType: "bit"}, "postgres") {
-		t.Error("postgres bit must not be classified boolean")
-	}
-	if !isBooleanType(driver.Column{DataType: "bit"}, "mssql") {
-		t.Error("mssql bit must be classified boolean")
-	}
-	// mssql bit → pg integer: boolean vs numeric → drift.
-	d := ComputeDrift(
-		[]driver.Table{{Name: "T", Columns: []driver.Column{{Name: "f", DataType: "bit"}}}},
-		[]driver.Table{{Name: "t", Columns: []driver.Column{{Name: "f", DataType: "integer"}}}},
-		"mssql", "postgres", DefaultDriftOptions())
-	if d.IsEmpty() {
-		t.Error("mssql bit → pg integer should drift on type class")
 	}
 }
 

--- a/internal/schemadiff/drift_test.go
+++ b/internal/schemadiff/drift_test.go
@@ -471,3 +471,21 @@ func TestRetargetSchema(t *testing.T) {
 		t.Errorf("empty target schema should pass through, got %q", got[0].Schema)
 	}
 }
+
+// MySQL INT UNSIGNED → INT (same-dialect) must drift on the structured
+// unsigned flag; cross-dialect (mysql→pg) must NOT, since unsigned is
+// absorbed into a wider target type.
+func TestComputeDrift_MySQLUnsigned(t *testing.T) {
+	src := []driver.Table{{Name: "T", Columns: []driver.Column{{Name: "n", DataType: "int", IsUnsigned: true}}}}
+	tgtSigned := []driver.Table{{Name: "t", Columns: []driver.Column{{Name: "n", DataType: "int", IsUnsigned: false}}}}
+
+	d := ComputeDrift(src, tgtSigned, "mysql", "mysql", DefaultDriftOptions())
+	if len(d.ChangedTables) != 1 || !strings.Contains(strings.Join(d.ChangedTables[0].ColumnDeltas, " "), "unsigned") {
+		t.Errorf("mysql int unsigned → int should drift, got %+v", d.ChangedTables)
+	}
+	// Cross-dialect: pg bigint target carries no unsigned flag — must not drift.
+	tgtPG := []driver.Table{{Name: "t", Columns: []driver.Column{{Name: "n", DataType: "bigint", IsUnsigned: false}}}}
+	if d := ComputeDrift(src, tgtPG, "mysql", "postgres", DefaultDriftOptions()); !d.IsEmpty() {
+		t.Errorf("mysql int unsigned → pg bigint must not drift, got %+v", d.ChangedTables)
+	}
+}

--- a/internal/schemadiff/drift_test.go
+++ b/internal/schemadiff/drift_test.go
@@ -385,3 +385,39 @@ func TestComputeDrift_IndexIncludeAndFilter(t *testing.T) {
 		t.Errorf("INCLUDE/filter loss should drift: missing=%v extra=%v", td.MissingIndexes, td.ExtraIndexes)
 	}
 }
+
+// A foreign key pointing at a different referenced SCHEMA must drift even when
+// the referenced table/columns match. RetargetSchema aligns both sides to the
+// target schema so same-schema FKs don't false-drift.
+func TestComputeDrift_FKRefSchemaAndRetarget(t *testing.T) {
+	desired := []driver.Table{{
+		Name:    "Orders",
+		Columns: []driver.Column{dcol("cust", "int")},
+		ForeignKeys: []driver.ForeignKey{
+			{Name: "fk", Columns: []string{"cust"}, RefSchema: "app", RefTable: "Customers", RefColumns: []string{"id"}},
+		},
+	}}
+	// Same FK shape but pointing at a different schema on the target.
+	existing := []driver.Table{{
+		Name:    "orders",
+		Columns: []driver.Column{dcol("cust", "integer")},
+		ForeignKeys: []driver.ForeignKey{
+			{Name: "fk", Columns: []string{"cust"}, RefSchema: "legacy", RefTable: "customers", RefColumns: []string{"id"}},
+		},
+	}}
+	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
+	if len(d.ChangedTables) != 1 || len(d.ChangedTables[0].MissingForeignKeys) == 0 {
+		t.Fatalf("cross-schema FK ref should drift, got %+v", d.ChangedTables)
+	}
+
+	// After retargeting both sides to the same schema, the FK matches.
+	rd := RetargetSchema(desired, "public")
+	re := RetargetSchema(existing, "public")
+	if d := ComputeDrift(rd, re, "mssql", "postgres", DefaultDriftOptions()); !d.IsEmpty() {
+		t.Errorf("same-schema FK after retarget should not drift, got %+v", d.ChangedTables)
+	}
+	// RetargetSchema must not mutate the input.
+	if desired[0].ForeignKeys[0].RefSchema != "app" {
+		t.Errorf("RetargetSchema mutated its input: %q", desired[0].ForeignKeys[0].RefSchema)
+	}
+}

--- a/internal/schemadiff/drift_test.go
+++ b/internal/schemadiff/drift_test.go
@@ -133,3 +133,55 @@ func TestComputeDrift_StableOrdering(t *testing.T) {
 		t.Errorf("missing tables not sorted: %v", first)
 	}
 }
+
+// Index, FK, and CHECK drift on a table present on both sides, matched by
+// column set / signature so renderer-normalized names don't cause false drift.
+func TestComputeDrift_IndexFKCheck(t *testing.T) {
+	desired := []driver.Table{{
+		Name:    "Orders",
+		Columns: []driver.Column{dcol("Id", "int"), dcol("CustomerId", "int")},
+		Indexes: []driver.Index{
+			{Name: "IX_Orders_Customer", Columns: []string{"CustomerId"}}, // present both sides
+			{Name: "IX_Orders_Id", Columns: []string{"Id"}},               // missing on target
+		},
+		ForeignKeys: []driver.ForeignKey{
+			{Name: "FK_Orders_Cust", Columns: []string{"CustomerId"}, RefTable: "Customers", RefColumns: []string{"Id"}},
+		},
+		CheckConstraints: []driver.CheckConstraint{{Name: "CK_a", Definition: "Id > 0"}, {Name: "CK_b", Definition: "CustomerId > 0"}},
+	}}
+	existing := []driver.Table{{
+		Name:    "orders",
+		Columns: []driver.Column{dcol("id", "integer"), dcol("customerid", "integer")},
+		Indexes: []driver.Index{
+			{Name: "ix_orders_customer", Columns: []string{"customerid"}},    // matches desired by column set
+			{Name: "ix_orders_extra", Columns: []string{"id", "customerid"}}, // extra on target
+		},
+		// FK dropped on target.
+		ForeignKeys: nil,
+		// One CHECK dropped on target.
+		CheckConstraints: []driver.CheckConstraint{{Name: "ck_a", Definition: "id > 0"}},
+	}}
+
+	d := ComputeDrift(desired, existing, "mssql", "postgres")
+	if len(d.ChangedTables) != 1 {
+		t.Fatalf("expected 1 changed table, got %d: %+v", len(d.ChangedTables), d.ChangedTables)
+	}
+	td := d.ChangedTables[0]
+	if len(td.MissingIndexes) != 1 || td.MissingIndexes[0] != "id" {
+		t.Errorf("missing indexes = %v, want [id]", td.MissingIndexes)
+	}
+	if len(td.ExtraIndexes) != 1 || td.ExtraIndexes[0] != "customerid,id" {
+		t.Errorf("extra indexes = %v, want [customerid,id]", td.ExtraIndexes)
+	}
+	if len(td.MissingForeignKeys) != 1 || td.MissingForeignKeys[0] != "customerid->customers" {
+		t.Errorf("missing FKs = %v, want [customerid->customers]", td.MissingForeignKeys)
+	}
+	if td.CheckDrift == "" {
+		t.Error("expected check drift (target dropped a CHECK)")
+	}
+	// Index/FK/check-only drops are not data-loss destructive (no row loss),
+	// so HasDestructiveDrift stays false here (no extra columns/tables).
+	if d.HasDestructiveDrift() {
+		t.Error("index/FK/check drift should not be classified as destructive (no data loss)")
+	}
+}

--- a/internal/schemadiff/drift_test.go
+++ b/internal/schemadiff/drift_test.go
@@ -170,11 +170,11 @@ func TestComputeDrift_IndexFKCheck(t *testing.T) {
 	if len(td.MissingIndexes) != 1 || td.MissingIndexes[0] != "id" {
 		t.Errorf("missing indexes = %v, want [id]", td.MissingIndexes)
 	}
-	if len(td.ExtraIndexes) != 1 || td.ExtraIndexes[0] != "customerid,id" {
-		t.Errorf("extra indexes = %v, want [customerid,id]", td.ExtraIndexes)
+	if len(td.ExtraIndexes) != 1 || td.ExtraIndexes[0] != "id,customerid" {
+		t.Errorf("extra indexes = %v, want [id,customerid]", td.ExtraIndexes)
 	}
-	if len(td.MissingForeignKeys) != 1 || td.MissingForeignKeys[0] != "customerid->customers" {
-		t.Errorf("missing FKs = %v, want [customerid->customers]", td.MissingForeignKeys)
+	if len(td.MissingForeignKeys) != 1 || td.MissingForeignKeys[0] != "customerid:id->customers|noaction|noaction" {
+		t.Errorf("missing FKs = %v, want [customerid:id->customers|noaction|noaction]", td.MissingForeignKeys)
 	}
 	if td.CheckDrift == "" {
 		t.Error("expected check drift (target dropped a CHECK)")
@@ -183,5 +183,89 @@ func TestComputeDrift_IndexFKCheck(t *testing.T) {
 	// so HasDestructiveDrift stays false here (no extra columns/tables).
 	if d.HasDestructiveDrift() {
 		t.Error("index/FK/check drift should not be classified as destructive (no data loss)")
+	}
+}
+
+// A matched column whose type changes family (int -> text) must drift even
+// though CompareColumns sees no length/precision/nullability delta. Legitimate
+// cross-family equivalences (bit -> boolean) must NOT false-flag.
+func TestComputeDrift_TypeFamilyMismatch(t *testing.T) {
+	desired := []driver.Table{dtbl("T",
+		dcol("a", "int"),
+		dcol("flag", "bit"),
+		dcol("name", "varchar", func(c *driver.Column) { c.MaxLength = 20 }),
+	)}
+	existing := []driver.Table{dtbl("t",
+		dcol("a", "text"),       // numeric -> string: drift
+		dcol("flag", "boolean"), // bit -> boolean: equivalent, no drift
+		dcol("name", "character varying", func(c *driver.Column) { c.MaxLength = 20 }), // equivalent
+	)}
+	d := ComputeDrift(desired, existing, "mssql", "postgres")
+	if len(d.ChangedTables) != 1 {
+		t.Fatalf("expected 1 changed table, got %d: %+v", len(d.ChangedTables), d.ChangedTables)
+	}
+	deltas := strings.Join(d.ChangedTables[0].ColumnDeltas, "\n")
+	if !strings.Contains(deltas, "a type class: source=numeric target=string") {
+		t.Errorf("missing int->text type-class delta, got: %v", d.ChangedTables[0].ColumnDeltas)
+	}
+	if strings.Contains(deltas, "flag") {
+		t.Errorf("bit->boolean false-flagged as type drift: %v", d.ChangedTables[0].ColumnDeltas)
+	}
+}
+
+// Composite index column ORDER is significant; FK referential ACTIONS matter.
+func TestComputeDrift_IndexOrderAndFKActions(t *testing.T) {
+	desired := []driver.Table{{
+		Name:    "T",
+		Columns: []driver.Column{dcol("a", "int"), dcol("b", "int")},
+		Indexes: []driver.Index{{Name: "ix", Columns: []string{"a", "b"}}},
+		ForeignKeys: []driver.ForeignKey{
+			{Name: "fk", Columns: []string{"a"}, RefTable: "P", RefColumns: []string{"id"}, OnDelete: "CASCADE"},
+		},
+	}}
+	existing := []driver.Table{{
+		Name:    "t",
+		Columns: []driver.Column{dcol("a", "integer"), dcol("b", "integer")},
+		Indexes: []driver.Index{{Name: "ix", Columns: []string{"b", "a"}}}, // reversed order
+		ForeignKeys: []driver.ForeignKey{
+			{Name: "fk", Columns: []string{"a"}, RefTable: "p", RefColumns: []string{"id"}, OnDelete: "NO ACTION"}, // action changed
+		},
+	}}
+	d := ComputeDrift(desired, existing, "mssql", "postgres")
+	if len(d.ChangedTables) != 1 {
+		t.Fatalf("expected 1 changed table, got %d", len(d.ChangedTables))
+	}
+	td := d.ChangedTables[0]
+	if len(td.MissingIndexes) != 1 || len(td.ExtraIndexes) != 1 {
+		t.Errorf("reversed-order index should drift: missing=%v extra=%v", td.MissingIndexes, td.ExtraIndexes)
+	}
+	if len(td.MissingForeignKeys) != 1 || len(td.ExtraForeignKeys) != 1 {
+		t.Errorf("changed FK action should drift: missing=%v extra=%v", td.MissingForeignKeys, td.ExtraForeignKeys)
+	}
+}
+
+// NormalizeIdentifiers folds all identifiers (including index/FK column lists
+// and referenced tables) and must not mutate the input.
+func TestNormalizeIdentifiers_FullAndPure(t *testing.T) {
+	in := []driver.Table{{
+		Name:       "Orders",
+		Columns:    []driver.Column{{Name: "OrderID"}},
+		PrimaryKey: []string{"OrderID"},
+		Indexes:    []driver.Index{{Name: "IX", Columns: []string{"OrderID"}}},
+		ForeignKeys: []driver.ForeignKey{
+			{Name: "FK", Columns: []string{"OrderID"}, RefTable: "Customers", RefColumns: []string{"CustID"}},
+		},
+	}}
+	out := NormalizeIdentifiers(in, func(s string) string { return strings.ToLower(s) })
+
+	// Input untouched.
+	if in[0].Name != "Orders" || in[0].Indexes[0].Columns[0] != "OrderID" || in[0].ForeignKeys[0].RefTable != "Customers" {
+		t.Errorf("NormalizeIdentifiers mutated its input: %+v", in[0])
+	}
+	// Output fully normalized.
+	o := out[0]
+	if o.Name != "orders" || o.Columns[0].Name != "orderid" || o.Indexes[0].Columns[0] != "orderid" ||
+		o.ForeignKeys[0].RefTable != "customers" || o.ForeignKeys[0].RefColumns[0] != "custid" {
+		t.Errorf("NormalizeIdentifiers did not fold all identifiers: %+v", o)
 	}
 }

--- a/internal/schemadiff/drift_test.go
+++ b/internal/schemadiff/drift_test.go
@@ -36,7 +36,7 @@ func TestComputeDrift_NoFalsePositiveCrossDialect(t *testing.T) {
 			dcol("createdat", "timestamp without time zone"),
 		),
 	}
-	d := ComputeDrift(desired, existing, "mssql", "postgres")
+	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
 	if !d.IsEmpty() {
 		t.Fatalf("expected no drift for equivalent schemas, got: missing=%v extra=%v changed=%+v",
 			d.MissingTables, d.ExtraTables, d.ChangedTables)
@@ -50,7 +50,7 @@ func TestComputeDrift_MissingAndExtraTables(t *testing.T) {
 	desired := []driver.Table{dtbl("Orders", dcol("Id", "int")), dtbl("Items", dcol("Id", "int"))}
 	existing := []driver.Table{dtbl("orders", dcol("id", "integer")), dtbl("legacy", dcol("id", "integer"))}
 
-	d := ComputeDrift(desired, existing, "mssql", "postgres")
+	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
 	if len(d.MissingTables) != 1 || d.MissingTables[0] != "items" {
 		t.Errorf("missing tables = %v, want [items]", d.MissingTables)
 	}
@@ -76,7 +76,7 @@ func TestComputeDrift_ColumnLevel(t *testing.T) {
 		dcol("legacy_flag", "boolean"),
 	)}
 
-	d := ComputeDrift(desired, existing, "mssql", "postgres")
+	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
 	if len(d.ChangedTables) != 1 {
 		t.Fatalf("expected 1 changed table, got %d: %+v", len(d.ChangedTables), d.ChangedTables)
 	}
@@ -98,7 +98,7 @@ func TestComputeDrift_ColumnMetadataDelta(t *testing.T) {
 	desired := []driver.Table{dtbl("Users", dcol("Code", "varchar", func(c *driver.Column) { c.MaxLength = 20; c.IsNullable = false }))}
 	existing := []driver.Table{dtbl("users", dcol("code", "character varying", func(c *driver.Column) { c.MaxLength = 10; c.IsNullable = false }))}
 
-	d := ComputeDrift(desired, existing, "mssql", "postgres")
+	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
 	if len(d.ChangedTables) != 1 {
 		t.Fatalf("expected 1 changed table, got %d", len(d.ChangedTables))
 	}
@@ -122,9 +122,9 @@ func TestComputeDrift_ColumnMetadataDelta(t *testing.T) {
 func TestComputeDrift_StableOrdering(t *testing.T) {
 	desired := []driver.Table{dtbl("Bravo", dcol("Id", "int")), dtbl("Alpha", dcol("Id", "int")), dtbl("Charlie", dcol("Id", "int"))}
 	existing := []driver.Table{}
-	first := ComputeDrift(desired, existing, "mssql", "postgres").MissingTables
+	first := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions()).MissingTables
 	for i := 0; i < 10; i++ {
-		got := ComputeDrift(desired, existing, "mssql", "postgres").MissingTables
+		got := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions()).MissingTables
 		if strings.Join(got, ",") != strings.Join(first, ",") {
 			t.Fatalf("unstable ordering: %v vs %v", got, first)
 		}
@@ -162,7 +162,7 @@ func TestComputeDrift_IndexFKCheck(t *testing.T) {
 		CheckConstraints: []driver.CheckConstraint{{Name: "ck_a", Definition: "id > 0"}},
 	}}
 
-	d := ComputeDrift(desired, existing, "mssql", "postgres")
+	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
 	if len(d.ChangedTables) != 1 {
 		t.Fatalf("expected 1 changed table, got %d: %+v", len(d.ChangedTables), d.ChangedTables)
 	}
@@ -200,7 +200,7 @@ func TestComputeDrift_TypeFamilyMismatch(t *testing.T) {
 		dcol("flag", "boolean"), // bit -> boolean: equivalent, no drift
 		dcol("name", "character varying", func(c *driver.Column) { c.MaxLength = 20 }), // equivalent
 	)}
-	d := ComputeDrift(desired, existing, "mssql", "postgres")
+	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
 	if len(d.ChangedTables) != 1 {
 		t.Fatalf("expected 1 changed table, got %d: %+v", len(d.ChangedTables), d.ChangedTables)
 	}
@@ -231,7 +231,7 @@ func TestComputeDrift_IndexOrderAndFKActions(t *testing.T) {
 			{Name: "fk", Columns: []string{"a"}, RefTable: "p", RefColumns: []string{"id"}, OnDelete: "NO ACTION"}, // action changed
 		},
 	}}
-	d := ComputeDrift(desired, existing, "mssql", "postgres")
+	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
 	if len(d.ChangedTables) != 1 {
 		t.Fatalf("expected 1 changed table, got %d", len(d.ChangedTables))
 	}
@@ -267,5 +267,57 @@ func TestNormalizeIdentifiers_FullAndPure(t *testing.T) {
 	if o.Name != "orders" || o.Columns[0].Name != "orderid" || o.Indexes[0].Columns[0] != "orderid" ||
 		o.ForeignKeys[0].RefTable != "customers" || o.ForeignKeys[0].RefColumns[0] != "custid" {
 		t.Errorf("NormalizeIdentifiers did not fold all identifiers: %+v", o)
+	}
+}
+
+// A dropped or re-keyed primary key must drift — the index loaders exclude
+// PK-backed indexes, so it's checked directly.
+func TestComputeDrift_PrimaryKey(t *testing.T) {
+	desired := []driver.Table{{
+		Name:       "Users",
+		Columns:    []driver.Column{dcol("Id", "int"), dcol("Email", "varchar")},
+		PrimaryKey: []string{"Id"},
+	}}
+	// Target lost its PK.
+	existing := []driver.Table{{
+		Name:       "users",
+		Columns:    []driver.Column{dcol("id", "integer"), dcol("email", "character varying")},
+		PrimaryKey: nil,
+	}}
+	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
+	if len(d.ChangedTables) != 1 || d.ChangedTables[0].PKDrift == "" {
+		t.Fatalf("dropped PK should drift, got %+v", d.ChangedTables)
+	}
+
+	// Same PK (case-insensitive) → no drift.
+	existing[0].PrimaryKey = []string{"id"}
+	if d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions()); !d.IsEmpty() {
+		t.Errorf("equal PK should not drift, got %+v", d.ChangedTables)
+	}
+}
+
+// DriftOptions gates unmanaged object kinds: with index/FK/check comparison
+// off, differences in those kinds must not surface.
+func TestComputeDrift_OptionsGateUnmanagedKinds(t *testing.T) {
+	desired := []driver.Table{{
+		Name:             "Orders",
+		Columns:          []driver.Column{dcol("Id", "int")},
+		Indexes:          []driver.Index{{Name: "ix", Columns: []string{"Id"}}},
+		ForeignKeys:      []driver.ForeignKey{{Name: "fk", Columns: []string{"Id"}, RefTable: "P", RefColumns: []string{"id"}}},
+		CheckConstraints: []driver.CheckConstraint{{Name: "ck", Definition: "Id > 0"}},
+	}}
+	existing := []driver.Table{{
+		Name:    "orders",
+		Columns: []driver.Column{dcol("id", "integer")},
+		// No indexes/FKs/checks on the target.
+	}}
+	// All comparisons off → no drift despite the missing index/FK/check.
+	off := DriftOptions{CompareIndexes: false, CompareForeignKeys: false, CompareChecks: false}
+	if d := ComputeDrift(desired, existing, "mssql", "postgres", off); !d.IsEmpty() {
+		t.Errorf("gated-off kinds should not drift, got %+v", d.ChangedTables)
+	}
+	// All on → drift across all three kinds.
+	if d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions()); d.IsEmpty() {
+		t.Error("with comparison on, missing index/FK/check should drift")
 	}
 }

--- a/internal/schemadiff/drift_test.go
+++ b/internal/schemadiff/drift_test.go
@@ -321,3 +321,67 @@ func TestComputeDrift_OptionsGateUnmanagedKinds(t *testing.T) {
 		t.Error("with comparison on, missing index/FK/check should drift")
 	}
 }
+
+// Computed-column presence and storage class are cross-dialect structural
+// facts drift must catch even when type/length/nullability are unchanged.
+func TestComputeDrift_ComputedColumn(t *testing.T) {
+	// Source column is generated; target made it a plain column.
+	desired := []driver.Table{{Name: "T", Columns: []driver.Column{
+		{Name: "total", DataType: "int", IsComputed: true, ComputedExpression: "a+b", ComputedPersisted: true},
+	}}}
+	existing := []driver.Table{{Name: "t", Columns: []driver.Column{
+		{Name: "total", DataType: "integer", IsComputed: false},
+	}}}
+	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
+	if len(d.ChangedTables) != 1 || len(d.ChangedTables[0].ColumnDeltas) == 0 {
+		t.Fatalf("computed→plain should drift, got %+v", d.ChangedTables)
+	}
+	if !strings.Contains(strings.Join(d.ChangedTables[0].ColumnDeltas, " "), "computed") {
+		t.Errorf("missing computed delta: %v", d.ChangedTables[0].ColumnDeltas)
+	}
+
+	// Both computed but storage class changed (persisted → virtual).
+	desired[0].Columns[0].IsComputed, existing[0].Columns[0].IsComputed = true, true
+	existing[0].Columns[0].ComputedPersisted = false
+	d = ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
+	if len(d.ChangedTables) != 1 || !strings.Contains(strings.Join(d.ChangedTables[0].ColumnDeltas, " "), "storage") {
+		t.Errorf("storage-class change should drift, got %+v", d.ChangedTables)
+	}
+
+	// Both computed, same storage → no drift.
+	existing[0].Columns[0].ComputedPersisted = true
+	if d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions()); !d.IsEmpty() {
+		t.Errorf("equivalent computed columns should not drift, got %+v", d.ChangedTables)
+	}
+}
+
+// A covering index that loses its INCLUDE columns, or an index that loses its
+// filter, must drift even though the key columns match.
+func TestComputeDrift_IndexIncludeAndFilter(t *testing.T) {
+	desired := []driver.Table{{
+		Name:    "T",
+		Columns: []driver.Column{dcol("a", "int"), dcol("b", "int")},
+		Indexes: []driver.Index{
+			{Name: "cover", Columns: []string{"a"}, IncludeCols: []string{"b"}},
+			{Name: "filt", Columns: []string{"a"}, Filter: "a > 0"},
+		},
+	}}
+	existing := []driver.Table{{
+		Name:    "t",
+		Columns: []driver.Column{dcol("a", "integer"), dcol("b", "integer")},
+		Indexes: []driver.Index{
+			{Name: "cover", Columns: []string{"a"}}, // lost INCLUDE
+			{Name: "filt", Columns: []string{"a"}},  // lost filter
+		},
+	}}
+	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
+	if len(d.ChangedTables) != 1 {
+		t.Fatalf("expected drift, got %+v", d.ChangedTables)
+	}
+	// Both desired index variants are "missing" (their keyed forms aren't on
+	// target) and both bare target indexes are "extra".
+	td := d.ChangedTables[0]
+	if len(td.MissingIndexes) != 2 || len(td.ExtraIndexes) != 2 {
+		t.Errorf("INCLUDE/filter loss should drift: missing=%v extra=%v", td.MissingIndexes, td.ExtraIndexes)
+	}
+}

--- a/internal/schemadiff/drift_test.go
+++ b/internal/schemadiff/drift_test.go
@@ -173,7 +173,7 @@ func TestComputeDrift_IndexFKCheck(t *testing.T) {
 	if len(td.ExtraIndexes) != 1 || td.ExtraIndexes[0] != "id,customerid" {
 		t.Errorf("extra indexes = %v, want [id,customerid]", td.ExtraIndexes)
 	}
-	if len(td.MissingForeignKeys) != 1 || td.MissingForeignKeys[0] != "customerid:id->customers|noaction|noaction" {
+	if len(td.MissingForeignKeys) != 1 || td.MissingForeignKeys[0] != "customerid:id->self.customers|noaction|noaction" {
 		t.Errorf("missing FKs = %v, want [customerid:id->customers|noaction|noaction]", td.MissingForeignKeys)
 	}
 	if td.CheckDrift == "" {
@@ -386,38 +386,72 @@ func TestComputeDrift_IndexIncludeAndFilter(t *testing.T) {
 	}
 }
 
-// A foreign key pointing at a different referenced SCHEMA must drift even when
-// the referenced table/columns match. RetargetSchema aligns both sides to the
-// target schema so same-schema FKs don't false-drift.
-func TestComputeDrift_FKRefSchemaAndRetarget(t *testing.T) {
+// FK referenced-schema comparison is schema-relative: a same-schema reference
+// (RefSchema equal to the owning table's schema, or empty) reads as "self" and
+// compares equal across dialects even when the literal schema names differ
+// (source "dbo" vs target "public"); a genuine cross-schema reference that
+// changes drifts.
+func TestComputeDrift_FKRefSchemaRelative(t *testing.T) {
+	// Same-schema FK on both sides but with different literal schema names —
+	// must NOT drift (both are "self").
 	desired := []driver.Table{{
-		Name:    "Orders",
+		Name: "Orders", Schema: "dbo",
 		Columns: []driver.Column{dcol("cust", "int")},
 		ForeignKeys: []driver.ForeignKey{
-			{Name: "fk", Columns: []string{"cust"}, RefSchema: "app", RefTable: "Customers", RefColumns: []string{"id"}},
+			{Name: "fk", Columns: []string{"cust"}, RefSchema: "dbo", RefTable: "Customers", RefColumns: []string{"id"}},
 		},
 	}}
-	// Same FK shape but pointing at a different schema on the target.
 	existing := []driver.Table{{
-		Name:    "orders",
+		Name: "orders", Schema: "public",
 		Columns: []driver.Column{dcol("cust", "integer")},
 		ForeignKeys: []driver.ForeignKey{
-			{Name: "fk", Columns: []string{"cust"}, RefSchema: "legacy", RefTable: "customers", RefColumns: []string{"id"}},
+			{Name: "fk", Columns: []string{"cust"}, RefSchema: "public", RefTable: "customers", RefColumns: []string{"id"}},
 		},
 	}}
-	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
-	if len(d.ChangedTables) != 1 || len(d.ChangedTables[0].MissingForeignKeys) == 0 {
-		t.Fatalf("cross-schema FK ref should drift, got %+v", d.ChangedTables)
+	if d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions()); !d.IsEmpty() {
+		t.Fatalf("same-schema FK across dialects should not drift, got %+v", d.ChangedTables)
 	}
 
-	// After retargeting both sides to the same schema, the FK matches.
-	rd := RetargetSchema(desired, "public")
-	re := RetargetSchema(existing, "public")
-	if d := ComputeDrift(rd, re, "mssql", "postgres", DefaultDriftOptions()); !d.IsEmpty() {
-		t.Errorf("same-schema FK after retarget should not drift, got %+v", d.ChangedTables)
+	// Target FK drifted to reference a different (cross-)schema → must drift.
+	existing[0].ForeignKeys[0].RefSchema = "legacy"
+	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
+	if len(d.ChangedTables) != 1 || len(d.ChangedTables[0].MissingForeignKeys) == 0 {
+		t.Fatalf("cross-schema FK drift should be detected, got %+v", d.ChangedTables)
 	}
-	// RetargetSchema must not mutate the input.
-	if desired[0].ForeignKeys[0].RefSchema != "app" {
-		t.Errorf("RetargetSchema mutated its input: %q", desired[0].ForeignKeys[0].RefSchema)
+}
+
+// Boolean→non-boolean type changes must drift while bit↔boolean↔tinyint(1)
+// stay equivalent.
+func TestComputeDrift_BooleanTypeClass(t *testing.T) {
+	bcol := func(name, dt string, width int) driver.Column {
+		return driver.Column{Name: name, DataType: dt, DisplayWidth: width, IsNullable: true}
+	}
+	// bit → integer: boolean vs numeric → drift.
+	d := ComputeDrift(
+		[]driver.Table{{Name: "T", Columns: []driver.Column{bcol("flag", "bit", 0)}}},
+		[]driver.Table{{Name: "t", Columns: []driver.Column{bcol("flag", "integer", 0)}}},
+		"mssql", "postgres", DefaultDriftOptions())
+	if len(d.ChangedTables) != 1 || !strings.Contains(strings.Join(d.ChangedTables[0].ColumnDeltas, " "), "boolean") {
+		t.Fatalf("bit→integer should drift on type class, got %+v", d.ChangedTables)
+	}
+
+	// bit → boolean and tinyint(1) → boolean: equivalent, no drift.
+	for _, src := range []driver.Column{bcol("flag", "bit", 0), bcol("flag", "tinyint", 1)} {
+		dd := ComputeDrift(
+			[]driver.Table{{Name: "T", Columns: []driver.Column{src}}},
+			[]driver.Table{{Name: "t", Columns: []driver.Column{bcol("flag", "boolean", 0)}}},
+			"mysql", "postgres", DefaultDriftOptions())
+		if !dd.IsEmpty() {
+			t.Errorf("%s→boolean should not drift, got %+v", src.DataType, dd.ChangedTables)
+		}
+	}
+
+	// Plain tinyint (no display width) is numeric, not boolean → vs boolean drifts.
+	d = ComputeDrift(
+		[]driver.Table{{Name: "T", Columns: []driver.Column{bcol("n", "tinyint", 0)}}},
+		[]driver.Table{{Name: "t", Columns: []driver.Column{bcol("n", "boolean", 0)}}},
+		"mysql", "postgres", DefaultDriftOptions())
+	if d.IsEmpty() {
+		t.Error("plain tinyint→boolean should drift (numeric vs boolean)")
 	}
 }

--- a/internal/schemadiff/drift_test.go
+++ b/internal/schemadiff/drift_test.go
@@ -455,3 +455,41 @@ func TestComputeDrift_BooleanTypeClass(t *testing.T) {
 		t.Error("plain tinyint→boolean should drift (numeric vs boolean)")
 	}
 }
+
+// PG bit/bit varying is a bit-STRING, not boolean — an MSSQL bit (boolean)
+// drifting to a PG bit column must flag a type-class change. MSSQL bit stays
+// boolean (so bit→pg boolean is fine, bit→pg bit is drift).
+func TestComputeDrift_PostgresBitNotBoolean(t *testing.T) {
+	// mssql bit (boolean) → pg bit (bit-string): boolean vs "" ... pg bit is
+	// not a strict family either, so to make the drift visible we compare the
+	// classes directly through ComputeDrift with a numeric target.
+	if isBooleanType(driver.Column{DataType: "bit"}, "postgres") {
+		t.Error("postgres bit must not be classified boolean")
+	}
+	if !isBooleanType(driver.Column{DataType: "bit"}, "mssql") {
+		t.Error("mssql bit must be classified boolean")
+	}
+	// mssql bit → pg integer: boolean vs numeric → drift.
+	d := ComputeDrift(
+		[]driver.Table{{Name: "T", Columns: []driver.Column{{Name: "f", DataType: "bit"}}}},
+		[]driver.Table{{Name: "t", Columns: []driver.Column{{Name: "f", DataType: "integer"}}}},
+		"mssql", "postgres", DefaultDriftOptions())
+	if d.IsEmpty() {
+		t.Error("mssql bit → pg integer should drift on type class")
+	}
+}
+
+// A target-only CHECK (target has MORE checks than the source) is drift too —
+// it can reject rows the source allows.
+func TestComputeDrift_TargetOnlyCheck(t *testing.T) {
+	desired := []driver.Table{{Name: "T", Columns: []driver.Column{dcol("a", "int")}}}
+	existing := []driver.Table{{
+		Name:             "t",
+		Columns:          []driver.Column{dcol("a", "integer")},
+		CheckConstraints: []driver.CheckConstraint{{Name: "ck", Definition: "a > 0"}},
+	}}
+	d := ComputeDrift(desired, existing, "mssql", "postgres", DefaultDriftOptions())
+	if len(d.ChangedTables) != 1 || d.ChangedTables[0].CheckDrift == "" {
+		t.Fatalf("target-only CHECK should drift, got %+v", d.ChangedTables)
+	}
+}


### PR DESCRIPTION
## Summary
`smt sync` diffs the source against its stored snapshot; it never looks at the target. `smt drift` introspects the **live target** and compares it against the **desired** schema derived from the current source, classifying differences at table, column, PK, index, FK, and check granularity.

- **Cross-dialect aware**: column drift is judged by `driver.CompareColumns`, so `varchar(20)` ≡ `character varying(20)`, `datetime2` ≡ `timestamp`, etc. — no false drift across engines. A conservative type-family check additionally catches gross changes (`int`→`text`) the comparator doesn't (boolean/uuid/json deferred to its equivalence classes).
- **Constraints**: secondary indexes (ordered columns + uniqueness), foreign keys (ordered local→ref pairs + ON DELETE/UPDATE actions), CHECK count, and the **primary key** column set are all compared. Index/FK names are renderer-normalized per dialect, so matching is by signature, not name.
- **Honors migration scope**: `include_tables`/`exclude_tables` filter both sides; `create_indexes`/`create_foreign_keys`/`create_check_constraints` gate which object kinds are introspected and compared, so unmanaged kinds aren't reported as drift.
- **Identifier normalization**: all desired identifiers (incl. index/FK column lists and referenced tables) are folded to the target convention via the pure, deep-copying `schemadiff.NormalizeIdentifiers`.
- Read-only. Exit 0 = in sync, 3 = drift. `--fail-on-destructive-only` exits 0 for additive-only drift (CI gate distinguishing "target behind" from "target diverged").

`schemadiff.ComputeDrift` is pure and unit-tested. Advances #69 (target introspection + desired-vs-existing classification). Known limitation: same-family width changes (`integer`→`bigint`, `varchar(20)`→`char(20)`) aren't flagged — distinguishing those from cross-dialect equivalences needs the canonical concrete-type model tracked in #62.

## Test plan
- [x] Unit: cross-dialect no-false-positive, missing/extra tables+columns, metadata + type-family deltas, index order, FK actions, PK drop/equality, option gating, normalize fold + immutability, stable ordering
- [x] cmd helper tests (target→source connection mapping)
- [x] Live mssql StackOverflow2010 → pg: clean target = no drift; injected table/column/index/PK drops detected and classified; exit codes 0/3
- [x] `go test ./... -short` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)