### PR TITLE
[codex] Fix multi-expression AI splice loop

### DIFF
--- a/internal/orchestrator/diagnose.go
+++ b/internal/orchestrator/diagnose.go
@@ -44,13 +44,25 @@ func (o *Orchestrator) diagnoseSchemaFailure(ctx context.Context, table, schema,
 	driver.EmitDiagnosis(diagnosis)
 }
 
-// splicedFix is the outcome of translating one failing expression and
-// re-rendering the table with it overridden.
-type splicedFix struct {
+const maxAIExpressionFixesPerObject = 10
+
+type expressionFixSuggester interface {
+	SuggestExpressionFix(context.Context, driver.FixRequest) (*driver.ExpressionFix, error)
+}
+
+// splicedExpressionFix records one AI-authored expression that was validated
+// and spliced into an otherwise deterministic object render.
+type splicedExpressionFix struct {
 	exprErr      *driver.ExpressionRenderError
 	fix          *driver.ExpressionFix
-	ddl          string // SMT's deterministic DDL with the one expression spliced
-	classMatched bool   // deterministic class-equivalence verdict
+	classMatched bool // deterministic class-equivalence verdict
+}
+
+// splicedFix is the outcome of translating one or more failing expressions and
+// re-rendering the object with those expressions overridden.
+type splicedFix struct {
+	expressions []splicedExpressionFix
+	ddl         string // SMT's deterministic DDL with the expression overrides spliced
 }
 
 // handleRenderFailure runs the failure advisories for a single-table render
@@ -66,8 +78,7 @@ func (o *Orchestrator) handleRenderFailure(ctx context.Context, runID, operation
 	}
 	o.diagnoseSchemaFailure(ctx, t.Name, t.Schema, operation, cause)
 
-	// Only do the (one) AI splice call if a suggestion or apply is actually
-	// requested.
+	// Only do AI splice calls if a suggestion or apply is actually requested.
 	if !aiSuggestFixesEnabled(o.config) && !o.opts.ApplySuggested {
 		return "", false
 	}
@@ -82,24 +93,24 @@ func (o *Orchestrator) handleRenderFailure(ctx context.Context, runID, operation
 		return "", false
 	}
 
-	verdict := "OK: expression class matches source"
-	if !sf.classMatched {
-		verdict = "REVIEW: class NOT mechanically confirmed"
+	var markers strings.Builder
+	for _, expr := range sf.expressions {
+		verdict := expressionFixVerdict(expr.classMatched)
+		logging.Warn("APPLYING AI-ASSISTED FIX (--apply-suggested): table %s, %s %s:  %s -> %s  [%s]. This expression was authored by an AI model.",
+			oneLine(t.Name), oneLine(expr.exprErr.Kind), oneLine(expr.exprErr.Column), oneLine(expr.exprErr.SourceExpr), oneLine(expr.fix.Expression), verdict)
+		fmt.Fprintf(&markers, "-- AI-ASSISTED FIX (--apply-suggested): %s %s  %s -> %s  [%s]\n",
+			oneLine(expr.exprErr.Kind), oneLine(expr.exprErr.Column), oneLine(expr.exprErr.SourceExpr), oneLine(expr.fix.Expression), verdict)
 	}
-	logging.Warn("APPLYING AI-ASSISTED FIX (--apply-suggested): table %s, %s %s:  %s -> %s  [%s]. This expression was authored by an AI model.",
-		oneLine(t.Name), oneLine(sf.exprErr.Kind), oneLine(sf.exprErr.Column), oneLine(sf.exprErr.SourceExpr), oneLine(sf.fix.Expression), verdict)
-	marker := fmt.Sprintf("-- AI-ASSISTED FIX (--apply-suggested): %s %s  %s -> %s  [%s]\n",
-		oneLine(sf.exprErr.Kind), oneLine(sf.exprErr.Column), oneLine(sf.exprErr.SourceExpr), oneLine(sf.fix.Expression), verdict)
-	return marker + sf.ddl, true
+	return markers.String() + sf.ddl, true
 }
 
-// spliceFix attempts the AI splice for a single-expression render failure:
-// translate the one failing expression (a column DEFAULT or a CHECK predicate)
-// and re-render that object with it overridden, so everything but the one
-// expression stays SMT's deterministic output. ok=false (debug-logged) when the
-// failure isn't a single splice-able expression, no provider is available, the
-// AI expression is malformed, or the re-render fails. Performs exactly one AI
-// call.
+// spliceFix attempts the AI splice loop for structured expression render
+// failures: translate the failing expression (a column DEFAULT or a CHECK
+// predicate), re-render that object with the expression overridden, and repeat
+// while the same object exposes another spliceable expression failure. Everything
+// outside the overridden expressions stays SMT's deterministic output. The loop
+// is bounded by the number of expression-bearing objects on the table, capped at
+// maxAIExpressionFixesPerObject, and aborts if the same expression fails twice.
 func (o *Orchestrator) spliceFix(ctx context.Context, renderer createDDLRenderer, t *driver.Table, cause error) (*splicedFix, bool) {
 	if o.config == nil || cause == nil || t == nil {
 		return nil, false
@@ -109,79 +120,96 @@ func (o *Orchestrator) spliceFix(ctx context.Context, renderer createDDLRenderer
 		return nil, false // not a single splice-able expression — diagnosis-only
 	}
 
-	// Locate the failing object and capture the source column type (default only).
-	colIdx, chkIdx, colType := -1, -1, ""
-	switch exprErr.Kind {
-	case "default":
-		for i := range t.Columns {
-			if t.Columns[i].Name == exprErr.Column {
-				colIdx = i
-				colType = t.Columns[i].DataType
-				break
-			}
-		}
-		if colIdx < 0 {
-			return nil, false
-		}
-	case "check":
-		for i := range t.CheckConstraints {
-			if t.CheckConstraints[i].Name == exprErr.Column {
-				chkIdx = i
-				break
-			}
-		}
-		if chkIdx < 0 {
-			return nil, false
-		}
-	}
-
-	suggester := o.errorDiagnoser()
+	suggester := o.expressionFixSuggester()
 	if suggester == nil {
 		return nil, false
 	}
-	fix, err := suggester.SuggestExpressionFix(ctx, driver.FixRequest{
-		Kind:          exprErr.Kind,
-		SourceExpr:    exprErr.SourceExpr,
-		ColumnName:    exprErr.Column,
-		ColumnType:    colType,
-		SourceDialect: canonicalDBType(o.config.Source.Type),
-		TargetDialect: canonicalDBType(o.config.Target.Type),
-	})
-	if err != nil {
-		logging.Debug("AI expression fix unavailable: %v", err)
-		return nil, false
-	}
-	// Structural guard: a malformed expression must not be spliced verbatim
-	// (it could inject extra columns/statements into the DDL).
-	if err := driver.ValidateTargetExpression(fix.Expression); err != nil {
-		logging.Debug("AI expression fix rejected (not a single value expression): %v", err)
-		return nil, false
-	}
 
-	// Re-render the affected object deterministically with ONLY the failing
-	// expression overridden by the AI translation.
-	var ddl string
-	var rerr error
-	classMatched := false
-	switch exprErr.Kind {
-	case "default":
-		spliced := *t
-		spliced.Columns = append([]driver.Column(nil), t.Columns...)
-		spliced.Columns[colIdx].DefaultExpressionOverride = fix.Expression
-		ddl, rerr = renderer.renderTable(ctx, &spliced)
-		classMatched = driver.DefaultExpressionsEquivalent(exprErr.SourceExpr, fix.Expression)
-	case "check":
-		chk := t.CheckConstraints[chkIdx]
-		chk.DefinitionOverride = fix.Expression
-		ddl, rerr = renderer.renderCheck(ctx, t, &chk)
-		// No deterministic class check for a boolean CHECK predicate — always
-		// flagged for review.
+	spliced := cloneTableForExpressionSplice(t)
+	mode := exprErr.Kind
+	limit := expressionFixLimit(&spliced)
+	seen := map[string]bool{}
+	fixes := make([]splicedExpressionFix, 0, limit)
+
+	for {
+		if exprErr.Kind != "default" && exprErr.Kind != "check" {
+			logging.Warn("AI-assisted expression repair aborted for table %s: unsupported expression kind %q after %d fix(es)",
+				oneLine(t.Name), oneLine(exprErr.Kind), len(fixes))
+			return nil, false
+		}
+		if exprErr.Kind != mode {
+			logging.Warn("AI-assisted expression repair aborted for table %s: re-render switched from %s to %s after %d fix(es)",
+				oneLine(t.Name), oneLine(mode), oneLine(exprErr.Kind), len(fixes))
+			return nil, false
+		}
+		if len(fixes) >= limit {
+			logging.Warn("AI-assisted expression repair aborted for table %s: reached safety limit of %d expression fix(es)",
+				oneLine(t.Name), limit)
+			return nil, false
+		}
+		key := expressionFailureKey(exprErr)
+		if seen[key] {
+			logging.Warn("AI-assisted expression repair aborted for table %s: repeated %s expression failure for %s",
+				oneLine(t.Name), oneLine(exprErr.Kind), oneLine(exprErr.Column))
+			return nil, false
+		}
+		seen[key] = true
+
+		colIdx, chkIdx, colType, ok := expressionLocation(&spliced, exprErr)
+		if !ok {
+			logging.Debug("AI expression fix unavailable: failed %s %q not found on table %s",
+				exprErr.Kind, exprErr.Column, t.Name)
+			return nil, false
+		}
+
+		fix, err := suggester.SuggestExpressionFix(ctx, driver.FixRequest{
+			Kind:          exprErr.Kind,
+			SourceExpr:    exprErr.SourceExpr,
+			ColumnName:    exprErr.Column,
+			ColumnType:    colType,
+			SourceDialect: canonicalDBType(o.config.Source.Type),
+			TargetDialect: canonicalDBType(o.config.Target.Type),
+		})
+		if err != nil {
+			logging.Debug("AI expression fix unavailable: %v", err)
+			return nil, false
+		}
+		// Structural guard: a malformed expression must not be spliced verbatim
+		// (it could inject extra columns/statements into the DDL).
+		if err := driver.ValidateTargetExpression(fix.Expression); err != nil {
+			logging.Debug("AI expression fix rejected (not a single value expression): %v", err)
+			return nil, false
+		}
+
+		fixRecord := splicedExpressionFix{exprErr: exprErr, fix: fix}
+		var ddl string
+		var rerr error
+		switch exprErr.Kind {
+		case "default":
+			spliced.Columns[colIdx].DefaultExpressionOverride = strings.TrimSpace(fix.Expression)
+			ddl, rerr = renderer.renderTable(ctx, &spliced)
+			fixRecord.classMatched = driver.DefaultExpressionsEquivalent(exprErr.SourceExpr, fix.Expression)
+		case "check":
+			spliced.CheckConstraints[chkIdx].DefinitionOverride = strings.TrimSpace(fix.Expression)
+			chk := spliced.CheckConstraints[chkIdx]
+			ddl, rerr = renderer.renderCheck(ctx, &spliced, &chk)
+			// No deterministic class check for a boolean CHECK predicate — always
+			// flagged for review.
+		}
+
+		fixes = append(fixes, fixRecord)
+		if rerr == nil {
+			return &splicedFix{expressions: fixes, ddl: ddl}, true
+		}
+		var next *driver.ExpressionRenderError
+		if !errors.As(rerr, &next) {
+			logging.Warn("AI-assisted expression repair aborted for table %s: re-render failed after %d fix(es): %v",
+				oneLine(t.Name), len(fixes), rerr)
+			return nil, false
+		}
+		logging.Debug("re-render with %d AI expression fix(es) found another expression failure: %v", len(fixes), rerr)
+		exprErr = next
 	}
-	if rerr != nil {
-		logging.Debug("re-render with AI expression failed: %v", rerr)
-		return nil, false
-	}
-	return &splicedFix{exprErr: exprErr, fix: fix, ddl: ddl, classMatched: classMatched}, true
 }
 
 // writeSuggestion writes the AI-assisted suggestion to schema.suggested.sql,
@@ -189,49 +217,51 @@ func (o *Orchestrator) spliceFix(ctx context.Context, renderer createDDLRenderer
 // schema.sql and the run still fails — review-only.
 func (o *Orchestrator) writeSuggestion(runID, table string, sf *splicedFix) {
 	o.suggestOnce.Do(func() {
-		content := renderSuggestionFile(table, sf.exprErr, sf.fix, sf.ddl, sf.classMatched)
+		content := renderSuggestionFile(table, sf)
 		if werr := o.writeSQLArtifact(runID, "schema.suggested.sql", content); werr != nil {
 			logging.Debug("writing schema.suggested.sql: %v", werr)
 			return
 		}
-		verdict := "review the translated expression (class not mechanically confirmed)"
-		if sf.classMatched {
-			verdict = "translated expression matches the source class"
+		verdict := "review translated expression(s) that were not mechanically confirmed"
+		if allExpressionFixClassesMatched(sf) {
+			verdict = "translated expression(s) match the source class"
 		}
 		logging.Warn("AI-assisted fix written to %s — %s. Review before applying; SMT did NOT apply it (use --apply-suggested to apply).",
 			filepath.Join(o.ddlArtifactDir(runID), "schema.suggested.sql"), verdict)
 	})
 }
 
-// renderSuggestionFile wraps SMT's deterministic DDL (with one AI-translated
-// expression spliced in) in a banner that makes the provenance — which single
-// expression came from the AI — unmistakable.
-func renderSuggestionFile(table string, exprErr *driver.ExpressionRenderError, fix *driver.ExpressionFix, ddl string, classMatched bool) string {
+// renderSuggestionFile wraps SMT's deterministic DDL (with AI-translated
+// expression(s) spliced in) in a banner that makes provenance unmistakable.
+func renderSuggestionFile(table string, sf *splicedFix) string {
 	var b strings.Builder
 	b.WriteString("-- ============================================================\n")
 	b.WriteString("-- AI-ASSISTED FIX · review before applying\n")
 	b.WriteString("--\n")
-	b.WriteString("-- This is SMT's deterministic DDL with ONE expression translated by\n")
-	b.WriteString("-- an AI model. SMT did not and will not apply it automatically.\n")
+	b.WriteString("-- This is SMT's deterministic DDL with the expression(s) below\n")
+	b.WriteString("-- translated by an AI model. SMT did not and will not apply it\n")
+	b.WriteString("-- automatically.\n")
 	b.WriteString(fmt.Sprintf("-- Table:  %s\n", oneLine(table)))
-	b.WriteString(fmt.Sprintf("-- Object: %s (%s)\n", oneLine(exprErr.Column), oneLine(exprErr.Kind)))
-	b.WriteString(fmt.Sprintf("-- AI-translated: %s  ->  %s\n", oneLine(exprErr.SourceExpr), oneLine(fix.Expression)))
-	if strings.TrimSpace(fix.Explanation) != "" {
-		b.WriteString("-- Note: " + oneLine(fix.Explanation) + "\n")
+	for i, expr := range sf.expressions {
+		b.WriteString(fmt.Sprintf("-- Object %d: %s (%s)\n", i+1, oneLine(expr.exprErr.Column), oneLine(expr.exprErr.Kind)))
+		b.WriteString(fmt.Sprintf("-- AI-translated %d: %s  ->  %s\n", i+1, oneLine(expr.exprErr.SourceExpr), oneLine(expr.fix.Expression)))
+		if strings.TrimSpace(expr.fix.Explanation) != "" {
+			b.WriteString(fmt.Sprintf("-- Note %d: %s\n", i+1, oneLine(expr.fix.Explanation)))
+		}
+		b.WriteString(fmt.Sprintf("-- Confidence %d: %s (AI)\n", i+1, expr.fix.Confidence))
 	}
-	b.WriteString(fmt.Sprintf("-- Confidence: %s (AI)\n", fix.Confidence))
 	b.WriteString("--\n")
 	b.WriteString("-- Verification (deterministic): every column type, length, nullability,\n")
-	b.WriteString("-- identity, and all other defaults/constraints are SMT's deterministic\n")
-	b.WriteString("-- output — only the one expression above is AI-authored.\n")
-	if classMatched {
-		b.WriteString("--   [OK] the translated expression matches the source class.\n")
+	b.WriteString("-- identity, and all defaults/constraints not listed above are SMT's\n")
+	b.WriteString("-- deterministic output — only the expression(s) above are AI-authored.\n")
+	if allExpressionFixClassesMatched(sf) {
+		b.WriteString("--   [OK] the translated expression(s) match the source class.\n")
 	} else {
-		b.WriteString("--   [REVIEW] SMT could not mechanically confirm the translated\n")
-		b.WriteString("--   expression is equivalent to the source — review it before applying.\n")
+		b.WriteString("--   [REVIEW] SMT could not mechanically confirm every translated\n")
+		b.WriteString("--   expression is equivalent to the source — review before applying.\n")
 	}
 	b.WriteString("-- ============================================================\n\n")
-	b.WriteString(strings.TrimSpace(ddl))
+	b.WriteString(strings.TrimSpace(sf.ddl))
 	b.WriteString(";\n")
 	return b.String()
 }
@@ -240,6 +270,86 @@ func renderSuggestionFile(table string, exprErr *driver.ExpressionRenderError, f
 // AI/source string can't break out of a single-line "-- " banner comment.
 func oneLine(s string) string {
 	return strings.Join(strings.Fields(s), " ")
+}
+
+func expressionFixVerdict(classMatched bool) string {
+	if classMatched {
+		return "OK: expression class matches source"
+	}
+	return "REVIEW: class NOT mechanically confirmed"
+}
+
+func allExpressionFixClassesMatched(sf *splicedFix) bool {
+	if sf == nil || len(sf.expressions) == 0 {
+		return false
+	}
+	for _, expr := range sf.expressions {
+		if !expr.classMatched {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneTableForExpressionSplice(t *driver.Table) driver.Table {
+	spliced := *t
+	spliced.Columns = append([]driver.Column(nil), t.Columns...)
+	spliced.CheckConstraints = append([]driver.CheckConstraint(nil), t.CheckConstraints...)
+	return spliced
+}
+
+func expressionFixLimit(t *driver.Table) int {
+	n := 0
+	for _, col := range t.Columns {
+		if strings.TrimSpace(col.DefaultExpression) != "" {
+			n++
+		}
+	}
+	for _, chk := range t.CheckConstraints {
+		if strings.TrimSpace(chk.Definition) != "" {
+			n++
+		}
+	}
+	if n < 1 {
+		return 1
+	}
+	if n > maxAIExpressionFixesPerObject {
+		return maxAIExpressionFixesPerObject
+	}
+	return n
+}
+
+func expressionLocation(t *driver.Table, exprErr *driver.ExpressionRenderError) (colIdx, chkIdx int, colType string, ok bool) {
+	colIdx, chkIdx = -1, -1
+	switch exprErr.Kind {
+	case "default":
+		for i := range t.Columns {
+			if t.Columns[i].Name == exprErr.Column {
+				return i, -1, t.Columns[i].DataType, true
+			}
+		}
+	case "check":
+		for i := range t.CheckConstraints {
+			if t.CheckConstraints[i].Name == exprErr.Column {
+				return -1, i, "", true
+			}
+		}
+	}
+	return colIdx, chkIdx, "", false
+}
+
+func expressionFailureKey(exprErr *driver.ExpressionRenderError) string {
+	if exprErr == nil {
+		return ""
+	}
+	return exprErr.Kind + "\x00" + exprErr.Column
+}
+
+func (o *Orchestrator) expressionFixSuggester() expressionFixSuggester {
+	if o.fixSuggester != nil {
+		return o.fixSuggester
+	}
+	return o.errorDiagnoser()
 }
 
 // errorDiagnoser lazily resolves the AI failure-diagnosis advisor from the

--- a/internal/orchestrator/diagnose_test.go
+++ b/internal/orchestrator/diagnose_test.go
@@ -3,12 +3,60 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"smt/internal/config"
+	ddlpkg "smt/internal/ddl"
 	"smt/internal/driver"
 )
+
+type fakeExpressionFixSuggester struct {
+	fixes map[string]*driver.ExpressionFix
+	calls []driver.FixRequest
+	err   error
+}
+
+func (f *fakeExpressionFixSuggester) SuggestExpressionFix(_ context.Context, req driver.FixRequest) (*driver.ExpressionFix, error) {
+	f.calls = append(f.calls, req)
+	if f.err != nil {
+		return nil, f.err
+	}
+	fix, ok := f.fixes[req.Kind+"\x00"+req.ColumnName]
+	if !ok {
+		return nil, fmt.Errorf("unexpected fix request for %s %s", req.Kind, req.ColumnName)
+	}
+	cp := *fix
+	return &cp, nil
+}
+
+func mssqlPostgresCreateRenderer(t *testing.T) createDDLRenderer {
+	t.Helper()
+	r, err := ddlpkg.NewRenderer("postgres", "public", "fail")
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	return createDDLRenderer{
+		sourceType:   "mssql",
+		targetType:   "postgres",
+		targetSchema: "public",
+		ddlRenderer:  r.WithSource("mssql"),
+	}
+}
+
+func singleSplicedFixForTest(exprErr *driver.ExpressionRenderError, fix *driver.ExpressionFix, ddl string, classMatched bool) *splicedFix {
+	return &splicedFix{
+		expressions: []splicedExpressionFix{{
+			exprErr:      exprErr,
+			fix:          fix,
+			classMatched: classMatched,
+		}},
+		ddl: ddl,
+	}
+}
 
 // withDiagnosisHandler captures whether a diagnosis was emitted, so the
 // opt-in/no-op guardrails can be asserted without a live AI provider.
@@ -51,21 +99,23 @@ func TestDiagnoseSchemaFailure_NilCauseIsNoOp(t *testing.T) {
 }
 
 // The suggestion file must be unmistakably labeled as AI-assisted/unverified,
-// show exactly which one expression came from the AI, and contain SMT's
-// deterministic DDL — so a user can never confuse it with schema.sql.
+// show exactly which expression(s) came from the AI, and contain SMT's
+// deterministic DDL so a user can never confuse it with schema.sql.
 func TestRenderSuggestionFile_LabeledAndProvenanced(t *testing.T) {
 	out := renderSuggestionFile(
 		"dbo.Subscriptions",
-		&driver.ExpressionRenderError{Column: "ExpiresAt", Kind: "default", SourceExpr: "dateadd(year,1,getdate())"},
-		&driver.ExpressionFix{Expression: "CURRENT_TIMESTAMP + INTERVAL '1 year'", Explanation: "interval arithmetic", Confidence: "high"},
-		`CREATE TABLE "subscriptions" ("expiresat" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP + INTERVAL '1 year')`,
-		false, // class not confirmed
+		singleSplicedFixForTest(
+			&driver.ExpressionRenderError{Column: "ExpiresAt", Kind: "default", SourceExpr: "dateadd(year,1,getdate())"},
+			&driver.ExpressionFix{Expression: "CURRENT_TIMESTAMP + INTERVAL '1 year'", Explanation: "interval arithmetic", Confidence: "high"},
+			`CREATE TABLE "subscriptions" ("expiresat" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP + INTERVAL '1 year')`,
+			false, // class not confirmed
+		),
 	)
 	for _, want := range []string{
 		"AI-ASSISTED", "review before applying", "did not and will not apply it",
-		"dbo.Subscriptions", "ExpiresAt (default)",
-		"dateadd(year,1,getdate())  ->  CURRENT_TIMESTAMP + INTERVAL '1 year'",
-		"Confidence: high", `CREATE TABLE "subscriptions"`,
+		"dbo.Subscriptions", "Object 1: ExpiresAt (default)",
+		"AI-translated 1: dateadd(year,1,getdate())  ->  CURRENT_TIMESTAMP + INTERVAL '1 year'",
+		"Confidence 1: high", `CREATE TABLE "subscriptions"`,
 		"[REVIEW]", // verification verdict for an unconfirmed class
 	} {
 		if !strings.Contains(out, want) {
@@ -77,11 +127,40 @@ func TestRenderSuggestionFile_LabeledAndProvenanced(t *testing.T) {
 // A class-confirmed translation stamps [OK] rather than [REVIEW].
 func TestRenderSuggestionFile_ClassMatchedStampsOK(t *testing.T) {
 	out := renderSuggestionFile("T",
-		&driver.ExpressionRenderError{Column: "d", Kind: "default", SourceExpr: "(convert(date,getdate()))"},
-		&driver.ExpressionFix{Expression: "CURRENT_DATE", Confidence: "high"},
-		"CREATE TABLE t (d date)", true)
+		singleSplicedFixForTest(
+			&driver.ExpressionRenderError{Column: "d", Kind: "default", SourceExpr: "(convert(date,getdate()))"},
+			&driver.ExpressionFix{Expression: "CURRENT_DATE", Confidence: "high"},
+			"CREATE TABLE t (d date)", true,
+		))
 	if !strings.Contains(out, "[OK]") || strings.Contains(out, "[REVIEW]") {
 		t.Errorf("expected [OK] verdict, got:\n%s", out)
+	}
+}
+
+func TestRenderSuggestionFile_ListsMultipleExpressions(t *testing.T) {
+	out := renderSuggestionFile("dbo.SubscriptionWindows", &splicedFix{
+		expressions: []splicedExpressionFix{
+			{
+				exprErr: &driver.ExpressionRenderError{Column: "StartsAt", Kind: "default", SourceExpr: "dateadd(day,7,getdate())"},
+				fix:     &driver.ExpressionFix{Expression: "CURRENT_TIMESTAMP + INTERVAL '7 days'", Confidence: "high"},
+			},
+			{
+				exprErr: &driver.ExpressionRenderError{Column: "EndsAt", Kind: "default", SourceExpr: "dateadd(year,1,getdate())"},
+				fix:     &driver.ExpressionFix{Expression: "CURRENT_TIMESTAMP + INTERVAL '1 year'", Confidence: "medium"},
+			},
+		},
+		ddl: `CREATE TABLE "subscriptionwindows" ("startsat" timestamp DEFAULT CURRENT_TIMESTAMP + INTERVAL '7 days', "endsat" timestamp DEFAULT CURRENT_TIMESTAMP + INTERVAL '1 year')`,
+	})
+	for _, want := range []string{
+		"Object 1: StartsAt (default)",
+		"Object 2: EndsAt (default)",
+		"AI-translated 1: dateadd(day,7,getdate())  ->  CURRENT_TIMESTAMP + INTERVAL '7 days'",
+		"AI-translated 2: dateadd(year,1,getdate())  ->  CURRENT_TIMESTAMP + INTERVAL '1 year'",
+		"only the expression(s) above are AI-authored",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("suggestion file missing %q:\n%s", want, out)
+		}
 	}
 }
 
@@ -90,10 +169,12 @@ func TestRenderSuggestionFile_ClassMatchedStampsOK(t *testing.T) {
 func TestRenderSuggestionFile_SanitizesMultilineBannerFields(t *testing.T) {
 	out := renderSuggestionFile(
 		"T",
-		&driver.ExpressionRenderError{Column: "c", Kind: "default", SourceExpr: "x\nDROP TABLE users; --"},
-		&driver.ExpressionFix{Expression: "1\nDELETE FROM secrets;", Explanation: "ok\nrm -rf /", Confidence: "low"},
-		"CREATE TABLE t (c int)",
-		false,
+		singleSplicedFixForTest(
+			&driver.ExpressionRenderError{Column: "c", Kind: "default", SourceExpr: "x\nDROP TABLE users; --"},
+			&driver.ExpressionFix{Expression: "1\nDELETE FROM secrets;", Explanation: "ok\nrm -rf /", Confidence: "low"},
+			"CREATE TABLE t (c int)",
+			false,
+		),
 	)
 	header := strings.SplitN(out, "\n\nCREATE TABLE", 2)[0]
 	for _, line := range strings.Split(header, "\n") {
@@ -158,6 +239,185 @@ func TestHandleRenderFailure_NonExpressionFailureNotApplied(t *testing.T) {
 	}
 }
 
+func TestHandleRenderFailure_AppliesMultipleDefaultFixesInOneTable(t *testing.T) {
+	renderer := mssqlPostgresCreateRenderer(t)
+	table := &driver.Table{
+		Schema: "dbo",
+		Name:   "SubscriptionWindows",
+		Columns: []driver.Column{
+			{Name: "Id", DataType: "bigint", IsIdentity: true, IsNullable: false},
+			{Name: "StartsAt", DataType: "datetime2", DatetimePrecision: intPtr(3), IsNullable: false,
+				DefaultExpression: "(dateadd(day,(7),getdate()))"},
+			{Name: "EndsAt", DataType: "datetime2", DatetimePrecision: intPtr(3), IsNullable: false,
+				DefaultExpression: "(dateadd(year,(1),getdate()))"},
+		},
+		PrimaryKey: []string{"Id"},
+	}
+	_, cause := renderer.renderTable(context.Background(), table)
+	if cause == nil {
+		t.Fatal("expected initial render to fail on unsupported DATEADD default")
+	}
+
+	suggester := &fakeExpressionFixSuggester{fixes: map[string]*driver.ExpressionFix{
+		"default\x00StartsAt": {Expression: "CURRENT_TIMESTAMP + INTERVAL '7 days'", Confidence: "high"},
+		"default\x00EndsAt":   {Expression: "CURRENT_TIMESTAMP + INTERVAL '1 year'", Confidence: "high"},
+	}}
+	cfg := &config.Config{}
+	cfg.Source.Type = "mssql"
+	cfg.Target.Type = "postgres"
+	o := &Orchestrator{config: cfg, opts: Options{ApplySuggested: true}, fixSuggester: suggester}
+
+	got, applied := o.handleRenderFailure(context.Background(), "run1", "rendering CREATE TABLE DDL", renderer, table, cause)
+	if !applied {
+		t.Fatalf("expected multi-default AI splice to apply; ddl=%q", got)
+	}
+	if strings.Count(got, "AI-ASSISTED FIX (--apply-suggested)") != 2 {
+		t.Fatalf("expected two inline AI markers, got:\n%s", got)
+	}
+	for _, want := range []string{
+		`"startsat" timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP + INTERVAL '7 days'`,
+		`"endsat" timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP + INTERVAL '1 year'`,
+		`-- AI-ASSISTED FIX (--apply-suggested): default StartsAt`,
+		`-- AI-ASSISTED FIX (--apply-suggested): default EndsAt`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+	if len(suggester.calls) != 2 {
+		t.Fatalf("AI suggester calls = %d, want 2", len(suggester.calls))
+	}
+	if suggester.calls[0].ColumnName != "StartsAt" || suggester.calls[1].ColumnName != "EndsAt" {
+		t.Fatalf("unexpected call order: %#v", suggester.calls)
+	}
+	if table.Columns[1].DefaultExpressionOverride != "" || table.Columns[2].DefaultExpressionOverride != "" {
+		t.Fatal("handleRenderFailure mutated the original table instead of an in-memory copy")
+	}
+}
+
+func TestHandleRenderFailure_WritesCombinedSuggestionForMultipleDefaults(t *testing.T) {
+	renderer := mssqlPostgresCreateRenderer(t)
+	table := &driver.Table{
+		Schema: "dbo",
+		Name:   "SubscriptionWindows",
+		Columns: []driver.Column{
+			{Name: "StartsAt", DataType: "datetime2", DatetimePrecision: intPtr(3), IsNullable: false,
+				DefaultExpression: "(dateadd(day,(7),getdate()))"},
+			{Name: "EndsAt", DataType: "datetime2", DatetimePrecision: intPtr(3), IsNullable: false,
+				DefaultExpression: "(dateadd(year,(1),getdate()))"},
+		},
+	}
+	_, cause := renderer.renderTable(context.Background(), table)
+	if cause == nil {
+		t.Fatal("expected initial render to fail on unsupported DATEADD default")
+	}
+
+	suggester := &fakeExpressionFixSuggester{fixes: map[string]*driver.ExpressionFix{
+		"default\x00StartsAt": {Expression: "CURRENT_TIMESTAMP + INTERVAL '7 days'", Confidence: "high"},
+		"default\x00EndsAt":   {Expression: "CURRENT_TIMESTAMP + INTERVAL '1 year'", Confidence: "medium"},
+	}}
+	cfg := &config.Config{}
+	cfg.Source.Type = "mssql"
+	cfg.Target.Type = "postgres"
+	cfg.Migration.DataDir = t.TempDir()
+	on := true
+	cfg.AIReview.SuggestFixes = &on
+	o := &Orchestrator{config: cfg, fixSuggester: suggester}
+
+	got, applied := o.handleRenderFailure(context.Background(), "run1", "rendering CREATE TABLE DDL", renderer, table, cause)
+	if applied || got != "" {
+		t.Fatalf("advisory suggestion must not apply DDL, got applied=%v ddl=%q", applied, got)
+	}
+	content, err := os.ReadFile(filepath.Join(cfg.Migration.DataDir, "runs", "run1", "ddl", "schema.suggested.sql"))
+	if err != nil {
+		t.Fatalf("reading schema.suggested.sql: %v", err)
+	}
+	suggestion := string(content)
+	for _, want := range []string{
+		"Object 1: StartsAt (default)",
+		"Object 2: EndsAt (default)",
+		`"startsat" timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP + INTERVAL '7 days'`,
+		`"endsat" timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP + INTERVAL '1 year'`,
+	} {
+		if !strings.Contains(suggestion, want) {
+			t.Errorf("suggestion file missing %q:\n%s", want, suggestion)
+		}
+	}
+}
+
+func TestHandleRenderFailure_AbortsAtExpressionFixCap(t *testing.T) {
+	renderer := mssqlPostgresCreateRenderer(t)
+	table := &driver.Table{Schema: "dbo", Name: "TooManyDefaults"}
+	table.Columns = append(table.Columns, driver.Column{Name: "Id", DataType: "int", IsNullable: false})
+
+	fixes := map[string]*driver.ExpressionFix{}
+	for i := 1; i <= maxAIExpressionFixesPerObject+1; i++ {
+		name := fmt.Sprintf("D%d", i)
+		table.Columns = append(table.Columns, driver.Column{
+			Name:              name,
+			DataType:          "datetime2",
+			IsNullable:        false,
+			DefaultExpression: fmt.Sprintf("(dateadd(day,(%d),getdate()))", i),
+		})
+		fixes["default\x00"+name] = &driver.ExpressionFix{
+			Expression: fmt.Sprintf("CURRENT_TIMESTAMP + INTERVAL '%d days'", i),
+			Confidence: "high",
+		}
+	}
+	_, cause := renderer.renderTable(context.Background(), table)
+	if cause == nil {
+		t.Fatal("expected initial render to fail on unsupported DATEADD default")
+	}
+
+	suggester := &fakeExpressionFixSuggester{fixes: fixes}
+	cfg := &config.Config{}
+	cfg.Source.Type = "mssql"
+	cfg.Target.Type = "postgres"
+	o := &Orchestrator{config: cfg, opts: Options{ApplySuggested: true}, fixSuggester: suggester}
+
+	got, applied := o.handleRenderFailure(context.Background(), "run1", "rendering CREATE TABLE DDL", renderer, table, cause)
+	if applied || got != "" {
+		t.Fatalf("expected safety cap abort, got applied=%v ddl=%q", applied, got)
+	}
+	if len(suggester.calls) != maxAIExpressionFixesPerObject {
+		t.Fatalf("AI suggester calls = %d, want cap %d", len(suggester.calls), maxAIExpressionFixesPerObject)
+	}
+}
+
+func TestHandleRenderFailure_AbortsOnRepeatedExpressionKey(t *testing.T) {
+	renderer := mssqlPostgresCreateRenderer(t)
+	table := &driver.Table{
+		Schema: "dbo",
+		Name:   "RepeatedDefaultKey",
+		Columns: []driver.Column{
+			{Name: "StartsAt", DataType: "datetime2", IsNullable: false,
+				DefaultExpression: "(dateadd(day,(7),getdate()))"},
+			{Name: "StartsAt", DataType: "datetime2", IsNullable: false,
+				DefaultExpression: "(dateadd(year,(1),getdate()))"},
+		},
+	}
+	_, cause := renderer.renderTable(context.Background(), table)
+	if cause == nil {
+		t.Fatal("expected initial render to fail on unsupported DATEADD default")
+	}
+
+	suggester := &fakeExpressionFixSuggester{fixes: map[string]*driver.ExpressionFix{
+		"default\x00StartsAt": {Expression: "CURRENT_TIMESTAMP + INTERVAL '7 days'", Confidence: "high"},
+	}}
+	cfg := &config.Config{}
+	cfg.Source.Type = "mssql"
+	cfg.Target.Type = "postgres"
+	o := &Orchestrator{config: cfg, opts: Options{ApplySuggested: true}, fixSuggester: suggester}
+
+	got, applied := o.handleRenderFailure(context.Background(), "run1", "rendering CREATE TABLE DDL", renderer, table, cause)
+	if applied || got != "" {
+		t.Fatalf("expected repeated expression key abort, got applied=%v ddl=%q", applied, got)
+	}
+	if len(suggester.calls) != 1 {
+		t.Fatalf("AI suggester calls = %d, want 1 before repeated-key abort", len(suggester.calls))
+	}
+}
+
 // Enabled but no usable AI provider must degrade gracefully: no emit, no panic,
 // and the original error path is unaffected (the caller still returns it).
 func TestDiagnoseSchemaFailure_EnabledNoProviderDegradesGracefully(t *testing.T) {
@@ -174,3 +434,5 @@ func TestDiagnoseSchemaFailure_EnabledNoProviderDegradesGracefully(t *testing.T)
 		t.Error("diagnosis emitted despite no usable provider")
 	}
 }
+
+func intPtr(v int) *int { return &v }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -38,8 +38,8 @@ type Options struct {
 	// SourceOnly skips the target connection (used by inspection commands).
 	SourceOnly bool
 
-	// ApplySuggested makes a single-expression render failure splice the AI
-	// fix and continue (instead of aborting), so the AI-assisted DDL becomes
+	// ApplySuggested makes structured expression render failures splice AI
+	// fixes and continue (instead of aborting), so the AI-assisted DDL becomes
 	// part of the plan. Explicit, off by default, and loud — the only path by
 	// which AI-authored content reaches schema.sql / the applied DDL (#134).
 	ApplySuggested bool
@@ -63,6 +63,7 @@ type Orchestrator struct {
 	// (ai_review.diagnose_failures), resolved lazily on the first failure.
 	diagnoser     *driver.AIErrorDiagnoser
 	diagnoserOnce sync.Once
+	fixSuggester  expressionFixSuggester
 
 	// suggestOnce guards writing schema.suggested.sql so concurrent table
 	// failures produce a single suggestion artifact.


### PR DESCRIPTION
## Summary

Addresses #140 by extending the AI expression-fix splice path from a single repair to a bounded retry loop for structured expression render failures in one rendered object.

## What changed

- Track every validated AI-authored expression spliced into the deterministic render.
- Retry rendering after each default/check expression override until the object succeeds or the repair loop hits a safety abort.
- Abort on unsupported kinds, kind switches, repeated expression failures, non-expression rerender failures, or the per-object cap.
- Mark each AI-authored expression in `--apply-suggested` output and in `schema.suggested.sql`.
- Add regression coverage for multiple defaults, combined suggestion output, cap aborts, and repeated-key aborts.

## Review notes

Self-review found no PR-blocking bugs in the uncommitted diff before commit. Residual risk is mostly around live AI provider behavior and real catalog edge cases; the deterministic retry and validation paths are covered with fake suggesters and renderer-level tests.

## Validation

- `go test -count=1 ./internal/orchestrator -run 'TestHandleRenderFailure|TestRenderSuggestionFile'`
- `go test -count=1 ./...`
- `git diff --check`