### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version is the current version of smt.
 // Can be overridden at build time with -ldflags "-X ...version.Version=..."
-var Version = "0.9.0"
+var Version = "0.10.0"
 
 // Name is the application name.
 const Name = "smt"


### PR DESCRIPTION
Version bump for the v0.10.0 release. Updates the hardcoded fallback in `internal/version` (Makefile builds override via `-ldflags` from `git describe`; this keeps `go install` builds reporting the right version). The annotated tag will be cut from the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)