### PR TITLE
Drop the darwin-amd64 (Intel Mac) build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BINARY_NAME)-linux-amd64 ./cmd/smt
 
 build-darwin:
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BINARY_NAME)-darwin-amd64 ./cmd/smt
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(BINARY_NAME)-darwin-arm64 ./cmd/smt
 
 build-windows:


### PR DESCRIPTION
`make build-darwin` (and `build-all`) no longer build the Intel Mac binary — only `smt-darwin-arm64` (Apple Silicon). The corresponding asset is being removed from the v0.10.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)