### PR TITLE
Migrate golangci-lint config to v2; track it; fix surfaced SA findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.yaml
 *.yml
 !config.yaml.example
+!.golangci.yml
 
 # State database
 *.db

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,54 @@
+# golangci-lint v2 config (migrated from v1 for golangci-lint >= 2.x).
+# Enforcement scope is kept equivalent to the previous v1 setup: govet +
+# staticcheck (SA/S analyzers) + ineffassign, with errcheck and unused off.
+version: "2"
+
+run:
+  go: "1.25"
+
+linters:
+  # v2 enables a default set (errcheck, govet, ineffassign, staticcheck,
+  # unused). Disable the two the project intentionally did not run under v1.
+  disable:
+    - errcheck # noisy for non-critical error returns (logging, notifications)
+    - unused # false positives with conditional compilation
+  settings:
+    staticcheck:
+      # In v2, staticcheck absorbed gosimple (S*), stylecheck (ST*) and the
+      # quickfix refactors (QF*). v1 only ran staticcheck's SA* and gosimple's
+      # S* analyzers — stylecheck and QF were never enabled — so scope ST*/QF*
+      # out to preserve the prior enforcement level rather than impose new
+      # stylistic rewrites across pre-existing code.
+      checks:
+        - all
+        - -ST1* # stylecheck — not enabled under v1
+        - -QF* # quickfix refactors — not enabled under v1
+        - -S1009 # nil check before len() — sometimes clearer explicit
+        - -SA9003 # empty branch — sometimes intentional for clarity
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # Unchecked errors on best-effort/cosmetic calls (parity with v1 rules).
+      - linters: [errcheck]
+        text: notifier\.
+      - linters: [errcheck]
+        text: bar\.
+      - linters: [errcheck]
+        text: CompleteRun|MarkTaskComplete
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1394,7 +1394,7 @@ func (c *Config) DebugDump() string {
 				b.WriteString(fmt.Sprintf("  Model: %s (default)\n", provider.GetEffectiveModel(providerName)))
 			}
 			// AI features status - check each feature separately
-			if typeMapper, err := driver.GetAITypeMapper(); err == nil && typeMapper != nil {
+			if _, err := driver.GetAITypeMapper(); err == nil {
 				b.WriteString("  Type Mapping: enabled\n")
 			} else {
 				b.WriteString("  Type Mapping: disabled\n")

--- a/internal/driver/ai_typemapper.go
+++ b/internal/driver/ai_typemapper.go
@@ -32,12 +32,6 @@ const (
 	defaultMaxDelay = 10 * time.Second
 )
 
-func init() {
-	// Seed the random number generator for jitter in backoff calculations.
-	// Go 1.20+ seeds automatically, but this ensures compatibility with older versions.
-	rand.Seed(time.Now().UnixNano())
-}
-
 // AIProvider represents supported AI providers for type mapping.
 type AIProvider string
 

--- a/internal/orchestrator/manifest_test.go
+++ b/internal/orchestrator/manifest_test.go
@@ -77,7 +77,9 @@ func TestFingerprintBytes(t *testing.T) {
 	if fingerprintBytes([]byte("x")) == fingerprintBytes([]byte("y")) {
 		t.Error("distinct bytes hashed to the same fingerprint")
 	}
-	if fingerprintBytes([]byte("same")) != fingerprintBytes([]byte("same")) {
+	first := fingerprintBytes([]byte("same"))
+	second := fingerprintBytes([]byte("same"))
+	if first != second {
 		t.Error("identical bytes hashed to different fingerprints")
 	}
 }


### PR DESCRIPTION
## What

`make lint` was broken two ways:
1. **golangci-lint is now v2.x** but `.golangci.yml` used the v1 schema → `can't load config: unsupported version of the configuration`.
2. **The config was never tracked** — `.golangci.yml` is caught by `*.yml` in `.gitignore`, so it only existed as a local file. `make lint` would do nothing useful on a fresh clone.

This migrates the config to the v2 schema, whitelists it in `.gitignore` (like `config.yaml.example`), and fixes the genuine findings that surfaced once lint could actually run.

## Enforcement scope preserved

v2's `staticcheck` absorbed `gosimple` (S*), `stylecheck` (ST*) and the quickfix refactors (QF*). v1 only ran `staticcheck`'s SA* and `gosimple`'s S* analyzers — stylecheck and QF were never enabled — so ST*/QF* are scoped out to keep the prior enforcement level rather than impose new stylistic rewrites across pre-existing code. Net checks: **govet + staticcheck(SA/S) + ineffassign**, errcheck/unused off (unchanged from v1).

## Fixes (real SA findings accumulated while lint was dark)

- **SA1019** — dropped the deprecated `rand.Seed(...)` `init()` (project is Go 1.25, which auto-seeds the global rand).
- **SA4023** — `driver.GetAITypeMapper()`'s `!= nil` check was always true; the call only needs its error, so the value is bound to `_`.
- **SA4000** — a determinism test compared two identical inline expressions; rewritten to compare two computed fingerprints.

## Verification

- `make lint` → **0 issues** (exit 0).
- `go build ./...`, `go test ./... -short`, and the **full `make test`** suite all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)