### PR TITLE
Route the PostgreSQL renderer through the canonical type IR (#62)

### DIFF
--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -77,7 +77,7 @@ func (r Renderer) CreateSchemaDDL() (string, error) {
 
 func (r Renderer) CreateTableDDL(t *driver.Table) (string, map[string]string, error) {
 	if r.target == "postgres" {
-		return pgddl.RenderCreateTableDDLWithPolicy(t, r.schema, false, r.unknownTypePolicy)
+		return pgddl.RenderCreateTableDDLWithSource(t, r.schema, false, r.unknownTypePolicy, r.source)
 	}
 
 	tableName := r.normalize(t.Name)
@@ -114,11 +114,11 @@ func (r Renderer) CreateTableDDL(t *driver.Table) (string, map[string]string, er
 
 func (r Renderer) ColumnDefinition(col driver.Column, tableColumns ...[]driver.Column) (string, string, error) {
 	if r.target == "postgres" {
-		def, err := pgddl.RenderColumnDefinitionWithContextAndPolicy(col, firstColumns(tableColumns), r.unknownTypePolicy)
+		def, err := pgddl.RenderColumnDefinitionWithSource(col, firstColumns(tableColumns), r.unknownTypePolicy, r.source)
 		if err != nil {
 			return "", "", err
 		}
-		typ, err := pgddl.RenderColumnTypeWithPolicy(col, r.unknownTypePolicy)
+		typ, err := pgddl.RenderColumnTypeWithSource(col, r.unknownTypePolicy, r.source)
 		return def, typ, err
 	}
 
@@ -194,7 +194,7 @@ func (r Renderer) ColumnDefinition(col driver.Column, tableColumns ...[]driver.C
 
 func (r Renderer) ColumnType(col driver.Column) (string, error) {
 	if r.target == "postgres" {
-		return pgddl.RenderColumnTypeWithPolicy(col, r.unknownTypePolicy)
+		return pgddl.RenderColumnTypeWithSource(col, r.unknownTypePolicy, r.source)
 	}
 
 	dt := normalizeTypeName(col.DataType)
@@ -210,7 +210,7 @@ func (r Renderer) ColumnType(col driver.Column) (string, error) {
 
 func (r Renderer) ColumnDefault(col driver.Column) (string, error) {
 	if r.target == "postgres" {
-		return pgddl.RenderColumnDefaultDDLWithPolicy(col, r.unknownTypePolicy)
+		return pgddl.RenderColumnDefaultDDLWithSource(col, r.unknownTypePolicy, r.source)
 	}
 	expr := unwrapDefaultParens(col.DefaultExpression)
 	if expr == "" {
@@ -348,7 +348,7 @@ func (r Renderer) mysqlRequiresExpressionDefault(col driver.Column) bool {
 
 func (r Renderer) CreateIndexDDL(t *driver.Table, idx *driver.Index) (string, error) {
 	if r.target == "postgres" {
-		return pgddl.RenderCreateIndexDDL(t, idx, r.schema)
+		return pgddl.RenderCreateIndexDDLWithSource(t, idx, r.schema, r.source)
 	}
 	if len(idx.Columns) == 0 {
 		return "", fmt.Errorf("index %s has no columns", idx.Name)
@@ -419,7 +419,7 @@ func (r Renderer) CreateForeignKeyDDL(t *driver.Table, fk *driver.ForeignKey) (s
 
 func (r Renderer) CreateCheckConstraintDDL(t *driver.Table, chk *driver.CheckConstraint) (string, error) {
 	if r.target == "postgres" {
-		return pgddl.RenderCreateCheckConstraintDDL(t, chk, r.schema)
+		return pgddl.RenderCreateCheckConstraintDDLWithSource(t, chk, r.schema, r.source)
 	}
 	def := strings.TrimSpace(chk.Definition)
 	if def == "" {
@@ -577,7 +577,7 @@ func (r Renderer) mysqlColumnType(col driver.Column, dt string) (string, error) 
 // CanonicalType for the source dialect, then rendered for the target dialect.
 // Non-portable (Raw) types fall through to the unknown-type policy.
 func (r Renderer) canonicalColumnType(col driver.Column, dt, target string) (string, error) {
-	ct := canonical.ToCanonical(dt, metaOf(col), r.source)
+	ct := canonical.ToCanonical(dt, driver.MetaOf(col), r.source)
 	typ, err := canonical.FromCanonical(ct, target, canonical.RenderOpts{IsIdentity: col.IsIdentity})
 	switch {
 	case errors.Is(err, canonical.ErrUnknownType):
@@ -592,19 +592,6 @@ func (r Renderer) canonicalColumnType(col driver.Column, dt, target string) (str
 		return "", fmt.Errorf("%s column %s is missing allowed values", strings.ToLower(dt), col.Name)
 	}
 	return typ, err
-}
-
-// metaOf extracts the type-shaping metadata canonical.ToCanonical needs.
-func metaOf(col driver.Column) canonical.TypeMeta {
-	return canonical.TypeMeta{
-		MaxLength:         col.MaxLength,
-		Precision:         col.Precision,
-		Scale:             col.Scale,
-		DatetimePrecision: col.DatetimePrecision,
-		IsUnsigned:        col.IsUnsigned,
-		DisplayWidth:      col.DisplayWidth,
-		EnumValues:        col.EnumValues,
-	}
 }
 
 func (r Renderer) Expression(expr string, tableColumns []driver.Column) (string, error) {

--- a/internal/driver/postgres/deterministic.go
+++ b/internal/driver/postgres/deterministic.go
@@ -1,10 +1,12 @@
 package postgres
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 
+	"smt/internal/canonical"
 	"smt/internal/driver"
 	"smt/internal/logging"
 )
@@ -12,6 +14,10 @@ import (
 type deterministicDDL struct {
 	dialect           Dialect
 	unknownTypePolicy string
+	// sourceDialect is the canonical source driver name ("mysql", "mssql",
+	// "postgres"). Empty means unknown — the canonical type mapping then falls
+	// back to dialect-blind defaults (the historical source-agnostic behavior).
+	sourceDialect string
 }
 
 func newDeterministicDDL(policy ...string) deterministicDDL {
@@ -22,12 +28,28 @@ func newDeterministicDDL(policy ...string) deterministicDDL {
 	return deterministicDDL{dialect: Dialect{}, unknownTypePolicy: unknownTypePolicy}
 }
 
+// withSource returns a copy that knows the source dialect, so the canonical
+// type mapping can resolve dialect-dependent source types (e.g. MySQL FLOAT is
+// single-precision while MSSQL FLOAT is double; MySQL tinyint(1) is boolean).
+func (r deterministicDDL) withSource(sourceDialect string) deterministicDDL {
+	r.sourceDialect = strings.ToLower(strings.TrimSpace(sourceDialect))
+	return r
+}
+
 func RenderCreateTableDDL(t *driver.Table, targetSchema string, unlogged bool) (string, map[string]string, error) {
 	return RenderCreateTableDDLWithPolicy(t, targetSchema, unlogged, "")
 }
 
 func RenderCreateTableDDLWithPolicy(t *driver.Table, targetSchema string, unlogged bool, unknownTypePolicy string) (string, map[string]string, error) {
 	return newDeterministicDDL(unknownTypePolicy).createTable(t, targetSchema, unlogged)
+}
+
+// RenderCreateTableDDLWithSource is RenderCreateTableDDLWithPolicy that also
+// knows the source dialect, so the canonical type mapping can resolve
+// dialect-dependent source types. sourceDialect "" reproduces the source-blind
+// behavior.
+func RenderCreateTableDDLWithSource(t *driver.Table, targetSchema string, unlogged bool, unknownTypePolicy, sourceDialect string) (string, map[string]string, error) {
+	return newDeterministicDDL(unknownTypePolicy).withSource(sourceDialect).createTable(t, targetSchema, unlogged)
 }
 
 func RenderColumnDefinition(col driver.Column) (string, error) {
@@ -44,12 +66,25 @@ func RenderColumnDefinitionWithContextAndPolicy(col driver.Column, tableColumns 
 	return def, err
 }
 
+// RenderColumnDefinitionWithSource is the source-dialect-aware variant of
+// RenderColumnDefinitionWithContextAndPolicy.
+func RenderColumnDefinitionWithSource(col driver.Column, tableColumns []driver.Column, unknownTypePolicy, sourceDialect string) (string, error) {
+	def, _, err := newDeterministicDDL(unknownTypePolicy).withSource(sourceDialect).columnDefinition(col, tableColumns)
+	return def, err
+}
+
 func RenderColumnType(col driver.Column) (string, error) {
 	return RenderColumnTypeWithPolicy(col, "")
 }
 
 func RenderColumnTypeWithPolicy(col driver.Column, unknownTypePolicy string) (string, error) {
 	return newDeterministicDDL(unknownTypePolicy).columnType(col)
+}
+
+// RenderColumnTypeWithSource is the source-dialect-aware variant of
+// RenderColumnTypeWithPolicy.
+func RenderColumnTypeWithSource(col driver.Column, unknownTypePolicy, sourceDialect string) (string, error) {
+	return newDeterministicDDL(unknownTypePolicy).withSource(sourceDialect).columnType(col)
 }
 
 func RenderColumnDefaultDDL(col driver.Column) (string, error) {
@@ -60,8 +95,22 @@ func RenderColumnDefaultDDLWithPolicy(col driver.Column, unknownTypePolicy strin
 	return newDeterministicDDL(unknownTypePolicy).defaultExpression(col)
 }
 
+// RenderColumnDefaultDDLWithSource is the source-dialect-aware variant of
+// RenderColumnDefaultDDLWithPolicy, so boolean defaults are translated for the
+// source's boolean convention (MSSQL bit and MySQL tinyint(1) alike).
+func RenderColumnDefaultDDLWithSource(col driver.Column, unknownTypePolicy, sourceDialect string) (string, error) {
+	return newDeterministicDDL(unknownTypePolicy).withSource(sourceDialect).defaultExpression(col)
+}
+
 func RenderCreateIndexDDL(t *driver.Table, idx *driver.Index, targetSchema string) (string, error) {
 	return newDeterministicDDL().createIndex(t, idx, targetSchema)
+}
+
+// RenderCreateIndexDDLWithSource is the source-dialect-aware variant of
+// RenderCreateIndexDDL, so a filtered-index predicate over a boolean-convention
+// column (MSSQL bit / MySQL tinyint(1)) is rewritten to boolean literals.
+func RenderCreateIndexDDLWithSource(t *driver.Table, idx *driver.Index, targetSchema, sourceDialect string) (string, error) {
+	return newDeterministicDDL().withSource(sourceDialect).createIndex(t, idx, targetSchema)
 }
 
 func RenderCreateForeignKeyDDL(t *driver.Table, fk *driver.ForeignKey, targetSchema string) (string, error) {
@@ -70,6 +119,14 @@ func RenderCreateForeignKeyDDL(t *driver.Table, fk *driver.ForeignKey, targetSch
 
 func RenderCreateCheckConstraintDDL(t *driver.Table, chk *driver.CheckConstraint, targetSchema string) (string, error) {
 	return newDeterministicDDL().createCheckConstraint(t, chk, targetSchema)
+}
+
+// RenderCreateCheckConstraintDDLWithSource is the source-dialect-aware variant
+// of RenderCreateCheckConstraintDDL, so a CHECK predicate over a
+// boolean-convention column (MSSQL bit / MySQL tinyint(1)) is rewritten to
+// boolean literals.
+func RenderCreateCheckConstraintDDLWithSource(t *driver.Table, chk *driver.CheckConstraint, targetSchema, sourceDialect string) (string, error) {
+	return newDeterministicDDL().withSource(sourceDialect).createCheckConstraint(t, chk, targetSchema)
 }
 
 func (r deterministicDDL) createTable(t *driver.Table, targetSchema string, unlogged bool) (string, map[string]string, error) {
@@ -130,7 +187,7 @@ func (r deterministicDDL) columnDefinition(col driver.Column, tableColumns ...[]
 		if isTextualPGType(colType) {
 			expr = rewriteSQLServerStringConcat(expr)
 		}
-		expr = rewriteSQLServerBitComparisons(expr, contextColumns)
+		expr = r.rewriteBooleanComparisons(expr, contextColumns)
 		if strings.EqualFold(strings.TrimSpace(col.DataType), "bit") {
 			expr = rewriteSQLServerBooleanResultLiterals(expr)
 		}
@@ -203,7 +260,7 @@ func (r deterministicDDL) createIndex(t *driver.Table, idx *driver.Index, target
 		if err != nil {
 			return "", fmt.Errorf("mapping filter for index %s: %w", idx.Name, err)
 		}
-		expr = rewriteSQLServerBitComparisons(expr, t.Columns)
+		expr = r.rewriteBooleanComparisons(expr, t.Columns)
 		b.WriteString(" WHERE ")
 		b.WriteString(expr)
 	}
@@ -262,7 +319,7 @@ func (r deterministicDDL) createCheckConstraint(t *driver.Table, chk *driver.Che
 	if err != nil {
 		return "", fmt.Errorf("mapping check constraint %s: %w", chk.Name, err)
 	}
-	expr = rewriteSQLServerBitComparisons(expr, t.Columns)
+	expr = r.rewriteBooleanComparisons(expr, t.Columns)
 
 	return fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s CHECK %s",
 		r.dialect.QualifyTable(targetSchema, tableName),
@@ -299,97 +356,21 @@ func ensureOuterParens(expr string) string {
 
 func (r deterministicDDL) columnType(col driver.Column) (string, error) {
 	dt := strings.ToLower(strings.TrimSpace(col.DataType))
-	var typ string
-	switch dt {
-	case "int", "integer", "int4", "serial":
-		if col.IsUnsigned {
-			typ = "bigint"
-			break
+
+	ct := canonical.ToCanonical(dt, driver.MetaOf(col), r.sourceDialect)
+	typ, err := canonical.FromCanonical(ct, "postgres", canonical.RenderOpts{IsIdentity: col.IsIdentity})
+	if err != nil {
+		if errors.Is(err, canonical.ErrUnknownType) {
+			switch r.unknownTypePolicy {
+			case "warn":
+				logging.Warn("deterministic PostgreSQL type mapper: unsupported source type %q for column %s; using text because unknown_type_policy=warn", col.DataType, col.Name)
+				return "text", nil
+			case "text_fallback":
+				return "text", nil
+			}
+			return "", fmt.Errorf("unsupported source type %q", col.DataType)
 		}
-		typ = "integer"
-	case "bigint", "int8", "bigserial":
-		if col.IsUnsigned && !col.IsIdentity {
-			typ = "numeric(20,0)"
-			break
-		}
-		typ = "bigint"
-	case "smallint", "int2", "smallserial":
-		if col.IsUnsigned {
-			typ = "integer"
-			break
-		}
-		typ = "smallint"
-	case "tinyint":
-		typ = "smallint"
-	case "bit", "bool", "boolean":
-		typ = "boolean"
-	case "varchar", "nvarchar", "character varying":
-		if col.MaxLength <= 0 || col.MaxLength == -1 {
-			typ = "text"
-		} else {
-			typ = fmt.Sprintf("character varying(%d)", col.MaxLength)
-		}
-	case "char", "nchar", "character", "bpchar":
-		if col.MaxLength <= 0 || col.MaxLength == -1 {
-			typ = "text"
-		} else {
-			typ = fmt.Sprintf("character(%d)", col.MaxLength)
-		}
-	case "text", "ntext", "tinytext", "mediumtext", "longtext":
-		typ = "text"
-	case "datetime", "datetime2", "smalldatetime", "timestamp":
-		typ = pgFspType("timestamp", col, "without time zone")
-	case "rowversion":
-		// SQL Server's rowversion (reported by old snapshots as "timestamp")
-		// is an opaque 8-byte binary counter.
-		typ = "bytea"
-	case "datetimeoffset", "timestamptz", "timestamp with time zone":
-		typ = pgFspType("timestamp", col, "with time zone")
-	case "date":
-		typ = "date"
-	case "time":
-		typ = pgFspType("time", col, "")
-	case "decimal", "numeric", "number":
-		if col.Precision > 0 {
-			typ = fmt.Sprintf("numeric(%d,%d)", col.Precision, col.Scale)
-		} else {
-			typ = "numeric"
-		}
-	case "money":
-		typ = "numeric(19,4)"
-	case "smallmoney":
-		typ = "numeric(10,4)"
-	case "float", "double", "double precision":
-		typ = "double precision"
-	case "real":
-		typ = "real"
-	case "uniqueidentifier", "uuid":
-		typ = "uuid"
-	case "varbinary", "binary", "image", "bytea", "blob", "tinyblob", "mediumblob", "longblob":
-		typ = "bytea"
-	case "xml":
-		typ = "xml"
-	case "json", "jsonb":
-		typ = "jsonb"
-	case "enum", "set":
-		typ = "text"
-	case "_text", "text[]":
-		typ = "text[]"
-	case "_varchar", "varchar[]", "_bpchar", "bpchar[]":
-		typ = "text[]"
-	case "_int2", "int2[]", "_int4", "int4[]", "_int8", "int8[]":
-		typ = "integer[]"
-	case "_uuid", "uuid[]":
-		typ = "uuid[]"
-	default:
-		switch r.unknownTypePolicy {
-		case "warn":
-			logging.Warn("deterministic PostgreSQL type mapper: unsupported source type %q for column %s; using text because unknown_type_policy=warn", col.DataType, col.Name)
-			return "text", nil
-		case "text_fallback":
-			return "text", nil
-		}
-		return "", fmt.Errorf("unsupported source type %q", col.DataType)
+		return "", err
 	}
 
 	if col.IsIdentity {
@@ -432,7 +413,11 @@ func (r deterministicDDL) defaultExpression(col driver.Column) (string, error) {
 		return "CURRENT_TIMESTAMP", nil
 	}
 
-	if strings.EqualFold(col.DataType, "bit") {
+	// A column that maps to pg boolean needs boolean default literals: pg
+	// rejects DEFAULT 1 on a boolean. This covers MSSQL bit and MySQL tinyint(1)
+	// (the boolean convention) alike, via the same source-aware canonical
+	// classification the type mapping uses.
+	if canonical.ToCanonical(strings.ToLower(strings.TrimSpace(col.DataType)), driver.MetaOf(col), r.sourceDialect).Kind == canonical.Boolean {
 		switch expr {
 		case "0":
 			return "false", nil
@@ -769,24 +754,6 @@ func isTextualPGType(colType string) bool {
 		colType == "text"
 }
 
-// pgFspType renders a timestamp/time type with the source's
-// fractional-seconds precision when known (#88), clamped to PostgreSQL's
-// maximum of 6; unknown precision keeps the bare type.
-func pgFspType(base string, col driver.Column, suffix string) string {
-	out := base
-	if col.DatetimePrecision != nil && *col.DatetimePrecision >= 0 {
-		p := *col.DatetimePrecision
-		if p > 6 {
-			p = 6
-		}
-		out = fmt.Sprintf("%s(%d)", base, p)
-	}
-	if suffix != "" {
-		out += " " + suffix
-	}
-	return out
-}
-
 func isTextualSourceType(dataType string) bool {
 	switch strings.ToLower(strings.TrimSpace(dataType)) {
 	case "varchar", "nvarchar", "character varying", "char", "nchar", "character", "bpchar", "text", "ntext", "enum", "set":
@@ -859,10 +826,18 @@ func rewriteSQLServerBooleanResultLiterals(expr string) string {
 	})
 }
 
-func rewriteSQLServerBitComparisons(expr string, cols []driver.Column) string {
+// rewriteBooleanComparisons rewrites integer 0/1 comparisons and IN-lists made
+// against columns that map to pg boolean into boolean literals, so predicates
+// from a source whose boolean convention is integer (MSSQL bit, MySQL
+// tinyint(1)) stay valid on the boolean target column. It covers `col = 1`,
+// `col <> 0`, and the redundant-domain `col IN (0,1)` form. Column boolean-ness
+// is decided by the same source-aware canonical classification the type mapping
+// uses, so it tracks the bit↔tinyint(1)↔boolean mapping automatically.
+func (r deterministicDDL) rewriteBooleanComparisons(expr string, cols []driver.Column) string {
 	out := expr
 	for _, col := range cols {
-		if !strings.EqualFold(strings.TrimSpace(col.DataType), "bit") {
+		dt := strings.ToLower(strings.TrimSpace(col.DataType))
+		if canonical.ToCanonical(dt, driver.MetaOf(col), r.sourceDialect).Kind != canonical.Boolean {
 			continue
 		}
 		quoted := `"` + sanitizePGIdentifier(col.Name) + `"`
@@ -882,6 +857,26 @@ func rewriteSQLServerBitComparisons(expr string, cols []driver.Column) string {
 				return match
 			}
 			return bitLiteral(firstNonEmpty(parts[1], parts[2])) + " " + parts[3] + " " + parts[4]
+		})
+		inRE := regexp.MustCompile(`(?i)(` + ident + `)\s+(NOT\s+)?IN\s*\(([^)]*)\)`)
+		out = inRE.ReplaceAllStringFunc(out, func(match string) string {
+			parts := inRE.FindStringSubmatch(match)
+			if len(parts) != 4 {
+				return match
+			}
+			items := strings.Split(parts[3], ",")
+			conv := make([]string, 0, len(items))
+			for _, item := range items {
+				switch strings.TrimSpace(item) {
+				case "0":
+					conv = append(conv, "false")
+				case "1":
+					conv = append(conv, "true")
+				default:
+					return match // not a pure 0/1 domain list — leave untouched
+				}
+			}
+			return parts[1] + " " + parts[2] + "IN (" + strings.Join(conv, ", ") + ")"
 		})
 	}
 	return out

--- a/internal/driver/postgres/deterministic_test.go
+++ b/internal/driver/postgres/deterministic_test.go
@@ -466,6 +466,46 @@ func TestDeterministicMySQLRegexpLikeCheckToPostgres(t *testing.T) {
 	}
 }
 
+// MySQL tinyint(1) is the boolean convention. With the source dialect known,
+// the pg renderer maps it to boolean, translates its 0/1 default to a boolean
+// literal, and rewrites a redundant `IN (0,1)` domain check to boolean literals
+// so the predicate stays valid on the boolean column. Without a source dialect
+// the historical source-blind behavior (smallint) is preserved.
+func TestDeterministicMySQLBooleanToPostgres(t *testing.T) {
+	boolCol := driver.Column{Name: "is_active", DataType: "tinyint", DisplayWidth: 1, DefaultExpression: "1"}
+
+	typ, err := RenderColumnTypeWithSource(boolCol, "fail", "mysql")
+	if err != nil {
+		t.Fatalf("RenderColumnTypeWithSource: %v", err)
+	}
+	if typ != "boolean" {
+		t.Fatalf("mysql tinyint(1) -> pg: got %q, want boolean", typ)
+	}
+	if blind, _ := RenderColumnTypeWithPolicy(boolCol, "fail"); blind != "smallint" {
+		t.Fatalf("source-blind mysql tinyint(1) -> pg: got %q, want smallint (historical)", blind)
+	}
+
+	def, err := RenderColumnDefaultDDLWithSource(boolCol, "fail", "mysql")
+	if err != nil {
+		t.Fatalf("RenderColumnDefaultDDLWithSource: %v", err)
+	}
+	if def != "true" {
+		t.Fatalf("mysql tinyint(1) default 1 -> pg: got %q, want true", def)
+	}
+
+	ddl, err := RenderCreateCheckConstraintDDLWithSource(&driver.Table{
+		Name:    "companies",
+		Columns: []driver.Column{boolCol},
+	}, &driver.CheckConstraint{
+		Name:       "chk_companies_active",
+		Definition: "`is_active` in (0,1)",
+	}, "public", "mysql")
+	if err != nil {
+		t.Fatalf("RenderCreateCheckConstraintDDLWithSource: %v", err)
+	}
+	assertContains(t, ddl, "IN (false, true)")
+}
+
 func TestDeterministicMSSQLCheckBitComparison(t *testing.T) {
 	renderer := newDeterministicDDL()
 	ddl, err := renderer.createCheckConstraint(&driver.Table{

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 	"unsafe"
+
+	"smt/internal/canonical"
 )
 
 // Table represents a database table with its metadata.
@@ -126,6 +128,22 @@ type Column struct {
 	EnumValues         []string `json:"enum_values,omitempty"`          // allowed values for MySQL ENUM/SET columns
 	SRID               int      `json:"srid,omitempty"`                 // Spatial Reference ID for geography/geometry columns (0 = default/unset)
 	SampleValues       []string `json:"sample_values,omitempty"`        // Sample data values for AI type mapping context
+}
+
+// MetaOf extracts the type-shaping metadata canonical.ToCanonical needs from a
+// column. It is the single Column -> canonical.TypeMeta mapping shared by the
+// deterministic renderer (both the internal/ddl layer and the postgres driver)
+// so the source-dialect-aware type fields are read identically everywhere.
+func MetaOf(col Column) canonical.TypeMeta {
+	return canonical.TypeMeta{
+		MaxLength:         col.MaxLength,
+		Precision:         col.Precision,
+		Scale:             col.Scale,
+		DatetimePrecision: col.DatetimePrecision,
+		IsUnsigned:        col.IsUnsigned,
+		DisplayWidth:      col.DisplayWidth,
+		EnumValues:        col.EnumValues,
+	}
 }
 
 // IsIntegerType returns true if the column is an integer type.


### PR DESCRIPTION
## What

Stage 3 of #62. The PostgreSQL deterministic renderer's `columnType` switch now maps `source → CanonicalType → pg type` via `internal/canonical` — the same pipeline the MSSQL/MySQL targets already use (#117). All three renderer targets now route through one type model.

The source dialect is threaded into the pg renderer (`deterministicDDL.sourceDialect` + `*WithSource` entry points) so dialect-dependent source types resolve correctly; the existing `*WithPolicy` entry points stay source-blind for their few direct callers. `driver.MetaOf` is added as the single `Column → canonical.TypeMeta` mapping shared by the `internal/ddl` layer and the pg driver (replacing the duplicate `metaOf` introduced in #117). `package driver` gains a `canonical` import — no cycle, since `canonical` is a leaf.

## Realized deltas on a pg target

All validated **live** on the CRM fixture (mysql→pg and mssql→pg `create --apply` clean; `drift` reports no false positives):

- **MySQL `FLOAT` → `real`, MySQL `REAL` → `double precision`** — dialect-correct float precision (the old pg switch was source-blind and always picked `double precision`/`real`). The "yes, fix it" float/real bug.
- **MySQL `mediumint` and `time with time zone` / `timetz` sources no longer error** — the old pg switch had no `case` for them and fell to the unknown-type policy (error under `fail`). They now map to `integer` and `time[(p)] with time zone`. Latent-bug fix surfaced by the oracle test.
- **MySQL `tinyint(1)` → `boolean`** (consistent with `tinyint(1)` → `BIT` on MSSQL in #117). This cascades — all handled here:
  - default `1`/`0` → `true`/`false` (the boolean-literal default translation now keys off the source-aware canonical `Boolean` classification, covering MySQL `tinyint(1)` as well as MSSQL `bit`);
  - a redundant `col IN (0,1)` domain CHECK is rewritten to `IN (false,true)` (`rewriteSQLServerBitComparisons` generalized to `rewriteBooleanComparisons`: canonical-Boolean-aware and IN-list-aware), so the predicate stays valid on the boolean column.

PostgreSQL FK rendering needs no source (no value predicates) and is unchanged.

## Live validation

```
mysql→pg  : Schema build complete in 190ms (14 tables) — drift: no drift
mssql→pg  : Schema build complete in 1.7s (18 tables) — drift: no drift
is_active : boolean DEFAULT true; CHECK (is_active = ANY(ARRAY[false,true]))
```

## Test

- `go test ./... -short` green; `go vet` clean.
- New `TestDeterministicMySQLBooleanToPostgres` pins type/default/CHECK for the tinyint(1)→boolean delta (and that source-blind stays `smallint`).
- Oracle delta test (`internal/canonical`) now reports the pg latent-bug errors resolved (0 error-disagreements) and only the 3 intended source-aware deltas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)