### PR TITLE
Bump version to 0.10.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version is the current version of smt.
 // Can be overridden at build time with -ldflags "-X ...version.Version=..."
-var Version = "0.10.0"
+var Version = "0.10.1"
 
 // Name is the application name.
 const Name = "smt"


### PR DESCRIPTION
Patch release for the v0.10.1 tag. Updates the hardcoded version fallback (Makefile builds override via `-ldflags` from `git describe`). The annotated tag is cut from the merge commit.

Contents since v0.10.0: the MSSQL→Postgres `CONVERT(date, <now>)` default fix (#128, closes #127) and dropping the Intel-Mac build target (#126).

🤖 Generated with [Claude Code](https://claude.com/claude-code)