### PR TITLE
Wrap AI diagnosis box output instead of truncating it

### DIFF
--- a/internal/driver/ai_errordiag.go
+++ b/internal/driver/ai_errordiag.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"smt/internal/logging"
 )
@@ -105,6 +106,43 @@ func getGlobalDiagnoser() *AIErrorDiagnoser {
 }
 
 // NewAIErrorDiagnoser creates a new AI-powered error diagnoser.
+// wrapText word-wraps s to at most width runes per line, breaking at spaces and
+// hard-splitting any single word longer than width. Returns at least one line.
+func wrapText(s string, width int) []string {
+	if width < 1 {
+		width = 1
+	}
+	var lines []string
+	cur := ""
+	flush := func() {
+		lines = append(lines, cur)
+		cur = ""
+	}
+	for _, word := range strings.Fields(s) {
+		for utf8.RuneCountInString(word) > width {
+			if cur != "" {
+				flush()
+			}
+			r := []rune(word)
+			lines = append(lines, string(r[:width]))
+			word = string(r[width:])
+		}
+		switch {
+		case cur == "":
+			cur = word
+		case utf8.RuneCountInString(cur)+1+utf8.RuneCountInString(word) <= width:
+			cur += " " + word
+		default:
+			flush()
+			cur = word
+		}
+	}
+	if cur != "" || len(lines) == 0 {
+		flush()
+	}
+	return lines
+}
+
 func NewAIErrorDiagnoser(mapper *AITypeMapper) *AIErrorDiagnoser {
 	return &AIErrorDiagnoser{
 		aiMapper: mapper,
@@ -358,18 +396,25 @@ func (diag *ErrorDiagnosis) FormatBox() string {
 
 	// Fixed width for the box
 	width := 72
+	inner := width - 4 // content columns between the "│ " and " │"
 
-	// Helper to write a padded line
+	// Helper to write one already-fit line, padded to the inner width. Rune-
+	// aware so multibyte content (and the box borders) line up.
 	writePadded := func(content string) {
-		// Truncate if too long
-		if len(content) > width-4 {
-			content = content[:width-7] + "..."
+		n := utf8.RuneCountInString(content)
+		if n > inner { // safety net; wrapText keeps lines within inner
+			content = string([]rune(content)[:inner])
+			n = inner
 		}
-		padding := width - 4 - len(content)
-		if padding < 0 {
-			padding = 0
+		sb.WriteString(vertical + " " + content + strings.Repeat(" ", inner-n) + " " + vertical + "\n")
+	}
+
+	// Write content wrapped across as many lines as needed — guidance is only
+	// useful if it isn't clipped.
+	writeWrapped := func(content string) {
+		for _, line := range wrapText(content, inner) {
+			writePadded(line)
 		}
-		sb.WriteString(vertical + " " + content + strings.Repeat(" ", padding) + " " + vertical + "\n")
 	}
 
 	// Top border with title
@@ -382,7 +427,7 @@ func (diag *ErrorDiagnosis) FormatBox() string {
 	writePadded("")
 
 	// Cause
-	writePadded("Cause: " + diag.Cause)
+	writeWrapped("Cause: " + diag.Cause)
 
 	// Empty line
 	writePadded("")
@@ -390,7 +435,7 @@ func (diag *ErrorDiagnosis) FormatBox() string {
 	// Suggestions
 	writePadded("Suggestions:")
 	for i, s := range diag.Suggestions {
-		writePadded(fmt.Sprintf("  %d. %s", i+1, s))
+		writeWrapped(fmt.Sprintf("  %d. %s", i+1, s))
 	}
 
 	// Empty line
@@ -398,7 +443,7 @@ func (diag *ErrorDiagnosis) FormatBox() string {
 
 	// Confidence and category
 	meta := fmt.Sprintf("Confidence: %s  |  Category: %s", diag.Confidence, diag.Category)
-	writePadded(meta)
+	writeWrapped(meta)
 
 	// Bottom border
 	sb.WriteString(bottomLeft + strings.Repeat(horizontal, width-2) + bottomRight)

--- a/internal/driver/ai_errordiag_wrap_test.go
+++ b/internal/driver/ai_errordiag_wrap_test.go
@@ -1,0 +1,43 @@
+package driver
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestWrapText_NoTruncationWithinWidth(t *testing.T) {
+	long := "Replace the MSSQL default expression dateadd(year,1,getdate()) with a Postgres-compatible equivalent such as CURRENT_TIMESTAMP + INTERVAL '1 year' on the target."
+	lines := wrapText(long, 68)
+	for _, l := range lines {
+		if utf8.RuneCountInString(l) > 68 {
+			t.Errorf("line exceeds width: %q (%d)", l, utf8.RuneCountInString(l))
+		}
+	}
+	if joined := strings.Join(lines, " "); joined != strings.Join(strings.Fields(long), " ") {
+		t.Errorf("wrap lost/altered content:\n got: %q", joined)
+	}
+}
+
+func TestWrapText_HardSplitsLongWord(t *testing.T) {
+	w := strings.Repeat("x", 150)
+	lines := wrapText(w, 70)
+	if len(lines) < 3 {
+		t.Fatalf("expected >=3 lines for a 150-char word at width 70, got %d", len(lines))
+	}
+	if strings.Join(lines, "") != w {
+		t.Error("hard-split altered content")
+	}
+}
+
+func TestFormatBox_NoEllipsisTruncation(t *testing.T) {
+	d := &ErrorDiagnosis{
+		Cause:       strings.Repeat("a very long cause that should wrap rather than be cut ", 4),
+		Suggestions: []string{strings.Repeat("a long actionable suggestion that must not be clipped ", 3)},
+		Confidence:  "high", Category: "type_mismatch",
+	}
+	box := d.FormatBox()
+	if strings.Contains(box, "...") {
+		t.Errorf("FormatBox still truncates with ellipsis:\n%s", box)
+	}
+}


### PR DESCRIPTION
A live run of the new `ai_review.diagnose_failures` path (#131) showed `FormatBox` clipping every line to 72 chars with `...`, so the guidance — the whole point of the feature — was cut off mid-sentence:

```
│ 1. Replace the MSSQL default expression `dateadd(year,(1),CURRE... │
```

This word-wraps each line across as many box rows as needed (rune-aware, with a hard-split fallback for any word longer than the box width), so the full cause + suggestions render:

```
│ 1. Manually replace the DEFAULT constraint in the target PostgreSQL  │
│ schema: change 'dateadd(year,(1),CURRENT_TIMESTAMP)' to              │
│ 'CURRENT_TIMESTAMP + INTERVAL '1 year'' in the CREATE TABLE DDL      │
```

Tests pin that wrapped lines stay within width, content is preserved, long words hard-split, and `FormatBox` no longer emits an ellipsis. `go test ./... -short` and `golangci-lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)