### PR TITLE
AI-assisted fix: splice one AI-translated expression into deterministic DDL (#134)

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -35,6 +35,10 @@ ai_review:
   diagnose_failures: false             # advise the user on extract/render failures
                                        # (cause + suggestions only — never edits or
                                        #  retries DDL); uses the model above
+  suggest_fixes: false                 # on a failure, write an AI-proposed corrected
+                                       # DDL to schema.suggested.sql (labeled, UNVERIFIED,
+                                       #  never schema.sql; never applied without
+                                       #  --apply-suggested)
   # Note: with review enabled the un-configured render fan-out drops from 8
   # to 2 so cold-cache runs stay under provider rate limits (#54). Set
   # migration.ai_concurrency explicitly to override.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,6 +211,13 @@ type AIReviewConfig struct {
 	// above (or the default provider when Model is empty).
 	DiagnoseFailures bool `yaml:"diagnose_failures"`
 
+	// SuggestFixes, when true, writes an AI-proposed corrected DDL to a
+	// clearly-labeled schema.suggested.sql artifact on a render/extract failure
+	// (#134). It is a SUGGESTION for the user to review and apply — SMT never
+	// writes it to schema.sql and never applies it automatically (that requires
+	// the explicit --apply-suggested flag). Uses the Model provider above.
+	SuggestFixes bool `yaml:"suggest_fixes"`
+
 	// Scope is reserved for future chunking choices such as "table" or "plan".
 	Scope string `yaml:"scope"`
 

--- a/internal/driver/ai_schemafix.go
+++ b/internal/driver/ai_schemafix.go
@@ -1,0 +1,94 @@
+package driver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ExpressionFix is an AI-proposed translation of a SINGLE source-dialect
+// expression (a DEFAULT/CHECK that SMT's deterministic renderer couldn't map)
+// into the target dialect. SMT splices just this one expression into its own
+// otherwise-deterministic DDL — the AI never authors a whole table (#134).
+type ExpressionFix struct {
+	// Expression is the target-dialect replacement expression.
+	Expression string `json:"expression"`
+
+	// Explanation is a short note on the translation.
+	Explanation string `json:"explanation"`
+
+	// Confidence is high | medium | low.
+	Confidence string `json:"confidence"`
+}
+
+// FixRequest describes the one expression that needs translating.
+type FixRequest struct {
+	Kind          string // "default" | "check"
+	SourceExpr    string // raw source-dialect expression
+	ColumnName    string
+	ColumnType    string // source column type, for context
+	SourceDialect string
+	TargetDialect string
+}
+
+// SuggestExpressionFix asks the AI to translate one expression to the target
+// dialect. The result is advisory and is spliced into SMT's deterministic DDL,
+// never applied automatically.
+func (d *AIErrorDiagnoser) SuggestExpressionFix(ctx context.Context, req FixRequest) (*ExpressionFix, error) {
+	if d.aiMapper == nil {
+		return nil, fmt.Errorf("AI mapper not configured")
+	}
+	response, err := d.aiMapper.CallAI(ctx, buildExpressionFixPrompt(req))
+	if err != nil {
+		return nil, fmt.Errorf("AI expression-fix suggestion failed: %w", err)
+	}
+	return parseExpressionFix(response)
+}
+
+func buildExpressionFixPrompt(req FixRequest) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Translate a single SQL %s expression from %s to %s. SMT's deterministic renderer could not map it.\n\n", strings.ToUpper(req.Kind), req.SourceDialect, req.TargetDialect))
+	sb.WriteString("STRICT RULES:\n")
+	sb.WriteString(fmt.Sprintf("- Return ONLY the replacement %s expression for %s, valid in %s.\n", req.Kind, req.TargetDialect, req.TargetDialect))
+	sb.WriteString("- Preserve the exact semantics; do not add casts, columns, or surrounding DDL.\n")
+	sb.WriteString("- Do not include the DEFAULT/CHECK keyword, the column name, or a trailing semicolon — just the expression.\n\n")
+	if req.ColumnName != "" {
+		sb.WriteString(fmt.Sprintf("Column: %s", req.ColumnName))
+		if req.ColumnType != "" {
+			sb.WriteString(fmt.Sprintf(" (%s)", req.ColumnType))
+		}
+		sb.WriteString("\n")
+	}
+	sb.WriteString(fmt.Sprintf("Source %s expression: %s\n\n", req.Kind, req.SourceExpr))
+	sb.WriteString("Respond with ONLY a JSON object (no markdown):\n")
+	sb.WriteString(`{
+  "expression": "<target-dialect expression>",
+  "explanation": "what you changed and why (1 sentence)",
+  "confidence": "high|medium|low"
+}`)
+	return sb.String()
+}
+
+func parseExpressionFix(response string) (*ExpressionFix, error) {
+	response = strings.TrimSpace(response)
+	response = strings.TrimPrefix(response, "```json")
+	response = strings.TrimPrefix(response, "```")
+	response = strings.TrimSuffix(response, "```")
+	response = strings.TrimSpace(response)
+
+	var fix ExpressionFix
+	if err := json.Unmarshal([]byte(response), &fix); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w (response: %s)", err, truncateString(response, 120))
+	}
+	if strings.TrimSpace(fix.Expression) == "" {
+		return nil, fmt.Errorf("expression-fix suggestion missing expression")
+	}
+	switch strings.ToLower(fix.Confidence) {
+	case "high", "medium", "low":
+		fix.Confidence = strings.ToLower(fix.Confidence)
+	default:
+		fix.Confidence = "medium"
+	}
+	return &fix, nil
+}

