### PR TITLE
Bump RendererVersion to 2 for the canonical type IR migration (#62)

### DIFF
--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -19,7 +19,12 @@ import (
 // run manifests distinguish artifacts produced by different renderer logic.
 // It is the single "renderer + type-mapper version" token #64 fingerprints
 // on — type mapping and DDL rendering are one deterministic unit here.
-const RendererVersion = "1"
+//
+// "2": type mapping moved onto the canonical type IR (#62). The mapper is now
+// source-dialect-aware, so the rendered DDL changed for some inputs vs "1"
+// (e.g. MySQL tinyint(1) -> BIT/boolean, dialect-correct float/real precision,
+// MySQL mediumint and time-with-tz no longer rejected on a pg target).
+const RendererVersion = "2"
 
 type Renderer struct {
 	target            string


### PR DESCRIPTION
## What

Bumps `ddl.RendererVersion` `"1"` → `"2"`. The canonical-IR migration (#116 / #117 / #118) made the deterministic type mapper source-dialect-aware, changing the rendered DDL for some inputs vs the old switch-based renderer:

- MySQL `tinyint(1)` → `BIT`/`boolean`
- dialect-correct float/real precision (MySQL FLOAT→single, REAL→double)
- MySQL `mediumint` and `time with time zone` no longer rejected on a pg target
- boolean default/CHECK rewrites on pg

## Why

`RendererVersion`'s documented contract is to bump whenever output can change for the same input, so persisted run manifests (#64) — and any downstream artifact cache keyed on `renderer_version` — distinguish canonical artifacts from pre-canonical ones. Without the bump, a cache could serve stale pre-canonical `schema.sql` for an unchanged source.

This satisfies #62's final acceptance criterion: *"Mapper version participates in cache/artifact fingerprints."*

## Test

`go test ./internal/ddl/ ./internal/orchestrator/ -short` green (the manifest acceptance test compares the field symbolically against `ddl.RendererVersion`, so it tracks the bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)