### PR TITLE
Extend the AI fix splice to CHECK constraints (#134)

### DIFF
--- a/internal/driver/ai_schemafix.go
+++ b/internal/driver/ai_schemafix.go
@@ -72,10 +72,16 @@ func buildExpressionFixPrompt(req FixRequest) string {
 
 // ValidateTargetExpression rejects an AI-proposed expression that isn't a single
 // self-contained value expression, so splicing it verbatim into a column's
-// DEFAULT clause can't break out and inject extra columns or statements into the
-// CREATE TABLE. It checks: non-empty, balanced parens/quotes, and no top-level
-// (unquoted, unparenthesized) comma or semicolon. It is a structural guard, not
-// a semantic or dialect validator.
+// DEFAULT clause (or a CHECK predicate) can't break out and inject extra
+// columns or statements. It checks: non-empty, balanced parens/quotes, no SQL
+// comment, and no top-level (unquoted, unparenthesized) comma or semicolon. It
+// is a structural guard, not a semantic validator.
+//
+// It assumes a target where backslashes are literal inside string literals
+// (PostgreSQL with standard_conforming_strings — the splice is pg-only today),
+// so `'^\d+$'` is a safe string and quote integrity rests on balanced `'`
+// alone. A backslash-escaping target (MySQL/E-strings) would need a stricter
+// check before splicing there.
 func ValidateTargetExpression(expr string) error {
 	s := strings.TrimSpace(expr)
 	if s == "" {
@@ -87,13 +93,6 @@ func ValidateTargetExpression(expr string) error {
 		c := s[i]
 		switch {
 		case inSingle:
-			// Backslash escaping is dialect-dependent (off in PG with
-			// standard_conforming_strings, on in MySQL/E-strings), so a string
-			// containing one could terminate early on some targets and break
-			// out of the literal — reject rather than guess.
-			if c == '\\' {
-				return fmt.Errorf("backslash escape in string literal (dialect-dependent)")
-			}
 			if c == '\'' {
 				if i+1 < len(s) && s[i+1] == '\'' { // escaped ''
 					i++

--- a/internal/driver/ai_schemafix_test.go
+++ b/internal/driver/ai_schemafix_test.go
@@ -60,7 +60,9 @@ func TestValidateTargetExpression(t *testing.T) {
 		"NOW() + INTERVAL '1 year'",
 		"(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::date",
 		"gen_random_uuid()",
-		"'a, b; c'", // commas/semicolons inside a string literal are fine
+		"'a, b; c'",      // commas/semicolons inside a string literal are fine
+		`code ~ '^\d+$'`, // pg regex CHECK — backslashes are literal on pg
+		`'a\'`,           // a backslash is a literal char in a pg string (= a\)
 	}
 	for _, e := range ok {
 		if err := ValidateTargetExpression(e); err != nil {
@@ -76,7 +78,7 @@ func TestValidateTargetExpression(t *testing.T) {
 		"1, 2",                            // top-level comma
 		"NOW() --",                        // line comment hides the separating comma
 		"NOW() /* x",                      // block comment swallows the rest
-		`'a\'`,                            // backslash escape can break out on some dialects
+		"foo(',",                          // unterminated string (the ' opens a literal that never closes)
 	}
 	for _, e := range bad {
 		if err := ValidateTargetExpression(e); err == nil {

--- a/internal/driver/postgres/deterministic.go
+++ b/internal/driver/postgres/deterministic.go
@@ -321,11 +321,17 @@ func (r deterministicDDL) createCheckConstraint(t *driver.Table, chk *driver.Che
 		return "", fmt.Errorf("check constraint %s has no definition", chk.Name)
 	}
 
-	expr, err := r.sqlServerExpression(def)
-	if err != nil {
-		return "", fmt.Errorf("mapping check constraint %s: %w", chk.Name, err)
+	expr := strings.TrimSpace(chk.DefinitionOverride)
+	if expr == "" {
+		var err error
+		expr, err = r.sqlServerExpression(def)
+		if err != nil {
+			return "", &driver.ExpressionRenderError{
+				Column: chk.Name, Kind: "check", SourceExpr: chk.Definition, Err: err,
+			}
+		}
+		expr = r.rewriteBooleanComparisons(expr, t.Columns)
 	}
-	expr = r.rewriteBooleanComparisons(expr, t.Columns)
 
 	return fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s CHECK %s",
 		r.dialect.QualifyTable(targetSchema, tableName),

--- a/internal/driver/postgres/exprerror_test.go
+++ b/internal/driver/postgres/exprerror_test.go
@@ -53,3 +53,37 @@ func TestCreateTable_DefaultOverrideEmittedVerbatim(t *testing.T) {
 		t.Errorf("override not emitted verbatim:\n%s", ddl)
 	}
 }
+
+// An unsupported CHECK predicate must surface as a structured *ExpressionRenderError
+// (kind=check), so the AI fix-suggestion path can translate just that predicate (#134).
+func TestCreateCheck_UnsupportedIsStructured(t *testing.T) {
+	tbl := &driver.Table{Schema: "dbo", Name: "T", Columns: []driver.Column{{Name: "code", DataType: "varchar", MaxLength: 20}}}
+	chk := &driver.CheckConstraint{Name: "CK_T_code", Definition: "([code] like '[0-9]%' AND patindex('%abc%',[code])=0)"}
+	_, err := RenderCreateCheckConstraintDDLWithSource(tbl, chk, "public", "mssql")
+	if err == nil {
+		t.Skip("renderer accepted this predicate; pick a harder one if this starts passing")
+	}
+	var ex *driver.ExpressionRenderError
+	if !errors.As(err, &ex) {
+		t.Fatalf("check error is not *ExpressionRenderError: %v", err)
+	}
+	if ex.Kind != "check" || ex.Column != "CK_T_code" {
+		t.Errorf("unexpected structured error: kind=%q column=%q", ex.Kind, ex.Column)
+	}
+}
+
+// With the override set, the CHECK predicate is emitted verbatim (the splice point).
+func TestCreateCheck_DefinitionOverrideEmittedVerbatim(t *testing.T) {
+	tbl := &driver.Table{Schema: "dbo", Name: "T", Columns: []driver.Column{{Name: "code", DataType: "varchar", MaxLength: 20}}}
+	chk := &driver.CheckConstraint{
+		Name: "CK_T_code", Definition: "([code] like '[0-9]%')",
+		DefinitionOverride: "code ~ '^[0-9]'",
+	}
+	ddl, err := RenderCreateCheckConstraintDDLWithSource(tbl, chk, "public", "mssql")
+	if err != nil {
+		t.Fatalf("render check with override failed: %v", err)
+	}
+	if !strings.Contains(ddl, "CHECK (code ~ '^[0-9]')") {
+		t.Errorf("override not emitted verbatim:\n%s", ddl)
+	}
+}

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -360,6 +360,11 @@ type ForeignKey struct {
 type CheckConstraint struct {
 	Name       string `json:"name"`
 	Definition string `json:"definition"`
+	// DefinitionOverride, when set, is emitted verbatim as the CHECK predicate
+	// instead of translating Definition. Transient, runtime-only (not
+	// persisted) — the AI fix-suggestion splice point for a CHECK (#134),
+	// analogous to Column.DefaultExpressionOverride. Must be valid target DDL.
+	DefinitionOverride string `json:"-"`
 }
 
 // ValidateIdentifier checks if a database identifier (schema, table, column name)

--- a/internal/orchestrator/ddl_plan.go
+++ b/internal/orchestrator/ddl_plan.go
@@ -203,7 +203,7 @@ func (o *Orchestrator) renderCreateTableStatements(ctx context.Context, runID st
 	if err := runParallel(ctx, o.tables, o.aiConcurrency(), func(ctx context.Context, i int, t source.Table) error {
 		ddl, err := renderer.renderTable(ctx, &t)
 		if err != nil {
-			fixedDDL, applied := o.handleRenderFailure(ctx, runID, renderer, &t, err)
+			fixedDDL, applied := o.handleRenderFailure(ctx, runID, "rendering CREATE TABLE DDL", renderer, &t, err)
 			if !applied {
 				return fmt.Errorf("rendering table %s: %w", t.Name, err)
 			}
@@ -310,7 +310,11 @@ func (o *Orchestrator) renderCreateCheckStatements(ctx context.Context, runID st
 			chk := t.CheckConstraints[j]
 			ddl, err := renderer.renderCheck(ctx, &t, &chk)
 			if err != nil {
-				return fmt.Errorf("rendering check %s: %w", chk.Name, err)
+				fixedDDL, applied := o.handleRenderFailure(ctx, runID, "rendering CHECK constraint DDL", renderer, &t, err)
+				if !applied {
+					return fmt.Errorf("rendering check %s: %w", chk.Name, err)
+				}
+				ddl = fixedDDL
 			}
 			stmts = append(stmts, schemadiff.Statement{
 				Table:       driver.NormalizeIdentifier(renderer.targetType, t.Name),

--- a/internal/orchestrator/diagnose.go
+++ b/internal/orchestrator/diagnose.go
@@ -60,11 +60,11 @@ type splicedFix struct {
 //
 // AI-authored content reaches the plan / schema.sql ONLY here, and only under
 // the explicit --apply-suggested flag — loudly logged and marked inline.
-func (o *Orchestrator) handleRenderFailure(ctx context.Context, runID string, renderer createDDLRenderer, t *driver.Table, cause error) (string, bool) {
+func (o *Orchestrator) handleRenderFailure(ctx context.Context, runID, operation string, renderer createDDLRenderer, t *driver.Table, cause error) (string, bool) {
 	if o.config == nil || t == nil {
 		return "", false
 	}
-	o.diagnoseSchemaFailure(ctx, t.Name, t.Schema, "rendering CREATE TABLE DDL", cause)
+	o.diagnoseSchemaFailure(ctx, t.Name, t.Schema, operation, cause)
 
 	// Only do the (one) AI splice call if a suggestion or apply is actually
 	// requested.
@@ -82,40 +82,59 @@ func (o *Orchestrator) handleRenderFailure(ctx context.Context, runID string, re
 		return "", false
 	}
 
-	verdict := "OK: default class matches source"
+	verdict := "OK: expression class matches source"
 	if !sf.classMatched {
 		verdict = "REVIEW: class NOT mechanically confirmed"
 	}
-	logging.Warn("APPLYING AI-ASSISTED FIX (--apply-suggested): table %s, column %s DEFAULT  %s -> %s  [%s]. This expression was authored by an AI model.",
-		oneLine(t.Name), oneLine(sf.exprErr.Column), oneLine(sf.exprErr.SourceExpr), oneLine(sf.fix.Expression), verdict)
-	marker := fmt.Sprintf("-- AI-ASSISTED FIX (--apply-suggested): %s DEFAULT  %s -> %s  [%s]\n",
-		oneLine(sf.exprErr.Column), oneLine(sf.exprErr.SourceExpr), oneLine(sf.fix.Expression), verdict)
+	logging.Warn("APPLYING AI-ASSISTED FIX (--apply-suggested): table %s, %s %s:  %s -> %s  [%s]. This expression was authored by an AI model.",
+		oneLine(t.Name), oneLine(sf.exprErr.Kind), oneLine(sf.exprErr.Column), oneLine(sf.exprErr.SourceExpr), oneLine(sf.fix.Expression), verdict)
+	marker := fmt.Sprintf("-- AI-ASSISTED FIX (--apply-suggested): %s %s  %s -> %s  [%s]\n",
+		oneLine(sf.exprErr.Kind), oneLine(sf.exprErr.Column), oneLine(sf.exprErr.SourceExpr), oneLine(sf.fix.Expression), verdict)
 	return marker + sf.ddl, true
 }
 
 // spliceFix attempts the AI splice for a single-expression render failure:
-// translate the one failing expression and re-render the table with it
-// overridden. ok=false (debug-logged) when the failure isn't a single
-// splice-able default, no provider is available, the AI expression is malformed,
-// or the re-render fails. Performs exactly one AI call.
+// translate the one failing expression (a column DEFAULT or a CHECK predicate)
+// and re-render that object with it overridden, so everything but the one
+// expression stays SMT's deterministic output. ok=false (debug-logged) when the
+// failure isn't a single splice-able expression, no provider is available, the
+// AI expression is malformed, or the re-render fails. Performs exactly one AI
+// call.
 func (o *Orchestrator) spliceFix(ctx context.Context, renderer createDDLRenderer, t *driver.Table, cause error) (*splicedFix, bool) {
 	if o.config == nil || cause == nil || t == nil {
 		return nil, false
 	}
 	var exprErr *driver.ExpressionRenderError
-	if !errors.As(cause, &exprErr) || exprErr.Kind != "default" {
+	if !errors.As(cause, &exprErr) || (exprErr.Kind != "default" && exprErr.Kind != "check") {
 		return nil, false // not a single splice-able expression — diagnosis-only
 	}
-	idx := -1
-	for i := range t.Columns {
-		if t.Columns[i].Name == exprErr.Column {
-			idx = i
-			break
+
+	// Locate the failing object and capture the source column type (default only).
+	colIdx, chkIdx, colType := -1, -1, ""
+	switch exprErr.Kind {
+	case "default":
+		for i := range t.Columns {
+			if t.Columns[i].Name == exprErr.Column {
+				colIdx = i
+				colType = t.Columns[i].DataType
+				break
+			}
+		}
+		if colIdx < 0 {
+			return nil, false
+		}
+	case "check":
+		for i := range t.CheckConstraints {
+			if t.CheckConstraints[i].Name == exprErr.Column {
+				chkIdx = i
+				break
+			}
+		}
+		if chkIdx < 0 {
+			return nil, false
 		}
 	}
-	if idx < 0 {
-		return nil, false
-	}
+
 	suggester := o.errorDiagnoser()
 	if suggester == nil {
 		return nil, false
@@ -124,7 +143,7 @@ func (o *Orchestrator) spliceFix(ctx context.Context, renderer createDDLRenderer
 		Kind:          exprErr.Kind,
 		SourceExpr:    exprErr.SourceExpr,
 		ColumnName:    exprErr.Column,
-		ColumnType:    t.Columns[idx].DataType,
+		ColumnType:    colType,
 		SourceDialect: canonicalDBType(o.config.Source.Type),
 		TargetDialect: canonicalDBType(o.config.Target.Type),
 	})
@@ -139,22 +158,30 @@ func (o *Orchestrator) spliceFix(ctx context.Context, renderer createDDLRenderer
 		return nil, false
 	}
 
-	// Re-render the whole table deterministically with ONLY the failing
+	// Re-render the affected object deterministically with ONLY the failing
 	// expression overridden by the AI translation.
-	spliced := *t
-	spliced.Columns = append([]driver.Column(nil), t.Columns...)
-	spliced.Columns[idx].DefaultExpressionOverride = fix.Expression
-	ddl, rerr := renderer.renderTable(ctx, &spliced)
+	var ddl string
+	var rerr error
+	classMatched := false
+	switch exprErr.Kind {
+	case "default":
+		spliced := *t
+		spliced.Columns = append([]driver.Column(nil), t.Columns...)
+		spliced.Columns[colIdx].DefaultExpressionOverride = fix.Expression
+		ddl, rerr = renderer.renderTable(ctx, &spliced)
+		classMatched = driver.DefaultExpressionsEquivalent(exprErr.SourceExpr, fix.Expression)
+	case "check":
+		chk := t.CheckConstraints[chkIdx]
+		chk.DefinitionOverride = fix.Expression
+		ddl, rerr = renderer.renderCheck(ctx, t, &chk)
+		// No deterministic class check for a boolean CHECK predicate — always
+		// flagged for review.
+	}
 	if rerr != nil {
 		logging.Debug("re-render with AI expression failed: %v", rerr)
 		return nil, false
 	}
-	return &splicedFix{
-		exprErr:      exprErr,
-		fix:          fix,
-		ddl:          ddl,
-		classMatched: driver.DefaultExpressionsEquivalent(exprErr.SourceExpr, fix.Expression),
-	}, true
+	return &splicedFix{exprErr: exprErr, fix: fix, ddl: ddl, classMatched: classMatched}, true
 }
 
 // writeSuggestion writes the AI-assisted suggestion to schema.suggested.sql,
@@ -169,7 +196,7 @@ func (o *Orchestrator) writeSuggestion(runID, table string, sf *splicedFix) {
 		}
 		verdict := "review the translated expression (class not mechanically confirmed)"
 		if sf.classMatched {
-			verdict = "translated default matches the source default class"
+			verdict = "translated expression matches the source class"
 		}
 		logging.Warn("AI-assisted fix written to %s — %s. Review before applying; SMT did NOT apply it (use --apply-suggested to apply).",
 			filepath.Join(o.ddlArtifactDir(runID), "schema.suggested.sql"), verdict)
@@ -187,7 +214,7 @@ func renderSuggestionFile(table string, exprErr *driver.ExpressionRenderError, f
 	b.WriteString("-- This is SMT's deterministic DDL with ONE expression translated by\n")
 	b.WriteString("-- an AI model. SMT did not and will not apply it automatically.\n")
 	b.WriteString(fmt.Sprintf("-- Table:  %s\n", oneLine(table)))
-	b.WriteString(fmt.Sprintf("-- Column: %s (%s)\n", oneLine(exprErr.Column), oneLine(exprErr.Kind)))
+	b.WriteString(fmt.Sprintf("-- Object: %s (%s)\n", oneLine(exprErr.Column), oneLine(exprErr.Kind)))
 	b.WriteString(fmt.Sprintf("-- AI-translated: %s  ->  %s\n", oneLine(exprErr.SourceExpr), oneLine(fix.Expression)))
 	if strings.TrimSpace(fix.Explanation) != "" {
 		b.WriteString("-- Note: " + oneLine(fix.Explanation) + "\n")
@@ -195,13 +222,13 @@ func renderSuggestionFile(table string, exprErr *driver.ExpressionRenderError, f
 	b.WriteString(fmt.Sprintf("-- Confidence: %s (AI)\n", fix.Confidence))
 	b.WriteString("--\n")
 	b.WriteString("-- Verification (deterministic): every column type, length, nullability,\n")
-	b.WriteString("-- identity, and all other defaults are SMT's deterministic output — only\n")
-	b.WriteString("-- the one DEFAULT above is AI-authored.\n")
+	b.WriteString("-- identity, and all other defaults/constraints are SMT's deterministic\n")
+	b.WriteString("-- output — only the one expression above is AI-authored.\n")
 	if classMatched {
-		b.WriteString("--   [OK] the translated default matches the source's default class.\n")
+		b.WriteString("--   [OK] the translated expression matches the source class.\n")
 	} else {
-		b.WriteString("--   [REVIEW] SMT could not mechanically confirm the translated default\n")
-		b.WriteString("--   is equivalent to the source — review it before applying.\n")
+		b.WriteString("--   [REVIEW] SMT could not mechanically confirm the translated\n")
+		b.WriteString("--   expression is equivalent to the source — review it before applying.\n")
 	}
 	b.WriteString("-- ============================================================\n\n")
 	b.WriteString(strings.TrimSpace(ddl))

--- a/internal/orchestrator/diagnose_test.go
+++ b/internal/orchestrator/diagnose_test.go
@@ -133,7 +133,7 @@ func TestAISuggestFixesEnabled_OptOutFollowsDiagnose(t *testing.T) {
 // no-op: no AI splice attempted, the table is not "applied", nothing written.
 func TestHandleRenderFailure_DisabledIsNoOp(t *testing.T) {
 	o := &Orchestrator{config: &config.Config{}} // SuggestFixes nil/false, ApplySuggested false
-	ddl, applied := o.handleRenderFailure(context.Background(), "run1", createDDLRenderer{},
+	ddl, applied := o.handleRenderFailure(context.Background(), "run1", "rendering CREATE TABLE DDL", createDDLRenderer{},
 		&driver.Table{Name: "T", Schema: "dbo"}, errors.New("boom"))
 	if applied || ddl != "" {
 		t.Errorf("expected no fix applied, got applied=%v ddl=%q", applied, ddl)
@@ -148,7 +148,7 @@ func TestHandleRenderFailure_DisabledIsNoOp(t *testing.T) {
 func TestHandleRenderFailure_NonExpressionFailureNotApplied(t *testing.T) {
 	o := &Orchestrator{config: &config.Config{}, opts: Options{ApplySuggested: true}}
 	// A plain error (not *driver.ExpressionRenderError) can't be spliced.
-	ddl, applied := o.handleRenderFailure(context.Background(), "run1", createDDLRenderer{},
+	ddl, applied := o.handleRenderFailure(context.Background(), "run1", "rendering CREATE TABLE DDL", createDDLRenderer{},
 		&driver.Table{Name: "T", Schema: "dbo"}, errors.New("unsupported source type \"geography\""))
 	if applied || ddl != "" {
 		t.Errorf("non-expression failure must not be applied, got applied=%v", applied)


### PR DESCRIPTION
The last #134 child: the splice (translate one failing expression, re-render with it overridden) now covers **CHECK predicates** as well as column DEFAULTs.

## Changes

- **driver:** `CheckConstraint.DefinitionOverride` (transient, `json:"-"`); `createCheckConstraint` emits it verbatim when set, and otherwise returns a structured `*ExpressionRenderError{Kind:"check"}` on an untranslatable predicate — mirroring the default path.
- **orchestrator:** `spliceFix` is now kind-aware — `default` re-renders the table with a column override, `check` re-renders the constraint with a definition override. `handleRenderFailure` takes an operation label and phrases its log/marker/banner generically (`default` | `check`); the check render phase routes failures through it. CHECK predicates have no deterministic class check, so they're always stamped `[REVIEW]`.

## Validator fix

The structural guard rejected **all** backslashes in string literals, which blocked legitimate PostgreSQL regex CHECKs like `'^\d+$'` (this actually fired on the live test). The splice is pg-only (`standard_conforming_strings` → backslashes are literal), so quote integrity rests on balanced quotes alone; the over-broad reject is removed (a backslash-escaping target would need it back — noted in the doc comment). Comment/semicolon/paren/top-level-comma injection guards are unchanged.

## Live (mssql→pg, `--apply-suggested`)

```
APPLYING AI-ASSISTED FIX (--apply-suggested): table Accounts, check CK_Acct_Code:  (isnumeric([Code])=(1)) -> Code ~ '^[+-]?([0-9]+\.?[0-9]*|\.[0-9]+)([eE][+-]?[0-9]+)?$'  [REVIEW: class NOT mechanically confirmed]. This expression was authored by an AI model.
Schema build complete in 4.07s (1 tables)
```
→ MSSQL `ISNUMERIC(Code)=1` translated to a pg regex CHECK, spliced, applied; constraint created on Postgres.

Tests: CHECK structured-error + override-verbatim contract; corrected validator (accepts pg regex, still rejects comments/injection). `go test ./... -short` and `golangci-lint` green.

**Closes the remaining #134 child** — DEFAULT and CHECK are both splice-able now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)