### PR TITLE
Route MSSQL/MySQL renderer targets through the canonical type IR (#62)

### DIFF
--- a/internal/canonical/from_canonical.go
+++ b/internal/canonical/from_canonical.go
@@ -10,6 +10,14 @@ import (
 // type. The caller applies its unknown-type policy (fail / warn / text_fallback).
 var ErrUnknownType = errors.New("non-portable source type")
 
+// ErrMissingEnumValues is returned by FromCanonical when an Enum/Set canonical
+// type reaches a target that renders a native member list (MySQL ENUM/SET) but
+// carries no values. The caller applies its unknown-type policy the same way it
+// would for an unmappable type (warn / text_fallback degrade to a sized VARCHAR;
+// fail surfaces the error). Targets that render enum/set as a plain sized string
+// (MSSQL NVARCHAR) never hit this.
+var ErrMissingEnumValues = errors.New("enum/set is missing allowed values")
+
 // RenderOpts carries the few column-level facts that affect the rendered TYPE
 // (as opposed to separate column clauses). IsIdentity matters because some
 // targets pick a different physical type for an identity column (pg keeps an
@@ -418,7 +426,7 @@ func setStringLen(ct CanonicalType) int {
 
 func enumDDL(name string, ct CanonicalType) (string, error) {
 	if len(ct.EnumValues) == 0 {
-		return "", fmt.Errorf("%s is missing allowed values", strings.ToLower(name))
+		return "", ErrMissingEnumValues
 	}
 	quoted := make([]string, len(ct.EnumValues))
 	for i, v := range ct.EnumValues {

--- a/internal/canonical/to_canonical.go
+++ b/internal/canonical/to_canonical.go
@@ -27,6 +27,9 @@ func ToCanonical(typeName string, m TypeMeta, dialect string) CanonicalType {
 	case "tinyint":
 		// MySQL's tinyint(1) is the boolean convention (the reader captures
 		// DisplayWidth==1 only for it). Plain tinyint is an 8-bit integer.
+		// tinyint(1) is MySQL's boolean (BOOL/BOOLEAN are aliases for it). The
+		// boolean class has no sign, so a tinyint(1) UNSIGNED canonicalizes to
+		// Boolean too — the (meaningless) UNSIGNED is dropped on round-trip.
 		if mysql && m.DisplayWidth == 1 {
 			return CanonicalType{Kind: Boolean}
 		}
@@ -105,10 +108,9 @@ func ToCanonical(typeName string, m TypeMeta, dialect string) CanonicalType {
 	case "image":
 		return CanonicalType{Kind: Blob} // MSSQL ~2GB
 	case "blob":
-		if mysql {
-			return CanonicalType{Kind: Blob, Length: baseCap}
-		}
-		return CanonicalType{Kind: Blob}
+		// "blob" is a MySQL-only type name — inherently the 64KiB tier
+		// regardless of how the source dialect is labeled.
+		return CanonicalType{Kind: Blob, Length: baseCap}
 	case "tinyblob":
 		return CanonicalType{Kind: Blob, Length: tinyCap}
 	case "mediumblob":

--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -579,8 +579,17 @@ func (r Renderer) mysqlColumnType(col driver.Column, dt string) (string, error) 
 func (r Renderer) canonicalColumnType(col driver.Column, dt, target string) (string, error) {
 	ct := canonical.ToCanonical(dt, metaOf(col), r.source)
 	typ, err := canonical.FromCanonical(ct, target, canonical.RenderOpts{IsIdentity: col.IsIdentity})
-	if errors.Is(err, canonical.ErrUnknownType) {
+	switch {
+	case errors.Is(err, canonical.ErrUnknownType):
 		return r.unknownType(dt)
+	case errors.Is(err, canonical.ErrMissingEnumValues):
+		// A native ENUM/SET target (MySQL) needs the member list. Preserve the
+		// pre-canonical renderer's contract: warn/text_fallback degrade to a
+		// sized string instead of failing the whole render; fail surfaces it.
+		if r.unknownTypePolicy == "warn" || r.unknownTypePolicy == "text_fallback" {
+			return "VARCHAR(255)", nil
+		}
+		return "", fmt.Errorf("%s column %s is missing allowed values", strings.ToLower(dt), col.Name)
 	}
 	return typ, err
 }

--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -2,11 +2,13 @@
 package ddl
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 	"sync"
 
+	"smt/internal/canonical"
 	"smt/internal/driver"
 	pgddl "smt/internal/driver/postgres"
 )
@@ -563,162 +565,36 @@ func (r Renderer) SetColumnDefaultDDL(tableName string, col driver.Column) (stri
 }
 
 func (r Renderer) mssqlColumnType(col driver.Column, dt string) (string, error) {
-	switch dt {
-	case "tinyint":
-		return "TINYINT", nil
-	case "smallint", "int2":
-		if col.IsUnsigned {
-			return "INT", nil
-		}
-		return "SMALLINT", nil
-	case "int", "integer", "int4", "serial", "mediumint":
-		if col.IsUnsigned {
-			return "BIGINT", nil
-		}
-		return "INT", nil
-	case "bigint", "int8", "bigserial":
-		if col.IsUnsigned {
-			return "DECIMAL(20,0)", nil
-		}
-		return "BIGINT", nil
-	case "bit", "bool", "boolean":
-		return "BIT", nil
-	case "varchar", "character varying":
-		return sizedTypeCapped("VARCHAR", col.MaxLength, 8000, "MAX"), nil
-	case "nvarchar":
-		return sizedTypeCapped("NVARCHAR", col.MaxLength, 4000, "MAX"), nil
-	case "char", "character", "bpchar":
-		if col.MaxLength > 8000 {
-			return "VARCHAR(MAX)", nil
-		}
-		return sizedType("CHAR", col.MaxLength, "1"), nil
-	case "nchar":
-		if col.MaxLength > 4000 {
-			return "NVARCHAR(MAX)", nil
-		}
-		return sizedType("NCHAR", col.MaxLength, "1"), nil
-	case "text", "ntext", "tinytext", "mediumtext", "longtext", "json", "jsonb", "xml", "array", "_text", "text[]", "_varchar", "varchar[]", "_bpchar", "bpchar[]", "_int2", "int2[]", "_int4", "int4[]", "_int8", "int8[]", "_uuid", "uuid[]":
-		return "NVARCHAR(MAX)", nil
-	case "enum":
-		return sizedType("NVARCHAR", enumStringLength(col), "255"), nil
-	case "set":
-		return sizedType("NVARCHAR", setStringLength(col), "255"), nil
-	case "rowversion":
-		return "ROWVERSION", nil
-	case "datetime", "datetime2", "smalldatetime", "timestamp", "timestamp without time zone":
-		return fspType("DATETIME2", col, 7), nil
-	case "datetimeoffset", "timestamptz", "timestamp with time zone":
-		return fspType("DATETIMEOFFSET", col, 7), nil
-	case "date":
-		return "DATE", nil
-	case "time", "time without time zone", "time with time zone":
-		return fspType("TIME", col, 7), nil
-	case "decimal", "numeric", "number":
-		return decimalType("DECIMAL", col), nil
-	case "money":
-		return "DECIMAL(19,4)", nil
-	case "smallmoney":
-		return "DECIMAL(10,4)", nil
-	case "float", "double", "double precision", "float8":
-		return "FLOAT", nil
-	case "real", "float4":
-		return "REAL", nil
-	case "uniqueidentifier", "uuid":
-		return "UNIQUEIDENTIFIER", nil
-	case "varbinary", "binary", "image", "bytea", "blob", "tinyblob", "mediumblob", "longblob":
-		return sizedTypeCapped("VARBINARY", col.MaxLength, 8000, "MAX"), nil
-	default:
-		return r.unknownType(dt)
-	}
+	return r.canonicalColumnType(col, dt, "mssql")
 }
 
 func (r Renderer) mysqlColumnType(col driver.Column, dt string) (string, error) {
-	switch dt {
-	case "tinyint":
-		if r.source == "mysql" && col.DisplayWidth == 1 {
-			return mysqlUnsignedType("TINYINT(1)", col), nil
-		}
-		return mysqlUnsignedType("TINYINT", col), nil
-	case "smallint", "int2":
-		return mysqlUnsignedType("SMALLINT", col), nil
-	case "mediumint":
-		return mysqlUnsignedType("MEDIUMINT", col), nil
-	case "int", "integer", "int4", "serial":
-		return mysqlUnsignedType("INT", col), nil
-	case "bigint", "int8", "bigserial":
-		return mysqlUnsignedType("BIGINT", col), nil
-	case "bit", "bool", "boolean":
-		return "TINYINT(1)", nil
-	case "varchar", "nvarchar", "character varying":
-		return mysqlVarcharType(col.MaxLength), nil
-	case "char", "nchar", "character", "bpchar":
-		if col.MaxLength > 255 {
-			return mysqlVarcharType(col.MaxLength), nil
-		}
-		return sizedType("CHAR", col.MaxLength, "1"), nil
-	case "text", "ntext", "tinytext", "mediumtext", "longtext":
-		// "text" is dialect-ambiguous: MySQL's 64KiB tier vs the unbounded
-		// LOB of pg (1GB) and legacy mssql (2GB). Same-dialect keeps the
-		// tier verbatim; foreign unbounded sources need LONGTEXT to avoid
-		// a silent capacity downgrade (#108).
-		if dt == "text" && r.source != "mysql" {
-			return "LONGTEXT", nil
-		}
-		return mysqlTextType(dt), nil
-	case "json", "jsonb", "array", "_text", "text[]", "_varchar", "varchar[]", "_bpchar", "bpchar[]", "_int2", "int2[]", "_int4", "int4[]", "_int8", "int8[]", "_uuid", "uuid[]":
-		return "JSON", nil
-	case "rowversion":
-		return "BINARY(8)", nil
-	case "timestamp":
-		// MySQL TIMESTAMP is UTC-normalized with session-tz conversion; a
-		// same-dialect run must keep it. For foreign sources "timestamp" is
-		// pg's naive datetime, where TIMESTAMP's 1970–2038 range and UTC
-		// normalization make DATETIME the right target.
-		if r.source == "mysql" {
-			return mysqlFspType("TIMESTAMP", col, 6), nil
-		}
-		return mysqlFspType("DATETIME", col, 6), nil
-	case "datetime", "datetime2", "smalldatetime", "timestamp without time zone", "timestamptz", "datetimeoffset", "timestamp with time zone":
-		return mysqlFspType("DATETIME", col, 6), nil
-	case "date":
-		return "DATE", nil
-	case "time", "time without time zone", "time with time zone":
-		return mysqlFspType("TIME", col, 0), nil
-	case "decimal", "numeric", "number":
-		return mysqlUnsignedType(decimalType("DECIMAL", col), col), nil
-	case "money":
-		return "DECIMAL(19,4)", nil
-	case "smallmoney":
-		return "DECIMAL(10,4)", nil
-	case "float", "float4":
-		return "FLOAT", nil
-	case "double", "double precision", "real", "float8":
-		return "DOUBLE", nil
-	case "uniqueidentifier", "uuid":
-		return "CHAR(36)", nil
-	case "varbinary", "binary", "bytea":
-		// Unbounded sources (pg bytea reports 0, mssql varbinary(max) -1)
-		// hold up to 1-2GB — only LONGBLOB doesn't lose capacity. Sized
-		// sources past VARBINARY's 65535-byte ceiling fit MEDIUMBLOB.
-		if col.MaxLength <= 0 {
-			return "LONGBLOB", nil
-		}
-		if col.MaxLength > 65535 {
-			return "MEDIUMBLOB", nil
-		}
-		return fmt.Sprintf("VARBINARY(%d)", col.MaxLength), nil
-	case "image":
-		// MSSQL IMAGE holds 2GB; BLOB (64KiB) would silently truncate.
-		return "LONGBLOB", nil
-	case "blob", "tinyblob", "mediumblob", "longblob":
-		// MySQL-only names: preserve the tier verbatim.
-		return strings.ToUpper(dt), nil
-	case "enum":
-		return r.enumSetType("ENUM", col)
-	case "set":
-		return r.enumSetType("SET", col)
-	default:
+	return r.canonicalColumnType(col, dt, "mysql")
+}
+
+// canonicalColumnType maps a source type to the target dialect's DDL type
+// through the canonical type IR (#62): the source column is normalized to a
+// CanonicalType for the source dialect, then rendered for the target dialect.
+// Non-portable (Raw) types fall through to the unknown-type policy.
+func (r Renderer) canonicalColumnType(col driver.Column, dt, target string) (string, error) {
+	ct := canonical.ToCanonical(dt, metaOf(col), r.source)
+	typ, err := canonical.FromCanonical(ct, target, canonical.RenderOpts{IsIdentity: col.IsIdentity})
+	if errors.Is(err, canonical.ErrUnknownType) {
 		return r.unknownType(dt)
+	}
+	return typ, err
+}
+
+// metaOf extracts the type-shaping metadata canonical.ToCanonical needs.
+func metaOf(col driver.Column) canonical.TypeMeta {
+	return canonical.TypeMeta{
+		MaxLength:         col.MaxLength,
+		Precision:         col.Precision,
+		Scale:             col.Scale,
+		DatetimePrecision: col.DatetimePrecision,
+		IsUnsigned:        col.IsUnsigned,
+		DisplayWidth:      col.DisplayWidth,
+		EnumValues:        col.EnumValues,
 	}
 }
 
@@ -821,53 +697,6 @@ func normalizeTypeName(dt string) string {
 	return dt
 }
 
-func sizedType(name string, length int, unbounded string) string {
-	if length <= 0 || length == -1 {
-		return fmt.Sprintf("%s(%s)", name, unbounded)
-	}
-	return fmt.Sprintf("%s(%d)", name, length)
-}
-
-// sizedTypeCapped degrades lengths above the target dialect's maximum for the
-// type to the unbounded form instead of emitting DDL the target rejects.
-func sizedTypeCapped(name string, length, max int, unbounded string) string {
-	if length > max {
-		return fmt.Sprintf("%s(%s)", name, unbounded)
-	}
-	return sizedType(name, length, unbounded)
-}
-
-// fspType renders a datetime/time type with the source's fractional-seconds
-// precision when known (#88), clamped to the target's maximum; unknown
-// precision keeps the bare type (target default).
-func fspType(name string, col driver.Column, max int) string {
-	if col.DatetimePrecision == nil || *col.DatetimePrecision < 0 {
-		return name
-	}
-	p := *col.DatetimePrecision
-	if p > max {
-		p = max
-	}
-	return fmt.Sprintf("%s(%d)", name, p)
-}
-
-// mysqlFspType is fspType for MySQL (max fsp 6), with a default precision for
-// unknown sources — 6 for DATETIME (the pre-#88 behavior), 0 for TIME. fsp 0
-// renders bare (DATETIME == DATETIME(0)).
-func mysqlFspType(name string, col driver.Column, def int) string {
-	p := def
-	if col.DatetimePrecision != nil && *col.DatetimePrecision >= 0 {
-		p = *col.DatetimePrecision
-		if p > 6 {
-			p = 6
-		}
-	}
-	if p == 0 {
-		return name
-	}
-	return fmt.Sprintf("%s(%d)", name, p)
-}
-
 // mysqlNowDefault renders the CURRENT_TIMESTAMP default with the same fsp the
 // column type will carry — MySQL rejects a default whose fsp differs from the
 // column's.
@@ -883,107 +712,6 @@ func mysqlNowDefault(col driver.Column) string {
 		return "CURRENT_TIMESTAMP"
 	}
 	return fmt.Sprintf("CURRENT_TIMESTAMP(%d)", p)
-}
-
-func decimalType(name string, col driver.Column) string {
-	if col.Precision > 0 {
-		return fmt.Sprintf("%s(%d,%d)", name, col.Precision, col.Scale)
-	}
-	return name
-}
-
-func mysqlUnsignedType(base string, col driver.Column) string {
-	if col.IsUnsigned {
-		return base + " UNSIGNED"
-	}
-	return base
-}
-
-func mysqlVarcharType(length int) string {
-	// Unbounded sources (mssql MAX = -1, pg unconstrained varchar = 0)
-	// hold up to 1-2GB — only LONGTEXT doesn't lose capacity.
-	if length <= 0 {
-		return "LONGTEXT"
-	}
-	// 16383 is the longest VARCHAR that fits MySQL's 65535-byte row limit
-	// under utf8mb4 (the charset our CREATE TABLE emits). Past it, pick the
-	// smallest text tier whose BYTE capacity covers the worst case of 4
-	// bytes per character: TEXT (64KiB) can hold only 16383 such chars, so
-	// the next safe tier is MEDIUMTEXT (16MiB, ~4.19M chars).
-	if length > 16777215/4 {
-		return "LONGTEXT"
-	}
-	if length > 16383 {
-		return "MEDIUMTEXT"
-	}
-	return fmt.Sprintf("VARCHAR(%d)", length)
-}
-
-func mysqlTextType(dt string) string {
-	switch dt {
-	case "tinytext":
-		return "TINYTEXT"
-	case "mediumtext":
-		return "MEDIUMTEXT"
-	case "longtext", "ntext":
-		return "LONGTEXT"
-	default:
-		return "TEXT"
-	}
-}
-
-func enumStringLength(col driver.Column) int {
-	length := col.MaxLength
-	for _, v := range enumValues(col) {
-		if len(v) > length {
-			length = len(v)
-		}
-	}
-	return length
-}
-
-func setStringLength(col driver.Column) int {
-	if col.MaxLength > 0 {
-		return col.MaxLength
-	}
-	values := enumValues(col)
-	if len(values) == 0 {
-		return 0
-	}
-	length := 0
-	for i, v := range values {
-		if i > 0 {
-			length++
-		}
-		length += len(v)
-	}
-	return length
-}
-
-func (r Renderer) enumSetType(name string, col driver.Column) (string, error) {
-	values := enumValues(col)
-	if len(values) == 0 {
-		if r.unknownTypePolicy == "warn" || r.unknownTypePolicy == "text_fallback" {
-			return "VARCHAR(255)", nil
-		}
-		return "", fmt.Errorf("%s column %s is missing allowed values", strings.ToLower(name), col.Name)
-	}
-	quoted := make([]string, len(values))
-	for i, v := range values {
-		quoted[i] = "'" + strings.ReplaceAll(strings.ReplaceAll(v, `\`, `\\`), "'", "''") + "'"
-	}
-	return name + "(" + strings.Join(quoted, ",") + ")", nil
-}
-
-func enumValues(col driver.Column) []string {
-	if len(col.EnumValues) > 0 {
-		return col.EnumValues
-	}
-	values, ok := parseInlineEnumSetValues(col.DataType)
-	if ok {
-		return values
-	}
-	return nil
 }
 
 func isBooleanColumn(col driver.Column) bool {
@@ -1623,68 +1351,6 @@ func unquoteSQLString(quoted string) (string, bool) {
 		b.WriteByte(body[i])
 	}
 	return b.String(), true
-}
-
-func parseInlineEnumSetValues(columnType string) ([]string, bool) {
-	columnType = strings.TrimSpace(columnType)
-	open := strings.IndexByte(columnType, '(')
-	if open < 0 || !strings.HasSuffix(columnType, ")") {
-		return nil, false
-	}
-	kind := strings.ToLower(strings.TrimSpace(columnType[:open]))
-	if kind != "enum" && kind != "set" {
-		return nil, false
-	}
-	body := columnType[open+1 : len(columnType)-1]
-	values := []string{}
-	for i := 0; i < len(body); {
-		for i < len(body) && strings.ContainsRune(" \t\n\r", rune(body[i])) {
-			i++
-		}
-		if i >= len(body) {
-			break
-		}
-		if body[i] != '\'' {
-			return nil, false
-		}
-		i++
-		var b strings.Builder
-		for i < len(body) {
-			switch body[i] {
-			case '\\':
-				if i+1 >= len(body) {
-					return nil, false
-				}
-				i++
-				b.WriteByte(body[i])
-			case '\'':
-				if i+1 < len(body) && body[i+1] == '\'' {
-					b.WriteByte('\'')
-					i += 2
-					continue
-				}
-				i++
-				values = append(values, b.String())
-				goto literalDone
-			default:
-				b.WriteByte(body[i])
-			}
-			i++
-		}
-		return nil, false
-
-	literalDone:
-		for i < len(body) && strings.ContainsRune(" \t\n\r", rune(body[i])) {
-			i++
-		}
-		if i < len(body) {
-			if body[i] != ',' {
-				return nil, false
-			}
-			i++
-		}
-	}
-	return values, true
 }
 
 func rewriteSQLServerStringConcatToConcat(expr string) string {

--- a/internal/ddl/renderer_source_dialect_test.go
+++ b/internal/ddl/renderer_source_dialect_test.go
@@ -28,7 +28,7 @@ func TestColumnType_MySQLSameDialectPassthrough(t *testing.T) {
 		{"pg naive ts stays datetime", fromPG, driver.Column{DataType: "timestamp", DatetimePrecision: intp(3)}, "DATETIME(3)"},
 		{"unknown source ts stays datetime", base, driver.Column{DataType: "timestamp", DatetimePrecision: intp(3)}, "DATETIME(3)"},
 		{"mysql tinyint(1)", fromMySQL, driver.Column{DataType: "tinyint", DisplayWidth: 1}, "TINYINT(1)"},
-		{"mysql tinyint(1) unsigned", fromMySQL, driver.Column{DataType: "tinyint", DisplayWidth: 1, IsUnsigned: true}, "TINYINT(1) UNSIGNED"},
+		{"mysql tinyint(1) unsigned -> boolean drops sign", fromMySQL, driver.Column{DataType: "tinyint", DisplayWidth: 1, IsUnsigned: true}, "TINYINT(1)"},
 		{"mysql tinyint plain", fromMySQL, driver.Column{DataType: "tinyint"}, "TINYINT"},
 		{"unknown source ignores width", base, driver.Column{DataType: "tinyint", DisplayWidth: 1}, "TINYINT"},
 	}

--- a/internal/ddl/renderer_test.go
+++ b/internal/ddl/renderer_test.go
@@ -179,6 +179,34 @@ func TestRenderer_MySQLEnumSetTypesPreserveValues(t *testing.T) {
 	assertEqualSQL(t, setType, "SET('vip','wholesale')")
 }
 
+// A MySQL ENUM/SET source whose member list is empty cannot render a native
+// ENUM(...)/SET(...). The unknown-type policy decides the outcome: fail surfaces
+// an error, while warn/text_fallback degrade to a sized VARCHAR rather than
+// failing the whole render (parity with the pre-canonical renderer).
+func TestRenderer_MySQLEnumMissingValuesHonorsPolicy(t *testing.T) {
+	missing := driver.Column{Name: "Kind", DataType: "enum"}
+
+	failRenderer, err := NewRenderer("mysql", "crm", "fail")
+	if err != nil {
+		t.Fatalf("NewRenderer fail: %v", err)
+	}
+	if _, err := failRenderer.ColumnType(missing); err == nil {
+		t.Fatalf("expected error for enum with no values under fail policy, got nil")
+	}
+
+	for _, policy := range []string{"warn", "text_fallback"} {
+		r, err := NewRenderer("mysql", "crm", policy)
+		if err != nil {
+			t.Fatalf("NewRenderer %s: %v", policy, err)
+		}
+		got, err := r.ColumnType(missing)
+		if err != nil {
+			t.Fatalf("ColumnType under %s policy: %v", policy, err)
+		}
+		assertEqualSQL(t, got, "VARCHAR(255)")
+	}
+}
+
 func TestRenderer_EnumSetTypesMapTextForOtherTargets(t *testing.T) {
 	mssqlRenderer, err := NewRenderer("mssql", "dbo", "fail")
 	if err != nil {


### PR DESCRIPTION
## What

Replaces the MSSQL and MySQL target type switches in the deterministic renderer with a thin pass through `internal/canonical`: `ToCanonical` normalizes the source column to a dialect-neutral `CanonicalType`, `FromCanonical` renders it for the target. This is the `source → canonical → target` pipeline #62 ports from UVG — so the renderer and the drift/AI-review comparator can route through one mapping and never disagree about types.

Stage 2 of #62 (foundation package landed in #116). PostgreSQL target rendering still uses the `pgddl` path; wiring it and the drift comparator through canonical is the next stage.

## Why it's a net reduction

Removes ~330 lines of duplicated per-target type logic — the `sizedType`, `decimalType`, `mysqlVarcharType`, `mysqlTextType`, `mysqlUnsignedType`, `enum/setStringLength`, `fspType`, `enumSetType` cluster, all now dead.

## Approved clean-model deltas

Validated live on the CRM fixture — both targets create+apply cleanly:

- **MySQL `tinyint(1)` → canonical `Boolean`**: the meaningless `UNSIGNED` is dropped, and the column renders as `BIT` on an MSSQL target (was `TINYINT`). Confirmed live: `is_active` lands as `bit`. Drift does **not** false-positive — `CompareColumns` already classes both as boolean.
- **Dialect-correct float/real precision**: MySQL `FLOAT`=single, MSSQL `FLOAT`=double; MySQL `REAL` is a `DOUBLE` synonym. `ToCanonical` resolves these by source dialect instead of the old dialect-blind `float→FLOAT` / `real→REAL` passthrough (the bug signed off as "yes, fix it").
- **LOB tier capacity** carried through canonical `Length` so a MySQL round-trip keeps its tier while a foreign unbounded source still picks the largest target tier.

## Test

- `go test ./... -short` green; `go vet` clean.
- Oracle delta tests in `internal/canonical` pin the canonical round-trip against the live renderers; reported deltas are exactly the approved set above.
- Live CRM mysql→mssql and mssql→mysql `create --apply` both succeed (15 tables); in-sync drift reports no type drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)