--- a/internal/driver/ai_schemafix_test.go
+++ b/internal/driver/ai_schemafix_test.go
@@ -1,0 +1,55 @@
+package driver
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseExpressionFix_Valid(t *testing.T) {
+	fix, err := parseExpressionFix("```json\n{\"expression\":\"CURRENT_TIMESTAMP + INTERVAL '1 year'\",\"explanation\":\"x\",\"confidence\":\"HIGH\"}\n```")
+	if err != nil {
+		t.Fatalf("parseExpressionFix: %v", err)
+	}
+	if !strings.Contains(fix.Expression, "INTERVAL") {
+		t.Fatalf("unexpected expression: %q", fix.Expression)
+	}
+	if fix.Confidence != "high" {
+		t.Errorf("confidence not normalized: %q", fix.Confidence)
+	}
+}
+
+func TestParseExpressionFix_MissingExpressionFails(t *testing.T) {
+	if _, err := parseExpressionFix(`{"expression":"   ","confidence":"high"}`); err == nil {
+		t.Error("expected error for empty expression")
+	}
+}
+
+func TestParseExpressionFix_DefaultsConfidence(t *testing.T) {
+	fix, err := parseExpressionFix(`{"expression":"CURRENT_DATE"}`)
+	if err != nil {
+		t.Fatalf("parseExpressionFix: %v", err)
+	}
+	if fix.Confidence != "medium" {
+		t.Errorf("confidence default = %q, want medium", fix.Confidence)
+	}
+}
+
+func TestBuildExpressionFixPrompt_ScopesToOneExpression(t *testing.T) {
+	p := buildExpressionFixPrompt(FixRequest{
+		Kind: "default", SourceExpr: "dateadd(year,1,getdate())",
+		ColumnName: "ExpiresAt", ColumnType: "datetime2",
+		SourceDialect: "mssql", TargetDialect: "postgres",
+	})
+	for _, want := range []string{
+		"dateadd(year,1,getdate())", "ExpiresAt", "datetime2",
+		"ONLY the replacement", "Do not include the DEFAULT",
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+	// It must not invite a whole-table rewrite.
+	if strings.Contains(strings.ToUpper(p), "CREATE TABLE") {
+		t.Error("expression-fix prompt should not mention CREATE TABLE")
+	}
+}

--- a/internal/driver/postgres/deterministic.go
+++ b/internal/driver/postgres/deterministic.go
@@ -213,9 +213,15 @@ func (r deterministicDDL) columnDefinition(col driver.Column, tableColumns ...[]
 		b.WriteString(" NOT NULL")
 	}
 	if !col.IsIdentity && strings.TrimSpace(col.DefaultExpression) != "" {
-		def, err := r.defaultExpression(col)
-		if err != nil {
-			return "", "", err
+		def := strings.TrimSpace(col.DefaultExpressionOverride)
+		if def == "" {
+			var err error
+			def, err = r.defaultExpression(col)
+			if err != nil {
+				return "", "", &driver.ExpressionRenderError{
+					Column: col.Name, Kind: "default", SourceExpr: col.DefaultExpression, Err: err,
+				}
+			}
 		}
 		if def != "" {
 			b.WriteString(" DEFAULT ")

--- a/internal/driver/postgres/exprerror_test.go
+++ b/internal/driver/postgres/exprerror_test.go
@@ -1,0 +1,55 @@
+package postgres
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"smt/internal/driver"
+)
+
+// The deterministic renderer must surface an unsupported DEFAULT as a structured
+// *driver.ExpressionRenderError (through all the error wrapping), so the AI
+// fix-suggestion path can translate just that expression (#134).
+func TestCreateTable_UnsupportedDefaultIsStructured(t *testing.T) {
+	tbl := &driver.Table{
+		Schema: "dbo", Name: "Subscriptions",
+		Columns: []driver.Column{
+			{Name: "ExpiresAt", DataType: "datetime2", IsNullable: false,
+				DefaultExpression: "(dateadd(year,(1),getdate()))"},
+		},
+	}
+	_, _, err := RenderCreateTableDDLWithSource(tbl, "public", false, "fail", "mssql")
+	if err == nil {
+		t.Fatal("expected render error for unsupported DATEADD default")
+	}
+	var ex *driver.ExpressionRenderError
+	if !errors.As(err, &ex) {
+		t.Fatalf("error is not *ExpressionRenderError: %v", err)
+	}
+	if ex.Kind != "default" || ex.Column != "ExpiresAt" {
+		t.Errorf("unexpected structured error: kind=%q column=%q", ex.Kind, ex.Column)
+	}
+	if ex.SourceExpr != "(dateadd(year,(1),getdate()))" {
+		t.Errorf("SourceExpr = %q, want the raw source default", ex.SourceExpr)
+	}
+}
+
+// With the override set, the same column renders verbatim (the splice point).
+func TestCreateTable_DefaultOverrideEmittedVerbatim(t *testing.T) {
+	tbl := &driver.Table{
+		Schema: "dbo", Name: "Subscriptions",
+		Columns: []driver.Column{
+			{Name: "ExpiresAt", DataType: "datetime2", IsNullable: false,
+				DefaultExpression:         "(dateadd(year,(1),getdate()))",
+				DefaultExpressionOverride: "CURRENT_TIMESTAMP + INTERVAL '1 year'"},
+		},
+	}
+	ddl, _, err := RenderCreateTableDDLWithSource(tbl, "public", false, "fail", "mssql")
+	if err != nil {
+		t.Fatalf("render with override failed: %v", err)
+	}
+	if !strings.Contains(ddl, "DEFAULT CURRENT_TIMESTAMP + INTERVAL '1 year'") {
+		t.Errorf("override not emitted verbatim:\n%s", ddl)
+	}
+}

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -109,26 +109,49 @@ func (t *Table) GetColumnNames() []string {
 
 // Column represents a table column.
 type Column struct {
-	Name               string   `json:"name"`
-	DataType           string   `json:"data_type"`
-	MaxLength          int      `json:"max_length"`
-	Precision          int      `json:"precision"`
-	Scale              int      `json:"scale"`
-	DatetimePrecision  *int     `json:"datetime_precision,omitempty"` // fractional-seconds precision for datetime/time-class columns; nil = unknown (pre-v3 snapshots)
-	IsNullable         bool     `json:"is_nullable"`
-	IsIdentity         bool     `json:"is_identity"`
-	IsUnsigned         bool     `json:"is_unsigned,omitempty"`   // true for MySQL unsigned numeric columns
-	DisplayWidth       int      `json:"display_width,omitempty"` // MySQL integer display width, captured only for tinyint(1) (the boolean convention); other widths are deprecated and intentionally not captured
-	OrdinalPos         int      `json:"ordinal_position"`
-	DefaultExpression  string   `json:"default_expression,omitempty"`   // raw default clause from source dialect (e.g. "((0))", "getutcdate()", "'pending'") — empty if no default
-	OnUpdateExpression string   `json:"on_update_expression,omitempty"` // raw MySQL ON UPDATE expression (e.g. "CURRENT_TIMESTAMP")
-	IsComputed         bool     `json:"is_computed,omitempty"`          // true if this column is a generated/computed column
-	ComputedExpression string   `json:"computed_expression,omitempty"`  // generation expression for computed columns
-	ComputedPersisted  bool     `json:"computed_persisted,omitempty"`   // true if computed value is persisted/stored (vs virtual)
-	EnumValues         []string `json:"enum_values,omitempty"`          // allowed values for MySQL ENUM/SET columns
-	SRID               int      `json:"srid,omitempty"`                 // Spatial Reference ID for geography/geometry columns (0 = default/unset)
-	SampleValues       []string `json:"sample_values,omitempty"`        // Sample data values for AI type mapping context
+	Name              string `json:"name"`
+	DataType          string `json:"data_type"`
+	MaxLength         int    `json:"max_length"`
+	Precision         int    `json:"precision"`
+	Scale             int    `json:"scale"`
+	DatetimePrecision *int   `json:"datetime_precision,omitempty"` // fractional-seconds precision for datetime/time-class columns; nil = unknown (pre-v3 snapshots)
+	IsNullable        bool   `json:"is_nullable"`
+	IsIdentity        bool   `json:"is_identity"`
+	IsUnsigned        bool   `json:"is_unsigned,omitempty"`   // true for MySQL unsigned numeric columns
+	DisplayWidth      int    `json:"display_width,omitempty"` // MySQL integer display width, captured only for tinyint(1) (the boolean convention); other widths are deprecated and intentionally not captured
+	OrdinalPos        int    `json:"ordinal_position"`
+	DefaultExpression string `json:"default_expression,omitempty"` // raw default clause from source dialect (e.g. "((0))", "getutcdate()", "'pending'") — empty if no default
+	// DefaultExpressionOverride, when set, is emitted verbatim as the column's
+	// DEFAULT instead of translating DefaultExpression. It is a transient,
+	// runtime-only splice point (not persisted) used by the AI fix-suggestion
+	// path to substitute one AI-translated target-dialect expression into SMT's
+	// otherwise-deterministic DDL (#134). It must already be valid target DDL.
+	DefaultExpressionOverride string   `json:"-"`
+	OnUpdateExpression        string   `json:"on_update_expression,omitempty"` // raw MySQL ON UPDATE expression (e.g. "CURRENT_TIMESTAMP")
+	IsComputed                bool     `json:"is_computed,omitempty"`          // true if this column is a generated/computed column
+	ComputedExpression        string   `json:"computed_expression,omitempty"`  // generation expression for computed columns
+	ComputedPersisted         bool     `json:"computed_persisted,omitempty"`   // true if computed value is persisted/stored (vs virtual)
+	EnumValues                []string `json:"enum_values,omitempty"`          // allowed values for MySQL ENUM/SET columns
+	SRID                      int      `json:"srid,omitempty"`                 // Spatial Reference ID for geography/geometry columns (0 = default/unset)
+	SampleValues              []string `json:"sample_values,omitempty"`        // Sample data values for AI type mapping context
 }
+
+// ExpressionRenderError is returned by the deterministic renderer when a single
+// column/constraint expression can't be translated to the target dialect. It
+// carries enough structure for the AI fix-suggestion path to translate just
+// that expression and splice it back (#134), rather than guessing from a string.
+type ExpressionRenderError struct {
+	Column     string // column the expression belongs to
+	Kind       string // "default" | "check" | "computed"
+	SourceExpr string // the raw source-dialect expression that failed
+	Err        error  // underlying renderer error
+}
+
+func (e *ExpressionRenderError) Error() string {
+	return fmt.Sprintf("unsupported %s expression for column %q: %v", e.Kind, e.Column, e.Err)
+}
+
+func (e *ExpressionRenderError) Unwrap() error { return e.Err }
 
 // MetaOf extracts the type-shaping metadata canonical.ToCanonical needs from a
 // column. It is the single Column -> canonical.TypeMeta mapping shared by the

--- a/internal/orchestrator/ddl_plan.go
+++ b/internal/orchestrator/ddl_plan.go
@@ -204,6 +204,7 @@ func (o *Orchestrator) renderCreateTableStatements(ctx context.Context, runID st
 		ddl, err := renderer.renderTable(ctx, &t)
 		if err != nil {
 			o.diagnoseSchemaFailure(ctx, t.Name, t.Schema, "rendering CREATE TABLE DDL", err)
+			o.suggestSchemaFix(ctx, runID, renderer, &t, err)
 			return fmt.Errorf("rendering table %s: %w", t.Name, err)
 		}
 		ddl = stripTrailingSemicolons(ddl)

--- a/internal/orchestrator/diagnose.go
+++ b/internal/orchestrator/diagnose.go
@@ -2,7 +2,10 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"smt/internal/driver"
 	"smt/internal/logging"
@@ -39,6 +42,108 @@ func (o *Orchestrator) diagnoseSchemaFailure(ctx context.Context, table, schema,
 		return
 	}
 	driver.EmitDiagnosis(diagnosis)
+}
+
+// suggestSchemaFix is the opt-in AI fix-suggestion hook (ai_review.
+// suggest_fixes). On a render failure caused by ONE unsupported expression, it
+// asks the AI to translate just that expression, splices it into SMT's own
+// deterministic DDL (re-rendering the whole table through the deterministic
+// renderer with the one expression overridden), and writes the result to a
+// clearly-labeled schema.suggested.sql.
+//
+// The AI never authors a whole table: only the one failing expression comes
+// from the model; everything else is SMT's deterministic output. If the failure
+// isn't a single splice-able expression, no suggestion is written (the diagnosis
+// still advises).
+//
+// SUGGESTION only: never written to schema.sql, never applied (that needs the
+// explicit --apply-suggested flag). The caller still returns the original error;
+// any provider/parse/re-render failure here is swallowed (debug-logged) so it
+// can never mask the real error.
+func (o *Orchestrator) suggestSchemaFix(ctx context.Context, runID string, renderer createDDLRenderer, t *driver.Table, cause error) {
+	if o.config == nil || !o.config.AIReview.SuggestFixes || cause == nil || t == nil {
+		return
+	}
+	var exprErr *driver.ExpressionRenderError
+	if !errors.As(cause, &exprErr) || exprErr.Kind != "default" {
+		return // not a single splice-able expression — diagnosis-only
+	}
+	idx := -1
+	for i := range t.Columns {
+		if t.Columns[i].Name == exprErr.Column {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return
+	}
+	suggester := o.errorDiagnoser()
+	if suggester == nil {
+		return
+	}
+	fix, err := suggester.SuggestExpressionFix(ctx, driver.FixRequest{
+		Kind:          exprErr.Kind,
+		SourceExpr:    exprErr.SourceExpr,
+		ColumnName:    exprErr.Column,
+		ColumnType:    t.Columns[idx].DataType,
+		SourceDialect: canonicalDBType(o.config.Source.Type),
+		TargetDialect: canonicalDBType(o.config.Target.Type),
+	})
+	if err != nil {
+		logging.Debug("AI expression fix unavailable: %v", err)
+		return
+	}
+
+	// Re-render the whole table deterministically with ONLY the failing
+	// expression overridden by the AI translation.
+	spliced := *t
+	spliced.Columns = append([]driver.Column(nil), t.Columns...)
+	spliced.Columns[idx].DefaultExpressionOverride = fix.Expression
+	ddl, rerr := renderer.renderTable(ctx, &spliced)
+	if rerr != nil {
+		logging.Debug("re-render with AI expression failed: %v", rerr)
+		return
+	}
+
+	o.suggestOnce.Do(func() {
+		content := renderSuggestionFile(t.Name, exprErr, fix, ddl)
+		if werr := o.writeSQLArtifact(runID, "schema.suggested.sql", content); werr != nil {
+			logging.Debug("writing schema.suggested.sql: %v", werr)
+			return
+		}
+		logging.Warn("AI-suggested fix written to %s — UNVERIFIED; review before applying. SMT did NOT apply it.",
+			filepath.Join(o.ddlArtifactDir(runID), "schema.suggested.sql"))
+	})
+}
+
+// renderSuggestionFile wraps SMT's deterministic DDL (with one AI-translated
+// expression spliced in) in a banner that makes the provenance — which single
+// expression came from the AI — unmistakable.
+func renderSuggestionFile(table string, exprErr *driver.ExpressionRenderError, fix *driver.ExpressionFix, ddl string) string {
+	var b strings.Builder
+	b.WriteString("-- ============================================================\n")
+	b.WriteString("-- AI-ASSISTED FIX · UNVERIFIED · review before applying\n")
+	b.WriteString("--\n")
+	b.WriteString("-- This is SMT's deterministic DDL with ONE expression translated by\n")
+	b.WriteString("-- an AI model. SMT did not and will not apply it automatically.\n")
+	b.WriteString(fmt.Sprintf("-- Table:  %s\n", oneLine(table)))
+	b.WriteString(fmt.Sprintf("-- Column: %s (%s)\n", oneLine(exprErr.Column), oneLine(exprErr.Kind)))
+	b.WriteString(fmt.Sprintf("-- AI-translated: %s  ->  %s\n", oneLine(exprErr.SourceExpr), oneLine(fix.Expression)))
+	if strings.TrimSpace(fix.Explanation) != "" {
+		b.WriteString("-- Note: " + oneLine(fix.Explanation) + "\n")
+	}
+	b.WriteString(fmt.Sprintf("-- Confidence: %s\n", fix.Confidence))
+	b.WriteString("-- ============================================================\n\n")
+	b.WriteString(strings.TrimSpace(ddl))
+	b.WriteString(";\n")
+	return b.String()
+}
+
+// oneLine collapses all whitespace (including newlines) to single spaces so an
+// AI/source string can't break out of a single-line "-- " banner comment.
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 // errorDiagnoser lazily resolves the AI failure-diagnosis advisor from the

--- a/internal/orchestrator/diagnose_test.go
+++ b/internal/orchestrator/diagnose_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"smt/internal/config"
@@ -46,6 +47,70 @@ func TestDiagnoseSchemaFailure_NilCauseIsNoOp(t *testing.T) {
 
 	if *emitted {
 		t.Error("diagnosis emitted for a nil cause")
+	}
+}
+
+// The suggestion file must be unmistakably labeled as AI-assisted/unverified,
+// show exactly which one expression came from the AI, and contain SMT's
+// deterministic DDL — so a user can never confuse it with schema.sql.
+func TestRenderSuggestionFile_LabeledAndProvenanced(t *testing.T) {
+	out := renderSuggestionFile(
+		"dbo.Subscriptions",
+		&driver.ExpressionRenderError{Column: "ExpiresAt", Kind: "default", SourceExpr: "dateadd(year,1,getdate())"},
+		&driver.ExpressionFix{Expression: "CURRENT_TIMESTAMP + INTERVAL '1 year'", Explanation: "interval arithmetic", Confidence: "high"},
+		`CREATE TABLE "subscriptions" ("expiresat" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP + INTERVAL '1 year')`,
+	)
+	for _, want := range []string{
+		"AI-ASSISTED", "UNVERIFIED", "did not and will not apply it",
+		"dbo.Subscriptions", "ExpiresAt (default)",
+		"dateadd(year,1,getdate())  ->  CURRENT_TIMESTAMP + INTERVAL '1 year'",
+		"Confidence: high", `CREATE TABLE "subscriptions"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("suggestion file missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// A multi-line AI/source string must not break out of the single-line "-- "
+// banner comments — every line above the DDL body stays a comment.
+func TestRenderSuggestionFile_SanitizesMultilineBannerFields(t *testing.T) {
+	out := renderSuggestionFile(
+		"T",
+		&driver.ExpressionRenderError{Column: "c", Kind: "default", SourceExpr: "x\nDROP TABLE users; --"},
+		&driver.ExpressionFix{Expression: "1\nDELETE FROM secrets;", Explanation: "ok\nrm -rf /", Confidence: "low"},
+		"CREATE TABLE t (c int)",
+	)
+	header := strings.SplitN(out, "\n\nCREATE TABLE", 2)[0]
+	for _, line := range strings.Split(header, "\n") {
+		if line != "" && !strings.HasPrefix(line, "--") {
+			t.Errorf("non-comment line escaped into the banner: %q", line)
+		}
+	}
+}
+
+// suggest_fixes off is a no-op: no provider resolved, nothing written.
+func TestSuggestSchemaFix_DisabledIsNoOp(t *testing.T) {
+	o := &Orchestrator{config: &config.Config{}} // SuggestFixes defaults false
+	o.suggestSchemaFix(context.Background(), "run1", createDDLRenderer{},
+		&driver.Table{Name: "T", Schema: "dbo"}, errors.New("boom"))
+	if o.diagnoser != nil {
+		t.Error("provider resolved while suggest_fixes is disabled")
+	}
+}
+
+// A failure that isn't a single splice-able expression must not produce a
+// suggestion (no whole-table rewrite) — even with suggest_fixes on.
+func TestSuggestSchemaFix_NonExpressionFailureNoSuggestion(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.AIReview.SuggestFixes = true
+	o := &Orchestrator{config: cfg}
+	// A plain error (not *driver.ExpressionRenderError) must short-circuit
+	// before resolving a provider.
+	o.suggestSchemaFix(context.Background(), "run1", createDDLRenderer{},
+		&driver.Table{Name: "T", Schema: "dbo"}, errors.New("unsupported source type \"geography\""))
+	if o.diagnoser != nil {
+		t.Error("provider resolved for a non-expression failure; should be diagnosis-only")
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -57,6 +57,10 @@ type Orchestrator struct {
 	// (ai_review.diagnose_failures), resolved lazily on the first failure.
 	diagnoser     *driver.AIErrorDiagnoser
 	diagnoserOnce sync.Once
+
+	// suggestOnce guards writing schema.suggested.sql so concurrent table
+	// failures produce a single suggestion artifact.
+	suggestOnce sync.Once
 }
 
 // New constructs an Orchestrator with default options.


### PR DESCRIPTION
Implements #134 as **Option B (targeted splice)** — the AI translates only the failing expression and SMT splices it into its own deterministic DDL. The AI never authors a whole table (the earlier whole-table approach was dropped after a live demo showed it diverging from SMT's conventions).

## Mechanism

- **`driver.ExpressionRenderError`** — the pg renderer returns a structured error (column, kind, raw source expression) when a column `DEFAULT` can't be translated, instead of a bare string.
- **`Column.DefaultExpressionOverride`** — a transient, non-persisted field; when set, the renderer emits it verbatim. SMT re-renders the whole table through its deterministic path with exactly one expression overridden.
- **`driver.SuggestExpressionFix`** — prompts the AI to translate ONE expression (not a table).
- **`orchestrator.suggestSchemaFix`** — `errors.As` the structured error → AI translates the expression → re-render with the override → write SMT's deterministic DDL (one expression spliced) to a labeled `schema.suggested.sql`.

## Guardrails

Never written to `schema.sql`, never applied (that's the future `--apply-suggested`), opt-in (`ai_review.suggest_fixes`, default off), best-effort (provider/parse/re-render failures swallowed; run still returns the original error). **If the failure isn't a single splice-able expression, no suggestion is written — SMT does not do a whole-table rewrite; the diagnosis still advises.**

## Live result (mssql→pg, `DATEADD` default)

SMT's deterministic DDL with only the one expression from the AI:
```sql
-- AI-translated: (dateadd(year,(1),getdate()))  ->  NOW() + INTERVAL '1 year'
CREATE TABLE "splicelive"."subscriptions" (
    "id" bigint GENERATED BY DEFAULT AS IDENTITY,
    "planname" character varying(100) NOT NULL,
    "price" numeric(10,2) NOT NULL,
    "expiresat" timestamp(6) without time zone NOT NULL DEFAULT NOW() + INTERVAL '1 year',
    CONSTRAINT "pk_subscriptions" PRIMARY KEY ("id")
);
```
Everything except `DEFAULT NOW() + INTERVAL '1 year'` is SMT's deterministic output; `schema.sql` was not written; the run still exited non-zero; and the suggestion **applies cleanly to Postgres**.

Tests pin structured-error propagation, override-verbatim rendering, prompt scoping, the disabled/non-expression no-ops, and banner provenance. `go test ./... -short` and `golangci-lint` green.

Follow-ups (#134): deterministic verification of the suggestion, CHECK-expression splice, and the opt-in `--apply-suggested`.