### PR TITLE
Verify AI-suggested fixes deterministically; make suggest_fixes opt-out (#134)

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -35,10 +35,12 @@ ai_review:
   diagnose_failures: false             # advise the user on extract/render failures
                                        # (cause + suggestions only — never edits or
                                        #  retries DDL); uses the model above
-  suggest_fixes: false                 # on a failure, write an AI-proposed corrected
-                                       # DDL to schema.suggested.sql (labeled, UNVERIFIED,
-                                       #  never schema.sql; never applied without
-                                       #  --apply-suggested)
+  # suggest_fixes: true                # OPT-OUT (defaults to diagnose_failures): on a
+                                       # failure, splice one AI-translated expression into
+                                       # SMT's deterministic DDL and write it to
+                                       # schema.suggested.sql (labeled; never schema.sql;
+                                       # never applied without --apply-suggested). Set
+                                       # false to get diagnosis without suggestions.
   # Note: with review enabled the un-configured render fan-out drops from 8
   # to 2 so cold-cache runs stay under provider rate limits (#54). Set
   # migration.ai_concurrency explicitly to override.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,12 +211,16 @@ type AIReviewConfig struct {
 	// above (or the default provider when Model is empty).
 	DiagnoseFailures bool `yaml:"diagnose_failures"`
 
-	// SuggestFixes, when true, writes an AI-proposed corrected DDL to a
-	// clearly-labeled schema.suggested.sql artifact on a render/extract failure
-	// (#134). It is a SUGGESTION for the user to review and apply — SMT never
-	// writes it to schema.sql and never applies it automatically (that requires
-	// the explicit --apply-suggested flag). Uses the Model provider above.
-	SuggestFixes bool `yaml:"suggest_fixes"`
+	// SuggestFixes writes an AI-proposed corrected DDL to a clearly-labeled
+	// schema.suggested.sql artifact on a render failure (#134) — SMT splices one
+	// AI-translated expression into its own deterministic DDL. It is a
+	// SUGGESTION: never written to schema.sql, never applied automatically (that
+	// needs --apply-suggested). Uses the Model provider above.
+	//
+	// Opt-OUT: it is a pointer so an omitted value defaults to DiagnoseFailures
+	// — if you've asked the AI for help on failures, you get fix suggestions
+	// too. Set it explicitly false to get diagnosis without suggestions.
+	SuggestFixes *bool `yaml:"suggest_fixes"`
 
 	// Scope is reserved for future chunking choices such as "table" or "plan".
 	Scope string `yaml:"scope"`
@@ -660,6 +664,13 @@ func (c *Config) applyDefaults() error {
 	if c.AIReview.Enabled == nil {
 		enabled := c.Migration.AIVerify
 		c.AIReview.Enabled = &enabled
+	}
+	// suggest_fixes is opt-OUT: when omitted it follows diagnose_failures, so
+	// asking the AI for help on failures also yields fix suggestions. An
+	// explicit value (true/false) always wins.
+	if c.AIReview.SuggestFixes == nil {
+		suggest := c.AIReview.DiagnoseFailures
+		c.AIReview.SuggestFixes = &suggest
 	}
 	if c.AIReview.Model == "" {
 		c.AIReview.Model = c.Migration.AIVerifierModel

--- a/internal/driver/ai_schemafix.go
+++ b/internal/driver/ai_schemafix.go
@@ -70,6 +70,73 @@ func buildExpressionFixPrompt(req FixRequest) string {
 	return sb.String()
 }
 
+// ValidateTargetExpression rejects an AI-proposed expression that isn't a single
+// self-contained value expression, so splicing it verbatim into a column's
+// DEFAULT clause can't break out and inject extra columns or statements into the
+// CREATE TABLE. It checks: non-empty, balanced parens/quotes, and no top-level
+// (unquoted, unparenthesized) comma or semicolon. It is a structural guard, not
+// a semantic or dialect validator.
+func ValidateTargetExpression(expr string) error {
+	s := strings.TrimSpace(expr)
+	if s == "" {
+		return fmt.Errorf("empty expression")
+	}
+	depth := 0
+	inSingle, inDouble := false, false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case inSingle:
+			// Backslash escaping is dialect-dependent (off in PG with
+			// standard_conforming_strings, on in MySQL/E-strings), so a string
+			// containing one could terminate early on some targets and break
+			// out of the literal — reject rather than guess.
+			if c == '\\' {
+				return fmt.Errorf("backslash escape in string literal (dialect-dependent)")
+			}
+			if c == '\'' {
+				if i+1 < len(s) && s[i+1] == '\'' { // escaped ''
+					i++
+					continue
+				}
+				inSingle = false
+			}
+		case inDouble:
+			if c == '"' {
+				inDouble = false
+			}
+		case c == '\'':
+			inSingle = true
+		case c == '"':
+			inDouble = true
+		case c == '(':
+			depth++
+		case c == ')':
+			depth--
+			if depth < 0 {
+				return fmt.Errorf("unbalanced parentheses")
+			}
+		case c == ';':
+			return fmt.Errorf("contains a statement separator %q", ";")
+		case c == ',' && depth == 0:
+			return fmt.Errorf("contains a top-level comma (would inject a column)")
+		case c == '-' && i+1 < len(s) && s[i+1] == '-':
+			// A line comment would comment out the rest of the DDL line (the
+			// separating comma or closing paren).
+			return fmt.Errorf("contains a line comment %q", "--")
+		case c == '/' && i+1 < len(s) && s[i+1] == '*':
+			return fmt.Errorf("contains a block comment %q", "/*")
+		}
+	}
+	if depth != 0 {
+		return fmt.Errorf("unbalanced parentheses")
+	}
+	if inSingle || inDouble {
+		return fmt.Errorf("unterminated quoted string")
+	}
+	return nil
+}
+
 func parseExpressionFix(response string) (*ExpressionFix, error) {
 	response = strings.TrimSpace(response)
 	response = strings.TrimPrefix(response, "```json")

--- a/internal/driver/ai_schemafix_test.go
+++ b/internal/driver/ai_schemafix_test.go
@@ -53,3 +53,45 @@ func TestBuildExpressionFixPrompt_ScopesToOneExpression(t *testing.T) {
 		t.Error("expression-fix prompt should not mention CREATE TABLE")
 	}
 }
+
+func TestValidateTargetExpression(t *testing.T) {
+	ok := []string{
+		"CURRENT_DATE",
+		"NOW() + INTERVAL '1 year'",
+		"(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::date",
+		"gen_random_uuid()",
+		"'a, b; c'", // commas/semicolons inside a string literal are fine
+	}
+	for _, e := range ok {
+		if err := ValidateTargetExpression(e); err != nil {
+			t.Errorf("ValidateTargetExpression(%q) = %v, want nil", e, err)
+		}
+	}
+	bad := []string{
+		"",
+		"1), (\"hacked\" text DEFAULT (2", // injects a column
+		"1; DROP TABLE users",             // statement separator
+		"now() + interval '1 year",        // unterminated string
+		"foo(()",                          // unbalanced parens
+		"1, 2",                            // top-level comma
+		"NOW() --",                        // line comment hides the separating comma
+		"NOW() /* x",                      // block comment swallows the rest
+		`'a\'`,                            // backslash escape can break out on some dialects
+	}
+	for _, e := range bad {
+		if err := ValidateTargetExpression(e); err == nil {
+			t.Errorf("ValidateTargetExpression(%q) = nil, want error", e)
+		}
+	}
+}
+
+func TestDefaultExpressionsEquivalent(t *testing.T) {
+	// The #127 idiom translates into a known class -> confirmable.
+	if !DefaultExpressionsEquivalent("(convert(date,getdate()))", "CURRENT_DATE") {
+		t.Error("CONVERT(date,getdate()) should be class-equivalent to CURRENT_DATE")
+	}
+	// A novel translation the comparator can't equate -> review.
+	if DefaultExpressionsEquivalent("(dateadd(year,(1),getdate()))", "NOW() + INTERVAL '1 year'") {
+		t.Error("dateadd vs now()+interval should NOT be mechanically confirmed equivalent")
+	}
+}

--- a/internal/driver/verify_compare.go
+++ b/internal/driver/verify_compare.go
@@ -520,6 +520,17 @@ func dataTypeClass(dialect string, c Column) string {
 // matches (e.g. current_date ≠ current_dt — that would be a real fidelity
 // loss). "other:..." results compare equal iff the normalized expressions
 // match exactly — safety floor for unknown defaults.
+// DefaultExpressionsEquivalent reports whether two default expressions resolve
+// to the same semantic class — the deterministic equivalence check the drift /
+// AI-review comparator uses (defaultExpressionClass). It is used to verify that
+// an AI-translated default preserves the source's default class. A "review"
+// (false) result does not mean the translation is wrong, only that SMT cannot
+// mechanically prove it equivalent (the comparator can't equate, say,
+// DATEADD(year,1,GETDATE()) with NOW() + INTERVAL '1 year').
+func DefaultExpressionsEquivalent(source, target string) bool {
+	return defaultExpressionClass(source) == defaultExpressionClass(target)
+}
+
 func defaultExpressionClass(expr string) string {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {

--- a/internal/orchestrator/diagnose.go
+++ b/internal/orchestrator/diagnose.go
@@ -61,7 +61,7 @@ func (o *Orchestrator) diagnoseSchemaFailure(ctx context.Context, table, schema,
 // any provider/parse/re-render failure here is swallowed (debug-logged) so it
 // can never mask the real error.
 func (o *Orchestrator) suggestSchemaFix(ctx context.Context, runID string, renderer createDDLRenderer, t *driver.Table, cause error) {
-	if o.config == nil || !o.config.AIReview.SuggestFixes || cause == nil || t == nil {
+	if o.config == nil || !aiSuggestFixesEnabled(o.config) || cause == nil || t == nil {
 		return
 	}
 	var exprErr *driver.ExpressionRenderError
@@ -94,6 +94,12 @@ func (o *Orchestrator) suggestSchemaFix(ctx context.Context, runID string, rende
 		logging.Debug("AI expression fix unavailable: %v", err)
 		return
 	}
+	// Structural guard: a malformed expression must not be spliced verbatim
+	// (it could inject extra columns/statements into the DDL).
+	if err := driver.ValidateTargetExpression(fix.Expression); err != nil {
+		logging.Debug("AI expression fix rejected (not a single value expression): %v", err)
+		return
+	}
 
 	// Re-render the whole table deterministically with ONLY the failing
 	// expression overridden by the AI translation.
@@ -106,24 +112,33 @@ func (o *Orchestrator) suggestSchemaFix(ctx context.Context, runID string, rende
 		return
 	}
 
+	// Deterministic verification: does the AI translation resolve to the same
+	// default class as the source? A "review" result is honest, not a failure —
+	// SMT just can't mechanically prove novel expressions equivalent.
+	classMatched := driver.DefaultExpressionsEquivalent(exprErr.SourceExpr, fix.Expression)
+
 	o.suggestOnce.Do(func() {
-		content := renderSuggestionFile(t.Name, exprErr, fix, ddl)
+		content := renderSuggestionFile(t.Name, exprErr, fix, ddl, classMatched)
 		if werr := o.writeSQLArtifact(runID, "schema.suggested.sql", content); werr != nil {
 			logging.Debug("writing schema.suggested.sql: %v", werr)
 			return
 		}
-		logging.Warn("AI-suggested fix written to %s — UNVERIFIED; review before applying. SMT did NOT apply it.",
-			filepath.Join(o.ddlArtifactDir(runID), "schema.suggested.sql"))
+		verdict := "review the translated expression (class not mechanically confirmed)"
+		if classMatched {
+			verdict = "translated default matches the source default class"
+		}
+		logging.Warn("AI-assisted fix written to %s — %s. Review before applying; SMT did NOT apply it.",
+			filepath.Join(o.ddlArtifactDir(runID), "schema.suggested.sql"), verdict)
 	})
 }
 
 // renderSuggestionFile wraps SMT's deterministic DDL (with one AI-translated
 // expression spliced in) in a banner that makes the provenance — which single
 // expression came from the AI — unmistakable.
-func renderSuggestionFile(table string, exprErr *driver.ExpressionRenderError, fix *driver.ExpressionFix, ddl string) string {
+func renderSuggestionFile(table string, exprErr *driver.ExpressionRenderError, fix *driver.ExpressionFix, ddl string, classMatched bool) string {
 	var b strings.Builder
 	b.WriteString("-- ============================================================\n")
-	b.WriteString("-- AI-ASSISTED FIX · UNVERIFIED · review before applying\n")
+	b.WriteString("-- AI-ASSISTED FIX · review before applying\n")
 	b.WriteString("--\n")
 	b.WriteString("-- This is SMT's deterministic DDL with ONE expression translated by\n")
 	b.WriteString("-- an AI model. SMT did not and will not apply it automatically.\n")
@@ -133,7 +148,17 @@ func renderSuggestionFile(table string, exprErr *driver.ExpressionRenderError, f
 	if strings.TrimSpace(fix.Explanation) != "" {
 		b.WriteString("-- Note: " + oneLine(fix.Explanation) + "\n")
 	}
-	b.WriteString(fmt.Sprintf("-- Confidence: %s\n", fix.Confidence))
+	b.WriteString(fmt.Sprintf("-- Confidence: %s (AI)\n", fix.Confidence))
+	b.WriteString("--\n")
+	b.WriteString("-- Verification (deterministic): every column type, length, nullability,\n")
+	b.WriteString("-- identity, and all other defaults are SMT's deterministic output — only\n")
+	b.WriteString("-- the one DEFAULT above is AI-authored.\n")
+	if classMatched {
+		b.WriteString("--   [OK] the translated default matches the source's default class.\n")
+	} else {
+		b.WriteString("--   [REVIEW] SMT could not mechanically confirm the translated default\n")
+		b.WriteString("--   is equivalent to the source — review it before applying.\n")
+	}
 	b.WriteString("-- ============================================================\n\n")
 	b.WriteString(strings.TrimSpace(ddl))
 	b.WriteString(";\n")

--- a/internal/orchestrator/diagnose_test.go
+++ b/internal/orchestrator/diagnose_test.go
@@ -59,16 +59,29 @@ func TestRenderSuggestionFile_LabeledAndProvenanced(t *testing.T) {
 		&driver.ExpressionRenderError{Column: "ExpiresAt", Kind: "default", SourceExpr: "dateadd(year,1,getdate())"},
 		&driver.ExpressionFix{Expression: "CURRENT_TIMESTAMP + INTERVAL '1 year'", Explanation: "interval arithmetic", Confidence: "high"},
 		`CREATE TABLE "subscriptions" ("expiresat" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP + INTERVAL '1 year')`,
+		false, // class not confirmed
 	)
 	for _, want := range []string{
-		"AI-ASSISTED", "UNVERIFIED", "did not and will not apply it",
+		"AI-ASSISTED", "review before applying", "did not and will not apply it",
 		"dbo.Subscriptions", "ExpiresAt (default)",
 		"dateadd(year,1,getdate())  ->  CURRENT_TIMESTAMP + INTERVAL '1 year'",
 		"Confidence: high", `CREATE TABLE "subscriptions"`,
+		"[REVIEW]", // verification verdict for an unconfirmed class
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("suggestion file missing %q:\n%s", want, out)
 		}
+	}
+}
+
+// A class-confirmed translation stamps [OK] rather than [REVIEW].
+func TestRenderSuggestionFile_ClassMatchedStampsOK(t *testing.T) {
+	out := renderSuggestionFile("T",
+		&driver.ExpressionRenderError{Column: "d", Kind: "default", SourceExpr: "(convert(date,getdate()))"},
+		&driver.ExpressionFix{Expression: "CURRENT_DATE", Confidence: "high"},
+		"CREATE TABLE t (d date)", true)
+	if !strings.Contains(out, "[OK]") || strings.Contains(out, "[REVIEW]") {
+		t.Errorf("expected [OK] verdict, got:\n%s", out)
 	}
 }
 
@@ -80,12 +93,39 @@ func TestRenderSuggestionFile_SanitizesMultilineBannerFields(t *testing.T) {
 		&driver.ExpressionRenderError{Column: "c", Kind: "default", SourceExpr: "x\nDROP TABLE users; --"},
 		&driver.ExpressionFix{Expression: "1\nDELETE FROM secrets;", Explanation: "ok\nrm -rf /", Confidence: "low"},
 		"CREATE TABLE t (c int)",
+		false,
 	)
 	header := strings.SplitN(out, "\n\nCREATE TABLE", 2)[0]
 	for _, line := range strings.Split(header, "\n") {
 		if line != "" && !strings.HasPrefix(line, "--") {
 			t.Errorf("non-comment line escaped into the banner: %q", line)
 		}
+	}
+}
+
+// suggest_fixes is opt-out: an omitted value follows diagnose_failures.
+func TestAISuggestFixesEnabled_OptOutFollowsDiagnose(t *testing.T) {
+	on, off := true, false
+	cases := []struct {
+		name      string
+		diagnose  bool
+		suggest   *bool
+		wantEnabl bool
+	}{
+		{"omitted follows diagnose on", true, nil, true},
+		{"omitted follows diagnose off", false, nil, false},
+		{"explicit false overrides diagnose on", true, &off, false},
+		{"explicit true overrides diagnose off", false, &on, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.AIReview.DiagnoseFailures = tc.diagnose
+			cfg.AIReview.SuggestFixes = tc.suggest
+			if got := aiSuggestFixesEnabled(cfg); got != tc.wantEnabl {
+				t.Errorf("aiSuggestFixesEnabled = %v, want %v", got, tc.wantEnabl)
+			}
+		})
 	}
 }
 
@@ -103,7 +143,8 @@ func TestSuggestSchemaFix_DisabledIsNoOp(t *testing.T) {
 // suggestion (no whole-table rewrite) — even with suggest_fixes on.
 func TestSuggestSchemaFix_NonExpressionFailureNoSuggestion(t *testing.T) {
 	cfg := &config.Config{}
-	cfg.AIReview.SuggestFixes = true
+	on := true
+	cfg.AIReview.SuggestFixes = &on
 	o := &Orchestrator{config: cfg}
 	// A plain error (not *driver.ExpressionRenderError) must short-circuit
 	// before resolving a provider.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -112,6 +112,17 @@ func aiReviewEnabled(cfg *config.Config) bool {
 	return cfg.AIReview.Enabled != nil && *cfg.AIReview.Enabled
 }
 
+// aiSuggestFixesEnabled reports whether AI fix suggestions are on. It is
+// opt-out: a nil (omitted) value follows diagnose_failures, applied by config
+// normalization; this helper also treats nil as diagnose_failures so callers
+// that build a Config directly (tests) behave consistently.
+func aiSuggestFixesEnabled(cfg *config.Config) bool {
+	if cfg.AIReview.SuggestFixes != nil {
+		return *cfg.AIReview.SuggestFixes
+	}
+	return cfg.AIReview.DiagnoseFailures
+}
+
 // Close releases all underlying resources.
 func (o *Orchestrator) Close() {
 	if o.source != nil {


### PR DESCRIPTION
Stage 2 of #134 (after the targeted splice in #135). Adds deterministic verification of the spliced suggestion, and makes `suggest_fixes` opt-out per your note ("if we're asking the AI for help then we want all of the help").

## Verification — deterministic, no AI, no target side effects

A `create` preview must not touch the target, and local DDL parsing would need CGO (off in this project). So verification is two deterministic checks:

- **Structural guard** — `driver.ValidateTargetExpression` rejects an AI expression that isn't a single self-contained value (unbalanced parens/quotes, a `;`, or a top-level comma), so it can't break out of the `DEFAULT` clause and inject columns/statements. A rejected expression is **not spliced** (no broken suggestion is written).
- **Class check** — `driver.DefaultExpressionsEquivalent` reuses the comparator's `defaultExpressionClass` to ask whether the translated default resolves to the same class as the source. The banner stamps:
  - `[OK]` — confirmed (e.g. `CONVERT(date,GETDATE())` → `CURRENT_DATE`), or
  - `[REVIEW]` — SMT can't mechanically prove equivalence (e.g. `DATEADD(year,1,GETDATE())` → `NOW() + INTERVAL '1 year'`). Honest, not a failure.

The banner also states the structural guarantee: **only the one DEFAULT is AI-authored; every other column/type/default is SMT's deterministic output.** (That's the meaningful remnant of `CompareColumns` for mode B — the columns are the source columns by construction, so a full parse+compare would be trivially equal.)

## Opt-out

`ai_review.suggest_fixes` is now `*bool` and defaults to `diagnose_failures`. Enable AI failure help → you get suggestions too; set `suggest_fixes: false` for diagnosis-only.

## Live (mssql→pg, only `diagnose_failures: true`, `suggest_fixes` omitted)

```
-- AI-translated: (dateadd(year,(1),getdate()))  ->  now() + interval '1 year'
-- Verification (deterministic): every column type, length, nullability,
-- identity, and all other defaults are SMT's deterministic output — only
-- the one DEFAULT above is AI-authored.
--   [REVIEW] SMT could not mechanically confirm the translated default
--   is equivalent to the source — review it before applying.
```
The suggestion was produced even though `suggest_fixes` was omitted (opt-out), and the verdict is honestly `[REVIEW]`.

Tests: validator (accepts real expressions / rejects injection), class equivalence (`[OK]`/`[REVIEW]`), opt-out matrix, banner verdict. `go test ./... -short` and `golangci-lint` green.

Remaining (#134): CHECK-expression splice, and the opt-in `--apply-suggested`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)