### PR TITLE
Render MSSQL CONVERT(date, <now>) date defaults for Postgres (#127)

### DIFF
--- a/internal/driver/postgres/deterministic.go
+++ b/internal/driver/postgres/deterministic.go
@@ -412,6 +412,9 @@ func (r deterministicDDL) defaultExpression(col driver.Column) (string, error) {
 	if strings.HasPrefix(lower, "current_timestamp(") || strings.HasPrefix(lower, "now(") {
 		return "CURRENT_TIMESTAMP", nil
 	}
+	if pg, ok := convertDateDefault(expr); ok {
+		return pg, nil
+	}
 
 	// A column that maps to pg boolean needs boolean default literals: pg
 	// rejects DEFAULT 1 on a boolean. This covers MSSQL bit and MySQL tinyint(1)
@@ -466,6 +469,31 @@ func (r deterministicDDL) sqlServerExpression(expr string) (string, error) {
 }
 
 var expressionFunctionRE = regexp.MustCompile(`(?i)\b([a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)*)\s*\(`)
+
+// convertDateDefaultRE matches the MSSQL idiom CONVERT(date, <now>) — a
+// "today's date" default — tolerating extra whitespace and an optionally
+// bracketed/quoted date type name (date / [date] / "date"). The argument is
+// captured loosely and classified by convertDateDefault, so only the now-family
+// argument is rewritten; any other CONVERT(...) form is left to fail.
+var convertDateDefaultRE = regexp.MustCompile(`(?i)^CONVERT\(\s*[\["]?\s*date\s*[\]"]?\s*,\s*(.+?)\s*\)$`)
+
+// convertDateDefault rewrites CONVERT(date, <now-family>) into the Postgres
+// equivalent for a date column default. It returns ok=false for any other
+// CONVERT argument so unsupported forms still fail rather than being silently
+// reinterpreted.
+func convertDateDefault(expr string) (string, bool) {
+	m := convertDateDefaultRE.FindStringSubmatch(expr)
+	if m == nil {
+		return "", false
+	}
+	switch strings.ReplaceAll(strings.ToLower(m[1]), " ", "") {
+	case "getdate()", "current_timestamp", "sysdatetime()", "sysdatetimeoffset()":
+		return "CURRENT_DATE", true
+	case "getutcdate()", "sysutcdatetime()":
+		return "(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::date", true
+	}
+	return "", false
+}
 
 func rejectUnsupportedSQLServerExpression(expr string) error {
 	scan := stripSingleQuotedStrings(expr)

--- a/internal/driver/postgres/deterministic_test.go
+++ b/internal/driver/postgres/deterministic_test.go
@@ -191,6 +191,53 @@ func TestDeterministicMSSQLDateTimeOffsetUTCDefault(t *testing.T) {
 	}
 }
 
+// The MSSQL "today's date" idiom CONVERT(date, <now>) is a valid, common date
+// column default that the Postgres renderer must map rather than reject (#127).
+func TestDeterministicMSSQLConvertDateDefault(t *testing.T) {
+	renderer := newDeterministicDDL()
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"(CONVERT(date, GETDATE()))", "CURRENT_DATE"},
+		{"(convert(date,getdate()))", "CURRENT_DATE"},
+		{"((CONVERT(date, GETDATE())))", "CURRENT_DATE"}, // extra metadata parens
+		{"(CONVERT([date], GETDATE()))", "CURRENT_DATE"}, // bracketed type name
+		{"(CONVERT(date, CURRENT_TIMESTAMP))", "CURRENT_DATE"},
+		{"(CONVERT(date, SYSDATETIME()))", "CURRENT_DATE"},
+		{"(CONVERT(date, GETUTCDATE()))", "(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::date"},
+		{"(CONVERT(date, SYSUTCDATETIME()))", "(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::date"},
+	}
+	for _, tc := range cases {
+		def, err := renderer.defaultExpression(driver.Column{
+			Name: "HireDate", DataType: "date", DefaultExpression: tc.raw,
+		})
+		if err != nil {
+			t.Fatalf("defaultExpression(%q): %v", tc.raw, err)
+		}
+		if def != tc.want {
+			t.Errorf("defaultExpression(%q) = %q, want %q", tc.raw, def, tc.want)
+		}
+	}
+}
+
+// A CONVERT to something other than a now-family date must still fail rather
+// than be silently reinterpreted (preserves the unknown-expression contract).
+func TestDeterministicMSSQLUnsupportedConvertStillFails(t *testing.T) {
+	renderer := newDeterministicDDL()
+	for _, raw := range []string{
+		"(CONVERT(int, [SomeColumn]))",
+		"(CONVERT(date, [SomeColumn]))", // date, but not a now-family argument
+		"(CONVERT(varchar(10), GETDATE()))",
+	} {
+		if _, err := renderer.defaultExpression(driver.Column{
+			Name: "X", DataType: "date", DefaultExpression: raw,
+		}); err == nil {
+			t.Errorf("defaultExpression(%q) succeeded, want unsupported-expression error", raw)
+		}
+	}
+}
+
 func TestDeterministicMSSQLComputedColumn(t *testing.T) {
 	renderer := newDeterministicDDL()
 	def, colType, err := renderer.columnDefinition(driver.Column{

--- a/internal/driver/verify_compare.go
+++ b/internal/driver/verify_compare.go
@@ -26,6 +26,13 @@ import (
 // default-class comparison.
 var fspNowArgPattern = regexp.MustCompile(`^([a-z_]+)\([0-9]+\)$`)
 
+// convertTemporalRE matches the MSSQL CONVERT(date|time, <expr>) coercion,
+// capturing the target temporal type and the inner expression. The date/time
+// type name may be bracketed or quoted (date / [date] / "date"). This lets a
+// CONVERT(date, GETDATE()) default classify by its result (a date) rather than
+// the inner now-function, mirroring a PG <expr>::date cast.
+var convertTemporalRE = regexp.MustCompile(`(?i)^convert\(\s*[\["]?\s*(date|time)\s*[\]"]?\s*,\s*(.+?)\s*\)$`)
+
 // ColumnDelta records a single per-(column, criterion) mismatch from
 // CompareColumns. Format() renders it in the same wire shape #53's prompt
 // produced, so PreviousAttempt feedback to the generator is unchanged from
@@ -534,12 +541,26 @@ func defaultExpressionClass(expr string) string {
 	norm = strings.TrimSpace(norm)
 	// Strip PG cast suffixes: 'foo'::text → 'foo', gen_random_uuid()::char(36)
 	// → gen_random_uuid(), '{}'::jsonb → '{}'. PG's introspection returns
-	// defaults with explicit casts; the cast doesn't change semantic class.
+	// defaults with explicit casts; most casts don't change semantic class.
 	// The cast type can itself contain parens (`char(36)`) so consume the
-	// whole tail after the last `::` rather than stopping at the first
-	// non-identifier char.
+	// whole tail after the last `::`. A ::date / ::time cast IS class-relevant
+	// (it coerces a datetime to a date/time, e.g. (CURRENT_TIMESTAMP)::date is a
+	// today's-date default) — remember it and apply it after classifying the
+	// inner expression.
+	coerceDate, coerceTime := false, false
 	if i := strings.LastIndex(norm, "::"); i >= 0 {
+		switch strings.TrimSpace(norm[i+2:]) {
+		case "date":
+			coerceDate = true
+		case "time", "time without time zone", "timetz", "time with time zone":
+			coerceTime = true
+		}
 		norm = strings.TrimSpace(norm[:i])
+	}
+	// Removing a cast can expose parens the first pass left behind, e.g.
+	// (CURRENT_TIMESTAMP)::date → (current_timestamp). Strip them again.
+	for len(norm) >= 2 && norm[0] == '(' && norm[len(norm)-1] == ')' {
+		norm = strings.TrimSpace(norm[1 : len(norm)-1])
 	}
 	// Strip MSSQL N-prefix on string literals: N'foo' ≡ 'foo'
 	if strings.HasPrefix(norm, "n'") && strings.HasSuffix(norm, "'") {
@@ -553,7 +574,12 @@ func defaultExpressionClass(expr string) string {
 	// value, so it must stay part of the class and not collapse to a bare
 	// current_timestamp.
 	if i := strings.Index(norm, " at time zone "); i >= 0 {
-		if zone := strings.TrimSpace(norm[i+len(" at time zone "):]); zone == "'utc'" {
+		zone := strings.TrimSpace(norm[i+len(" at time zone "):])
+		// PG may render the zone literal with a cast, e.g. 'utc'::text.
+		if j := strings.LastIndex(zone, "::"); j >= 0 {
+			zone = strings.TrimSpace(zone[:j])
+		}
+		if zone == "'utc'" {
 			norm = strings.TrimSpace(norm[:i])
 		}
 	}
@@ -565,6 +591,23 @@ func defaultExpressionClass(expr string) string {
 	// reduced, so literals and multi-arg calls are untouched.
 	if m := fspNowArgPattern.FindStringSubmatch(norm); m != nil {
 		norm = m[1]
+	}
+
+	// MSSQL CONVERT(date|time, <expr>) coerces <expr> to a date/time, exactly
+	// like a PG ::date / ::time cast. Reduce to the inner expression and flag
+	// the coercion so the class reflects the result type, not the inner
+	// now-function — so CONVERT(date, GETDATE()) ≡ CURRENT_DATE.
+	if m := convertTemporalRE.FindStringSubmatch(norm); m != nil {
+		switch strings.ToLower(m[1]) {
+		case "date":
+			coerceDate = true
+		case "time":
+			coerceTime = true
+		}
+		norm = strings.TrimSpace(m[2])
+		for len(norm) >= 2 && norm[0] == '(' && norm[len(norm)-1] == ')' {
+			norm = strings.TrimSpace(norm[1 : len(norm)-1])
+		}
 	}
 
 	// "Now-style" function families. Split into three classes by what the
@@ -587,6 +630,12 @@ func defaultExpressionClass(expr string) string {
 		"sysdatetimeoffset()", "sysdatetimeoffset",
 		"systimestamp",
 		"localtimestamp", "localtimestamp()":
+		if coerceDate {
+			return "current_date"
+		}
+		if coerceTime {
+			return "current_t"
+		}
 		return "current_dt"
 	case "current_date", "current_date()":
 		return "current_date"

--- a/internal/driver/verify_compare_test.go
+++ b/internal/driver/verify_compare_test.go
@@ -174,6 +174,10 @@ func TestDefaultExpressionClass_DistinctNowFamilies(t *testing.T) {
 		{"CURRENT_TIME", "CURRENT_TIMESTAMP"},
 		{"CURRENT_TIME", "LOCALTIMESTAMP"},
 		{"CURRENT_TIME", "CURRENT_DATE"},
+		// A date-coerced now must stay distinct from the un-coerced datetime —
+		// CONVERT(date, GETDATE()) is a date default, not a current_timestamp one.
+		{"(CONVERT([date],getdate()))", "GETDATE()"},
+		{"(CURRENT_TIMESTAMP)::date", "CURRENT_TIMESTAMP"},
 	}
 	for _, p := range pairs {
 		t.Run(p.a+"_vs_"+p.b, func(t *testing.T) {
@@ -211,6 +215,13 @@ func TestDefaultExpressionClass_CrossDialectEquivalence(t *testing.T) {
 		// PG cast wrappings ≡ unwrapped equivalent on other dialects.
 		{"pg '{}'::jsonb ≡ mssql '{}' ", "'{}'::jsonb", "'{}'"},
 		{"pg gen_random_uuid()::char(36) ≡ mysql UUID()", "gen_random_uuid()::char(36)", "UUID()"},
+
+		// MSSQL "today's date" idiom CONVERT(date, <now>) ≡ PG CURRENT_DATE and
+		// the equivalent <now>::date cast (#127). The coercion classifies by the
+		// result (a date), not the inner now-function.
+		{"CONVERT(date,GETDATE()) ≡ CURRENT_DATE", "(CONVERT([date],getdate()))", "CURRENT_DATE"},
+		{"CONVERT(date,GETDATE()) ≡ CURRENT_TIMESTAMP::date", "(CONVERT([date],getdate()))", "(CURRENT_TIMESTAMP)::date"},
+		{"CONVERT(date,GETUTCDATE()) ≡ utc ::date", "(CONVERT([date],getutcdate()))", "(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::date"},
 	}
 	for _, p := range pairs {
 		t.Run(p.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #127.

## Problem

The MSSQL→Postgres renderer aborted on a valid, common SQL Server date default:

```sql
HireDate DATE NOT NULL DEFAULT (CONVERT(date, GETDATE()))
```

```
Error: rendering table Employees: mapping column Employees.HireDate:
unsupported SQL expression function "CONVERT" in "CONVERT(\"date\",CURRENT_TIMESTAMP)"
```

`defaultExpression` had no case for the `CONVERT(date, …)` wrapper, so it fell through to `sqlServerExpression`, which rewrote the inner `GETDATE()` but then rejected the unsupported `CONVERT` function — failing the whole render before any DDL (or optional `ai_review`) existed.

This is the issue's **Option A** (deterministic rewrite). Option B (an AI expression fallback) is intentionally **not** taken: it would put AI in the executable-DDL path, which contradicts SMT's core rule that executable DDL is deterministic and AI is advisory-only.

## Changes

**Renderer** (`internal/driver/postgres/deterministic.go`):
- `CONVERT(date, <now-family>)` → `CURRENT_DATE`; UTC now-family (`GETUTCDATE`/`SYSUTCDATETIME`) → `(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::date`.
- Case-insensitive; tolerates extra metadata parens (`((…))`) and a bracketed/quoted `date` type name. **Any other `CONVERT(...)` still fails** rather than being silently reinterpreted.

**Comparator** (`internal/driver/verify_compare.go`) — so the rendered default reports **no drift** (issue acceptance criterion #3):
- `defaultExpressionClass` now classifies a now-family value coerced to date/time as `current_date` / `current_t`, covering both MSSQL `CONVERT(date, <now>)` and PG `<now>::date`. Also fixes a latent bug where `(…)::date` was misclassified as `current_dt` (the `::date` cast was being stripped as class-irrelevant).
- Re-strips parens after cast removal and tolerates a cast on the `AT TIME ZONE` zone literal (`'utc'::text`), both of which PG introspection emits.

## Validation

Live mssql→pg, the issue's exact minimal schema plus a `CONVERT(date, GETUTCDATE())` variant:
- `create --out` renders `"hiredate" date NOT NULL DEFAULT CURRENT_DATE` ✅
- `create --apply` succeeds ✅
- `drift` reports **no drift** ✅

Unit tests cover the render mappings, the parens/bracket/case tolerance, that unsupported `CONVERT(...)` still errors, and the new default-class equivalences (plus a distinctness guard that a date default ≠ a datetime default). Full `go test ./... -short` and `golangci-lint` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)