### PR TITLE
Add opt-in AI failure diagnosis: advise on extract/render failures (#131)

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -32,6 +32,9 @@ ai_review:
   enabled: false                       # optional review of deterministic DDL
   mode: warn                           # warn | fail
   # model: strong-reviewer             # provider entry in ~/.secrets/smt-config.yaml
+  diagnose_failures: false             # advise the user on extract/render failures
+                                       # (cause + suggestions only — never edits or
+                                       #  retries DDL); uses the model above
   # Note: with review enabled the un-configured render fan-out drops from 8
   # to 2 so cold-cache runs stay under provider rate limits (#54). Set
   # migration.ai_concurrency explicitly to override.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,6 +203,14 @@ type AIReviewConfig struct {
 	// before applying DDL with reviewer issues.
 	Mode string `yaml:"mode"`
 
+	// DiagnoseFailures, when true, lets the AI advise the user on how to resolve
+	// a schema extraction or DDL-render failure — a bug that aborts before any
+	// DDL exists, which the verifier never sees. It is strictly advisory: it
+	// surfaces guidance (cause + suggestions), never generates, patches, or
+	// retries DDL, and never changes the run's outcome. Uses the Model provider
+	// above (or the default provider when Model is empty).
+	DiagnoseFailures bool `yaml:"diagnose_failures"`
+
 	// Scope is reserved for future chunking choices such as "table" or "plan".
 	Scope string `yaml:"scope"`
 
@@ -1399,10 +1407,10 @@ func (c *Config) DebugDump() string {
 			} else {
 				b.WriteString("  Type Mapping: disabled\n")
 			}
-			if diagnoser := driver.GetAIErrorDiagnoser(); diagnoser != nil {
-				b.WriteString("  Error Diagnosis: enabled\n")
+			if c.AIReview.DiagnoseFailures {
+				b.WriteString("  Failure Diagnosis: enabled (ai_review.diagnose_failures)\n")
 			} else {
-				b.WriteString("  Error Diagnosis: disabled\n")
+				b.WriteString("  Failure Diagnosis: disabled\n")
 			}
 		} else {
 			b.WriteString("  Disabled (no provider configured in ~/.secrets/smt-config.yaml)\n")

--- a/internal/driver/ai_errordiag.go
+++ b/internal/driver/ai_errordiag.go
@@ -112,6 +112,29 @@ func NewAIErrorDiagnoser(mapper *AITypeMapper) *AIErrorDiagnoser {
 	}
 }
 
+// NewErrorDiagnoserByName builds an error diagnoser backed by the named AI
+// provider (empty name uses the default provider). It mirrors how AI review
+// resolves its provider, so failure diagnosis and review can share one
+// ai_review.model entry. Returns an error if no usable provider is configured.
+func NewErrorDiagnoserByName(name string) (*AIErrorDiagnoser, error) {
+	if strings.TrimSpace(name) != "" {
+		mapper, err := NewAITypeMapperByName(name)
+		if err != nil {
+			return nil, err
+		}
+		return NewAIErrorDiagnoser(mapper), nil
+	}
+	tm, err := GetAITypeMapper()
+	if err != nil {
+		return nil, err
+	}
+	mapper, ok := tm.(*AITypeMapper)
+	if !ok || mapper == nil {
+		return nil, fmt.Errorf("configured AI provider cannot be used for diagnosis")
+	}
+	return NewAIErrorDiagnoser(mapper), nil
+}
+
 // Diagnose analyzes an error and returns actionable suggestions.
 func (d *AIErrorDiagnoser) Diagnose(ctx context.Context, errCtx *ErrorContext) (*ErrorDiagnosis, error) {
 	if d.aiMapper == nil {

--- a/internal/orchestrator/ddl_plan.go
+++ b/internal/orchestrator/ddl_plan.go
@@ -203,6 +203,7 @@ func (o *Orchestrator) renderCreateTableStatements(ctx context.Context, runID st
 	if err := runParallel(ctx, o.tables, o.aiConcurrency(), func(ctx context.Context, i int, t source.Table) error {
 		ddl, err := renderer.renderTable(ctx, &t)
 		if err != nil {
+			o.diagnoseSchemaFailure(ctx, t.Name, t.Schema, "rendering CREATE TABLE DDL", err)
 			return fmt.Errorf("rendering table %s: %w", t.Name, err)
 		}
 		ddl = stripTrailingSemicolons(ddl)

--- a/internal/orchestrator/diagnose.go
+++ b/internal/orchestrator/diagnose.go
@@ -1,0 +1,58 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+
+	"smt/internal/driver"
+	"smt/internal/logging"
+)
+
+// diagnoseSchemaFailure is the opt-in AI advisory hook (ai_review.
+// diagnose_failures). When a schema extraction or DDL-render bug aborts the run
+// before any DDL exists — which the verifier-only ai_review never sees — it asks
+// the configured AI provider for user-facing guidance (cause + suggestions) on
+// how to resolve it.
+//
+// It is strictly advisory: it never generates, patches, or retries DDL, and it
+// never changes the run's outcome. The caller still returns the original error;
+// a provider/network failure here is swallowed (logged at debug) so diagnosis
+// can never mask or replace the real error.
+func (o *Orchestrator) diagnoseSchemaFailure(ctx context.Context, table, schema, operation string, cause error) {
+	if o.config == nil || !o.config.AIReview.DiagnoseFailures || cause == nil {
+		return
+	}
+	diag := o.errorDiagnoser()
+	if diag == nil {
+		return
+	}
+	diagnosis, err := diag.Diagnose(ctx, &driver.ErrorContext{
+		ErrorMessage: fmt.Sprintf("%s: %v", operation, cause),
+		TableName:    table,
+		TableSchema:  schema,
+		SourceDBType: canonicalDBType(o.config.Source.Type),
+		TargetDBType: canonicalDBType(o.config.Target.Type),
+		TargetMode:   o.config.SchemaGeneration.Mode,
+	})
+	if err != nil {
+		logging.Debug("AI failure diagnosis unavailable: %v", err)
+		return
+	}
+	driver.EmitDiagnosis(diagnosis)
+}
+
+// errorDiagnoser lazily resolves the AI failure-diagnosis advisor from the
+// ai_review.model provider on first use, so no AI client is constructed unless a
+// failure actually occurs. A resolution error is logged once and yields nil
+// (diagnosis is best-effort).
+func (o *Orchestrator) errorDiagnoser() *driver.AIErrorDiagnoser {
+	o.diagnoserOnce.Do(func() {
+		d, err := driver.NewErrorDiagnoserByName(o.config.AIReview.Model)
+		if err != nil {
+			logging.Debug("AI failure diagnosis disabled: no usable provider: %v", err)
+			return
+		}
+		o.diagnoser = d
+	})
+	return o.diagnoser
+}

--- a/internal/orchestrator/diagnose_test.go
+++ b/internal/orchestrator/diagnose_test.go
@@ -1,0 +1,67 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"smt/internal/config"
+	"smt/internal/driver"
+)
+
+// withDiagnosisHandler captures whether a diagnosis was emitted, so the
+// opt-in/no-op guardrails can be asserted without a live AI provider.
+func withDiagnosisHandler(t *testing.T) *bool {
+	t.Helper()
+	emitted := false
+	driver.SetDiagnosisHandler(func(*driver.ErrorDiagnosis) { emitted = true })
+	t.Cleanup(func() { driver.SetDiagnosisHandler(nil) })
+	return &emitted
+}
+
+// When diagnose_failures is off, the hook must short-circuit before resolving a
+// provider or emitting anything — failure diagnosis is strictly opt-in.
+func TestDiagnoseSchemaFailure_DisabledIsNoOp(t *testing.T) {
+	emitted := withDiagnosisHandler(t)
+	o := &Orchestrator{config: &config.Config{}} // AIReview.DiagnoseFailures defaults false
+
+	o.diagnoseSchemaFailure(context.Background(), "Employees", "dbo", "rendering CREATE TABLE DDL", errors.New("boom"))
+
+	if *emitted {
+		t.Error("diagnosis emitted while ai_review.diagnose_failures is disabled")
+	}
+	if o.diagnoser != nil {
+		t.Error("provider resolved while diagnosis is disabled; should stay lazy/unresolved")
+	}
+}
+
+// A nil cause is a no-op even when enabled (nothing to diagnose).
+func TestDiagnoseSchemaFailure_NilCauseIsNoOp(t *testing.T) {
+	emitted := withDiagnosisHandler(t)
+	cfg := &config.Config{}
+	cfg.AIReview.DiagnoseFailures = true
+	o := &Orchestrator{config: cfg}
+
+	o.diagnoseSchemaFailure(context.Background(), "Employees", "dbo", "rendering CREATE TABLE DDL", nil)
+
+	if *emitted {
+		t.Error("diagnosis emitted for a nil cause")
+	}
+}
+
+// Enabled but no usable AI provider must degrade gracefully: no emit, no panic,
+// and the original error path is unaffected (the caller still returns it).
+func TestDiagnoseSchemaFailure_EnabledNoProviderDegradesGracefully(t *testing.T) {
+	emitted := withDiagnosisHandler(t)
+	cfg := &config.Config{}
+	cfg.AIReview.DiagnoseFailures = true
+	cfg.AIReview.Model = "this-provider-does-not-exist"
+	o := &Orchestrator{config: cfg}
+
+	// Must not panic; with no resolvable provider nothing is emitted.
+	o.diagnoseSchemaFailure(context.Background(), "Employees", "dbo", "rendering CREATE TABLE DDL", errors.New("boom"))
+
+	if *emitted {
+		t.Error("diagnosis emitted despite no usable provider")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -17,9 +17,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"smt/internal/checkpoint"
 	"smt/internal/config"
+	"smt/internal/driver"
 	"smt/internal/notify"
 	"smt/internal/pool"
 	"smt/internal/source"
@@ -50,6 +52,11 @@ type Orchestrator struct {
 	runProfile string
 	runConfig  string
 	opts       Options
+
+	// diagnoser is the optional AI failure-diagnosis advisor
+	// (ai_review.diagnose_failures), resolved lazily on the first failure.
+	diagnoser     *driver.AIErrorDiagnoser
+	diagnoserOnce sync.Once
 }
 
 // New constructs an Orchestrator with default options.

--- a/internal/orchestrator/phases.go
+++ b/internal/orchestrator/phases.go
@@ -164,6 +164,7 @@ func (o *Orchestrator) ExtractSchema(ctx context.Context, runID string) error {
 
 	tables, err := o.source.ExtractSchema(ctx, o.config.Source.Schema)
 	if err != nil {
+		o.diagnoseSchemaFailure(ctx, "", o.config.Source.Schema, "extracting source schema", err)
 		return fmt.Errorf("extracting source schema: %w", err)
 	}
 


### PR DESCRIPTION
Closes #131.

## Why

When a deterministic-DDL bug aborts a run during **schema extraction** or **DDL rendering**, it fails *before any DDL exists* — so the verifier-only `ai_review` never runs and the user gets only a raw error (exactly what #127 showed: `unsupported SQL expression function "CONVERT"` with no guidance). This expands the AI's **advisory** role to cover that gap, without ever letting the AI author DDL.

## What

The AI error-diagnosis advisor (`ai_errordiag.go`) already existed but was never invoked. This wires it into the two failure points, behind a new opt-in flag:

- **Config:** `ai_review.diagnose_failures` (default `false`), reusing `ai_review.model` for the provider. Documented in `config.yaml.example`; the `DebugDump` status line now reflects the flag.
- **Driver:** `NewErrorDiagnoserByName` resolves a diagnoser from the named/default provider, mirroring how `ai_review` resolves its reviewer.
- **Orchestrator:** `diagnoseSchemaFailure()` asks the provider for user-facing guidance (`Cause` + `Suggestions`) on a render/extraction failure and emits it. CLI gets a boxed advisory via `EmitDiagnosis`'s existing log fallback; the provider is resolved lazily on first failure (no AI client unless something fails).

## Guardrails (advise, never fix) — by construction

1. **Advisory only** — surfaces cause + suggestions; never generates, patches, or retries DDL.
2. **Outcome unchanged** — the caller still returns the original error and exits non-zero; the diagnosis is supplementary.
3. **Opt-in, default off** — short-circuits before resolving a provider when disabled.
4. **Best-effort** — a provider/network failure in the diagnoser is swallowed (debug-logged), so it can never mask or replace the real error.

Pinned by tests: disabled → no-op (no provider resolved, nothing emitted); nil cause → no-op; enabled with no usable provider → degrades gracefully (no panic, nothing emitted).

## Example (the #127 case, pre-fix)

`CONVERT(date, GETDATE())` render abort would additionally surface: *Cause: SMT's deterministic renderer can't map this `CONVERT(date, …)` default to PostgreSQL. Suggestions: simplify the source default to `GETDATE()`; drop it and set it app-side; or upgrade SMT.* — never a rewritten DDL.

`go build`, `go test ./... -short`, and `golangci-lint` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)