### PR TITLE
Add --apply-suggested: splice the AI fix into the plan and continue (#134)

### DIFF
--- a/cmd/smt/run.go
+++ b/cmd/smt/run.go
@@ -28,6 +28,7 @@ func createCommand() *cli.Command {
 			&cli.StringFlag{Name: "out", Aliases: []string{"o"}, Value: "schema.sql", Usage: "Output file when not applying"},
 			&cli.StringFlag{Name: "source-schema", Usage: "Override source schema from config"},
 			&cli.StringFlag{Name: "target-schema", Usage: "Override target schema from config"},
+			&cli.BoolFlag{Name: "apply-suggested", Usage: "On a single-expression render failure, splice the AI-translated fix into the plan and continue instead of aborting (requires an AI provider; AI-authored content is included and clearly marked)"},
 		},
 		Action: runCreate,
 	}
@@ -50,8 +51,9 @@ func runCreate(c *cli.Context) error {
 			return err
 		}
 		orch, err := orchestrator.NewWithOptions(cfg, orchestrator.Options{
-			StateFile:  c.String("state-file"),
-			SourceOnly: true,
+			StateFile:      c.String("state-file"),
+			SourceOnly:     true,
+			ApplySuggested: c.Bool("apply-suggested"),
 		})
 		if err != nil {
 			return err
@@ -77,7 +79,8 @@ func runCreate(c *cli.Context) error {
 		return err
 	}
 	orch, err := orchestrator.NewWithOptions(cfg, orchestrator.Options{
-		StateFile: c.String("state-file"),
+		StateFile:      c.String("state-file"),
+		ApplySuggested: c.Bool("apply-suggested"),
 	})
 	if err != nil {
 		return err

--- a/cmd/smt/run_test.go
+++ b/cmd/smt/run_test.go
@@ -77,7 +77,9 @@ func TestCLIFlagInfoCoversGlobals(t *testing.T) {
 			t.Errorf("command flag %s wrongly marked global", name)
 		}
 	}
-	if info.TakesValue["--apply"] {
-		t.Error("bool flag --apply wrongly marked as value-taking")
+	for _, name := range []string{"--apply", "--apply-suggested"} {
+		if info.TakesValue[name] {
+			t.Errorf("bool flag %s wrongly marked as value-taking", name)
+		}
 	}
 }

--- a/internal/orchestrator/ddl_plan.go
+++ b/internal/orchestrator/ddl_plan.go
@@ -203,9 +203,11 @@ func (o *Orchestrator) renderCreateTableStatements(ctx context.Context, runID st
 	if err := runParallel(ctx, o.tables, o.aiConcurrency(), func(ctx context.Context, i int, t source.Table) error {
 		ddl, err := renderer.renderTable(ctx, &t)
 		if err != nil {
-			o.diagnoseSchemaFailure(ctx, t.Name, t.Schema, "rendering CREATE TABLE DDL", err)
-			o.suggestSchemaFix(ctx, runID, renderer, &t, err)
-			return fmt.Errorf("rendering table %s: %w", t.Name, err)
+			fixedDDL, applied := o.handleRenderFailure(ctx, runID, renderer, &t, err)
+			if !applied {
+				return fmt.Errorf("rendering table %s: %w", t.Name, err)
+			}
+			ddl = fixedDDL
 		}
 		ddl = stripTrailingSemicolons(ddl)
 		tableName := driver.NormalizeIdentifier(renderer.targetType, t.Name)

--- a/internal/orchestrator/diagnose.go
+++ b/internal/orchestrator/diagnose.go
@@ -44,29 +44,67 @@ func (o *Orchestrator) diagnoseSchemaFailure(ctx context.Context, table, schema,
 	driver.EmitDiagnosis(diagnosis)
 }
 
-// suggestSchemaFix is the opt-in AI fix-suggestion hook (ai_review.
-// suggest_fixes). On a render failure caused by ONE unsupported expression, it
-// asks the AI to translate just that expression, splices it into SMT's own
-// deterministic DDL (re-rendering the whole table through the deterministic
-// renderer with the one expression overridden), and writes the result to a
-// clearly-labeled schema.suggested.sql.
+// splicedFix is the outcome of translating one failing expression and
+// re-rendering the table with it overridden.
+type splicedFix struct {
+	exprErr      *driver.ExpressionRenderError
+	fix          *driver.ExpressionFix
+	ddl          string // SMT's deterministic DDL with the one expression spliced
+	classMatched bool   // deterministic class-equivalence verdict
+}
+
+// handleRenderFailure runs the failure advisories for a single-table render
+// error and, when --apply-suggested is set, splices the AI fix into the plan.
+// It returns the (marked) spliced DDL and true when the table was fixed
+// in-place; false means the caller must return the original error.
 //
-// The AI never authors a whole table: only the one failing expression comes
-// from the model; everything else is SMT's deterministic output. If the failure
-// isn't a single splice-able expression, no suggestion is written (the diagnosis
-// still advises).
-//
-// SUGGESTION only: never written to schema.sql, never applied (that needs the
-// explicit --apply-suggested flag). The caller still returns the original error;
-// any provider/parse/re-render failure here is swallowed (debug-logged) so it
-// can never mask the real error.
-func (o *Orchestrator) suggestSchemaFix(ctx context.Context, runID string, renderer createDDLRenderer, t *driver.Table, cause error) {
-	if o.config == nil || !aiSuggestFixesEnabled(o.config) || cause == nil || t == nil {
-		return
+// AI-authored content reaches the plan / schema.sql ONLY here, and only under
+// the explicit --apply-suggested flag — loudly logged and marked inline.
+func (o *Orchestrator) handleRenderFailure(ctx context.Context, runID string, renderer createDDLRenderer, t *driver.Table, cause error) (string, bool) {
+	if o.config == nil || t == nil {
+		return "", false
+	}
+	o.diagnoseSchemaFailure(ctx, t.Name, t.Schema, "rendering CREATE TABLE DDL", cause)
+
+	// Only do the (one) AI splice call if a suggestion or apply is actually
+	// requested.
+	if !aiSuggestFixesEnabled(o.config) && !o.opts.ApplySuggested {
+		return "", false
+	}
+	sf, ok := o.spliceFix(ctx, renderer, t, cause)
+	if !ok {
+		return "", false
+	}
+	if aiSuggestFixesEnabled(o.config) {
+		o.writeSuggestion(runID, t.Name, sf)
+	}
+	if !o.opts.ApplySuggested {
+		return "", false
+	}
+
+	verdict := "OK: default class matches source"
+	if !sf.classMatched {
+		verdict = "REVIEW: class NOT mechanically confirmed"
+	}
+	logging.Warn("APPLYING AI-ASSISTED FIX (--apply-suggested): table %s, column %s DEFAULT  %s -> %s  [%s]. This expression was authored by an AI model.",
+		oneLine(t.Name), oneLine(sf.exprErr.Column), oneLine(sf.exprErr.SourceExpr), oneLine(sf.fix.Expression), verdict)
+	marker := fmt.Sprintf("-- AI-ASSISTED FIX (--apply-suggested): %s DEFAULT  %s -> %s  [%s]\n",
+		oneLine(sf.exprErr.Column), oneLine(sf.exprErr.SourceExpr), oneLine(sf.fix.Expression), verdict)
+	return marker + sf.ddl, true
+}
+
+// spliceFix attempts the AI splice for a single-expression render failure:
+// translate the one failing expression and re-render the table with it
+// overridden. ok=false (debug-logged) when the failure isn't a single
+// splice-able default, no provider is available, the AI expression is malformed,
+// or the re-render fails. Performs exactly one AI call.
+func (o *Orchestrator) spliceFix(ctx context.Context, renderer createDDLRenderer, t *driver.Table, cause error) (*splicedFix, bool) {
+	if o.config == nil || cause == nil || t == nil {
+		return nil, false
 	}
 	var exprErr *driver.ExpressionRenderError
 	if !errors.As(cause, &exprErr) || exprErr.Kind != "default" {
-		return // not a single splice-able expression — diagnosis-only
+		return nil, false // not a single splice-able expression — diagnosis-only
 	}
 	idx := -1
 	for i := range t.Columns {
@@ -76,11 +114,11 @@ func (o *Orchestrator) suggestSchemaFix(ctx context.Context, runID string, rende
 		}
 	}
 	if idx < 0 {
-		return
+		return nil, false
 	}
 	suggester := o.errorDiagnoser()
 	if suggester == nil {
-		return
+		return nil, false
 	}
 	fix, err := suggester.SuggestExpressionFix(ctx, driver.FixRequest{
 		Kind:          exprErr.Kind,
@@ -92,13 +130,13 @@ func (o *Orchestrator) suggestSchemaFix(ctx context.Context, runID string, rende
 	})
 	if err != nil {
 		logging.Debug("AI expression fix unavailable: %v", err)
-		return
+		return nil, false
 	}
 	// Structural guard: a malformed expression must not be spliced verbatim
 	// (it could inject extra columns/statements into the DDL).
 	if err := driver.ValidateTargetExpression(fix.Expression); err != nil {
 		logging.Debug("AI expression fix rejected (not a single value expression): %v", err)
-		return
+		return nil, false
 	}
 
 	// Re-render the whole table deterministically with ONLY the failing
@@ -109,25 +147,31 @@ func (o *Orchestrator) suggestSchemaFix(ctx context.Context, runID string, rende
 	ddl, rerr := renderer.renderTable(ctx, &spliced)
 	if rerr != nil {
 		logging.Debug("re-render with AI expression failed: %v", rerr)
-		return
+		return nil, false
 	}
+	return &splicedFix{
+		exprErr:      exprErr,
+		fix:          fix,
+		ddl:          ddl,
+		classMatched: driver.DefaultExpressionsEquivalent(exprErr.SourceExpr, fix.Expression),
+	}, true
+}
 
-	// Deterministic verification: does the AI translation resolve to the same
-	// default class as the source? A "review" result is honest, not a failure —
-	// SMT just can't mechanically prove novel expressions equivalent.
-	classMatched := driver.DefaultExpressionsEquivalent(exprErr.SourceExpr, fix.Expression)
-
+// writeSuggestion writes the AI-assisted suggestion to schema.suggested.sql,
+// once even under concurrent failures (suggest_fixes path). It never writes to
+// schema.sql and the run still fails — review-only.
+func (o *Orchestrator) writeSuggestion(runID, table string, sf *splicedFix) {
 	o.suggestOnce.Do(func() {
-		content := renderSuggestionFile(t.Name, exprErr, fix, ddl, classMatched)
+		content := renderSuggestionFile(table, sf.exprErr, sf.fix, sf.ddl, sf.classMatched)
 		if werr := o.writeSQLArtifact(runID, "schema.suggested.sql", content); werr != nil {
 			logging.Debug("writing schema.suggested.sql: %v", werr)
 			return
 		}
 		verdict := "review the translated expression (class not mechanically confirmed)"
-		if classMatched {
+		if sf.classMatched {
 			verdict = "translated default matches the source default class"
 		}
-		logging.Warn("AI-assisted fix written to %s — %s. Review before applying; SMT did NOT apply it.",
+		logging.Warn("AI-assisted fix written to %s — %s. Review before applying; SMT did NOT apply it (use --apply-suggested to apply).",
 			filepath.Join(o.ddlArtifactDir(runID), "schema.suggested.sql"), verdict)
 	})
 }

--- a/internal/orchestrator/diagnose_test.go
+++ b/internal/orchestrator/diagnose_test.go
@@ -129,29 +129,32 @@ func TestAISuggestFixesEnabled_OptOutFollowsDiagnose(t *testing.T) {
 	}
 }
 
-// suggest_fixes off is a no-op: no provider resolved, nothing written.
-func TestSuggestSchemaFix_DisabledIsNoOp(t *testing.T) {
-	o := &Orchestrator{config: &config.Config{}} // SuggestFixes defaults false
-	o.suggestSchemaFix(context.Background(), "run1", createDDLRenderer{},
+// With both suggest_fixes and --apply-suggested off, the render failure is a
+// no-op: no AI splice attempted, the table is not "applied", nothing written.
+func TestHandleRenderFailure_DisabledIsNoOp(t *testing.T) {
+	o := &Orchestrator{config: &config.Config{}} // SuggestFixes nil/false, ApplySuggested false
+	ddl, applied := o.handleRenderFailure(context.Background(), "run1", createDDLRenderer{},
 		&driver.Table{Name: "T", Schema: "dbo"}, errors.New("boom"))
+	if applied || ddl != "" {
+		t.Errorf("expected no fix applied, got applied=%v ddl=%q", applied, ddl)
+	}
 	if o.diagnoser != nil {
-		t.Error("provider resolved while suggest_fixes is disabled")
+		t.Error("provider resolved while both features are disabled")
 	}
 }
 
-// A failure that isn't a single splice-able expression must not produce a
-// suggestion (no whole-table rewrite) — even with suggest_fixes on.
-func TestSuggestSchemaFix_NonExpressionFailureNoSuggestion(t *testing.T) {
-	cfg := &config.Config{}
-	on := true
-	cfg.AIReview.SuggestFixes = &on
-	o := &Orchestrator{config: cfg}
-	// A plain error (not *driver.ExpressionRenderError) must short-circuit
-	// before resolving a provider.
-	o.suggestSchemaFix(context.Background(), "run1", createDDLRenderer{},
+// A failure that isn't a single splice-able expression must not be fixed (no
+// whole-table rewrite) — even with --apply-suggested on it must abort.
+func TestHandleRenderFailure_NonExpressionFailureNotApplied(t *testing.T) {
+	o := &Orchestrator{config: &config.Config{}, opts: Options{ApplySuggested: true}}
+	// A plain error (not *driver.ExpressionRenderError) can't be spliced.
+	ddl, applied := o.handleRenderFailure(context.Background(), "run1", createDDLRenderer{},
 		&driver.Table{Name: "T", Schema: "dbo"}, errors.New("unsupported source type \"geography\""))
+	if applied || ddl != "" {
+		t.Errorf("non-expression failure must not be applied, got applied=%v", applied)
+	}
 	if o.diagnoser != nil {
-		t.Error("provider resolved for a non-expression failure; should be diagnosis-only")
+		t.Error("provider resolved for a non-expression failure; should abort")
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -37,6 +37,12 @@ type Options struct {
 
 	// SourceOnly skips the target connection (used by inspection commands).
 	SourceOnly bool
+
+	// ApplySuggested makes a single-expression render failure splice the AI
+	// fix and continue (instead of aborting), so the AI-assisted DDL becomes
+	// part of the plan. Explicit, off by default, and loud — the only path by
+	// which AI-authored content reaches schema.sql / the applied DDL (#134).
+	ApplySuggested bool
 }
 
 // Orchestrator opens source/target connections via the driver registry and


### PR DESCRIPTION
The apply UX for AI-assisted fixes (#134). Closes the loop after the suggestion (#135) and verification (#136).

## Behavior

With `--apply-suggested`, a single-expression render failure no longer aborts: SMT translates the one failing expression, splices it into its **deterministic** DDL, and continues — so the fixed table joins the plan (`create` writes it to `schema.sql`; `create --apply` applies it). **Off by default, loud.**

The two-step review flow stays intact:
- **Run 1** (no flag): writes `schema.suggested.sql` for review and **aborts** (nothing applied).
- **Run 2** (`--apply-suggested`): splices and applies.

## Safety

This is the **only** path by which AI-authored content reaches `schema.sql` / the applied DDL, and only under the explicit flag:
- Loud per-table log: `APPLYING AI-ASSISTED FIX (--apply-suggested): table …, column … DEFAULT  <src> -> <ai>  [OK|REVIEW]. This expression was authored by an AI model.`
- Inline marker in `schema.sql` above the table, so the applied artifact is self-documenting.
- A non-splice-able failure aborts even with the flag (no whole-table rewrite). No provider → aborts (best-effort; original error returned).
- The spliced expression still goes through the structural validator (no injection) and the class-equivalence verdict from #136.

## Implementation

`Options.ApplySuggested`; the render-failure path refactored into `handleRenderFailure` → `spliceFix` (reusable: `errors.As` the structured `ExpressionRenderError`, AI-translate the one expression, validate, re-render with the per-column override) + `writeSuggestion`. Exactly one AI call per failing table.

## Live (mssql→pg, `DATEADD` default)

```
APPLYING AI-ASSISTED FIX (--apply-suggested): table Subscriptions, column ExpiresAt DEFAULT  (dateadd(year,(1),getdate())) -> now() + interval '1 year'  [REVIEW: class NOT mechanically confirmed]. This expression was authored by an AI model.
Schema build complete in 3.066s (1 tables)
```
→ table created on Postgres with `expiresat DEFAULT (now() + '1 year'::interval)`; `schema.sql` carries the inline marker. Without the flag the same run writes `schema.suggested.sql` and aborts (0 tables).

`go test ./... -short`, cmd flag test, and `golangci-lint` green.

Remaining (#134): CHECK-expression splice (currently DEFAULT only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)