### PR TITLE
Resolve canonical type follow-ups

### DIFF
--- a/internal/canonical/canonical.go
+++ b/internal/canonical/canonical.go
@@ -51,6 +51,8 @@ const (
 
 	Array // Element is the element kind (best-effort; pg arrays)
 
+	Spatial // SpatialType, SpatialSubType, SRID
+
 	// Raw is a non-portable passthrough: the original type name is kept in
 	// Raw and emitted verbatim / handled by the unknown-type policy.
 	Raw
@@ -99,6 +101,13 @@ type CanonicalType struct {
 	// Element is the element type for Array.
 	Element *CanonicalType
 
+	// SpatialType is the spatial storage family ("geometry" or "geography").
+	// SpatialSubType is the optional shape subtype ("point", "polygon", ...).
+	// SRID is 0 when unset/default.
+	SpatialType    string
+	SpatialSubType string
+	SRID           int
+
 	// Raw holds the original source type name for Kind == Raw.
 	Raw string
 }
@@ -122,4 +131,6 @@ type TypeMeta struct {
 	IsUnsigned        bool
 	DisplayWidth      int      // MySQL: captured only for tinyint(1)
 	EnumValues        []string // MySQL ENUM/SET members
+	SRID              int      // Spatial Reference ID, when known
+	SpatialSubType    string   // PostGIS geometry/geography subtype, when known
 }

--- a/internal/canonical/from_canonical.go
+++ b/internal/canonical/from_canonical.go
@@ -26,20 +26,45 @@ type RenderOpts struct {
 	IsIdentity bool
 }
 
+// MappingWarning describes a mappable-but-lossy canonical type conversion.
+// These warnings are advisory: the rendered DDL is valid, but it does not carry
+// every source-side semantic fact.
+type MappingWarning struct {
+	Kind          string `json:"kind"`
+	TargetDialect string `json:"target_dialect"`
+	Reason        string `json:"reason"`
+}
+
 // FromCanonical renders a CanonicalType as a target dialect's DDL type string
 // (without NOT NULL / DEFAULT / IDENTITY clauses — those are the renderer's).
 // dialect is the canonical target driver name.
 func FromCanonical(ct CanonicalType, dialect string, opts RenderOpts) (string, error) {
-	switch canonDialect(dialect) {
+	typ, _, err := FromCanonicalWithWarnings(ct, dialect, opts)
+	return typ, err
+}
+
+// FromCanonicalWithWarnings renders the type and returns advisory warnings for
+// conversions that are supported but approximate/lossy.
+func FromCanonicalWithWarnings(ct CanonicalType, dialect string, opts RenderOpts) (string, []MappingWarning, error) {
+	target := canonDialect(dialect)
+	var (
+		typ string
+		err error
+	)
+	switch target {
 	case "postgres":
-		return fromCanonicalPG(ct, opts)
+		typ, err = fromCanonicalPG(ct, opts)
 	case "mssql":
-		return fromCanonicalMSSQL(ct, opts)
+		typ, err = fromCanonicalMSSQL(ct, opts)
 	case "mysql":
-		return fromCanonicalMySQL(ct, opts)
+		typ, err = fromCanonicalMySQL(ct, opts)
 	default:
-		return "", fmt.Errorf("FromCanonical: unsupported target dialect %q", dialect)
+		return "", nil, fmt.Errorf("FromCanonical: unsupported target dialect %q", dialect)
 	}
+	if err != nil {
+		return "", nil, err
+	}
+	return typ, mappingWarnings(ct, target, typ, opts), nil
 }
 
 func canonDialect(d string) string {
@@ -130,6 +155,8 @@ func fromCanonicalPG(ct CanonicalType, opts RenderOpts) (string, error) {
 		default:
 			return "text[]", nil
 		}
+	case Spatial:
+		return pgSpatialDDL(ct), nil
 	case Raw:
 		return "", fmt.Errorf("%w: %s", ErrUnknownType, ct.Raw)
 	default:
@@ -224,6 +251,11 @@ func fromCanonicalMSSQL(ct CanonicalType, opts RenderOpts) (string, error) {
 		return sized("NVARCHAR", enumStringLen(ct), "255"), nil
 	case Set:
 		return sized("NVARCHAR", setStringLen(ct), "255"), nil
+	case Spatial:
+		if ct.SpatialType == "geography" {
+			return "GEOGRAPHY", nil
+		}
+		return "GEOMETRY", nil
 	case Raw:
 		return "", fmt.Errorf("%w: %s", ErrUnknownType, ct.Raw)
 	default:
@@ -299,6 +331,8 @@ func fromCanonicalMySQL(ct CanonicalType, opts RenderOpts) (string, error) {
 		return enumDDL("ENUM", ct)
 	case Set:
 		return enumDDL("SET", ct)
+	case Spatial:
+		return mysqlSpatialDDL(ct), nil
 	case Raw:
 		return "", fmt.Errorf("%w: %s", ErrUnknownType, ct.Raw)
 	default:
@@ -433,4 +467,213 @@ func enumDDL(name string, ct CanonicalType) (string, error) {
 		quoted[i] = "'" + strings.ReplaceAll(strings.ReplaceAll(v, `\`, `\\`), "'", "''") + "'"
 	}
 	return name + "(" + strings.Join(quoted, ",") + ")", nil
+}
+
+func pgSpatialDDL(ct CanonicalType) string {
+	family := ct.SpatialType
+	if family != "geography" {
+		family = "geometry"
+	}
+	subtype := pgSpatialSubType(ct.SpatialSubType)
+	if subtype == "" && ct.SRID <= 0 {
+		return family
+	}
+	if subtype == "" {
+		subtype = "Geometry"
+	}
+	if ct.SRID > 0 {
+		return fmt.Sprintf("%s(%s,%d)", family, subtype, ct.SRID)
+	}
+	return fmt.Sprintf("%s(%s)", family, subtype)
+}
+
+func mysqlSpatialDDL(ct CanonicalType) string {
+	base := strings.ToUpper(mysqlSpatialBase(ct.SpatialSubType))
+	if base == "" {
+		base = "GEOMETRY"
+	}
+	if ct.SRID > 0 {
+		return fmt.Sprintf("%s SRID %d", base, ct.SRID)
+	}
+	return base
+}
+
+func mysqlSpatialBase(subtype string) string {
+	switch strings.ToLower(strings.TrimSpace(subtype)) {
+	case "point":
+		return "POINT"
+	case "linestring":
+		return "LINESTRING"
+	case "polygon":
+		return "POLYGON"
+	case "multipoint":
+		return "MULTIPOINT"
+	case "multilinestring":
+		return "MULTILINESTRING"
+	case "multipolygon":
+		return "MULTIPOLYGON"
+	case "geometrycollection":
+		return "GEOMETRYCOLLECTION"
+	default:
+		return "GEOMETRY"
+	}
+}
+
+func pgSpatialSubType(subtype string) string {
+	switch strings.ToLower(strings.TrimSpace(subtype)) {
+	case "point":
+		return "Point"
+	case "linestring":
+		return "LineString"
+	case "polygon":
+		return "Polygon"
+	case "multipoint":
+		return "MultiPoint"
+	case "multilinestring":
+		return "MultiLineString"
+	case "multipolygon":
+		return "MultiPolygon"
+	case "geometrycollection":
+		return "GeometryCollection"
+	default:
+		return ""
+	}
+}
+
+func mappingWarnings(ct CanonicalType, target, rendered string, opts RenderOpts) []MappingWarning {
+	var out []MappingWarning
+	add := func(reason string) {
+		out = append(out, MappingWarning{
+			Kind:          kindName(ct.Kind),
+			TargetDialect: target,
+			Reason:        reason,
+		})
+	}
+
+	switch ct.Kind {
+	case TinyInt:
+		if target == "postgres" {
+			add("target has no 8-bit integer; rendered as " + rendered)
+		}
+	case MediumInt:
+		if target != "mysql" {
+			add("target has no 24-bit integer; rendered as " + rendered)
+		}
+	case SmallInt, Integer:
+		if ct.Unsigned && target != "mysql" {
+			add("target has no unsigned integer flag; widened to " + rendered)
+		}
+	case BigInt:
+		if ct.Unsigned && target != "mysql" && !opts.IsIdentity {
+			add("target has no unsigned 64-bit integer; rendered as " + rendered)
+		}
+	case Time, Timestamp:
+		if ct.WithTZ && target == "mysql" {
+			add("target has no equivalent time-zone-aware type; rendered as " + rendered)
+		}
+		if ct.UTCNormalized && target != "mysql" {
+			add("MySQL TIMESTAMP UTC-normalization is not represented on target; rendered as " + rendered)
+		}
+		if max := temporalFSPMax(target); max >= 0 {
+			if fsp, ok := ct.Fspv(); ok && fsp > max {
+				add(fmt.Sprintf("fractional-seconds precision %d clamped to target max %d", fsp, max))
+			}
+		}
+	case Text, Blob:
+		if target != "mysql" && mysqlLOBCapacity(ct.Length) {
+			add("MySQL LOB capacity tier is not represented on target; rendered as " + rendered)
+		}
+	case Spatial:
+		if target == "postgres" {
+			add("PostgreSQL spatial rendering requires PostGIS types to be installed")
+		}
+		if target == "mssql" && (ct.SRID > 0 || ct.SpatialSubType != "") {
+			add("SQL Server column DDL does not encode spatial subtype or SRID; rendered as " + rendered)
+		}
+		if target == "mysql" && ct.SpatialType == "geography" {
+			add("MySQL has no native geography type; rendered as " + rendered)
+		}
+	}
+	return out
+}
+
+func temporalFSPMax(target string) int {
+	switch target {
+	case "postgres", "mysql":
+		return 6
+	case "mssql":
+		return 7
+	default:
+		return -1
+	}
+}
+
+func mysqlLOBCapacity(length int) bool {
+	switch length {
+	case tinyCap, baseCap, mediumCap, longCap:
+		return true
+	default:
+		return false
+	}
+}
+
+func kindName(k Kind) string {
+	switch k {
+	case Boolean:
+		return "boolean"
+	case TinyInt:
+		return "tinyint"
+	case SmallInt:
+		return "smallint"
+	case MediumInt:
+		return "mediumint"
+	case Integer:
+		return "integer"
+	case BigInt:
+		return "bigint"
+	case Decimal:
+		return "decimal"
+	case Real:
+		return "real"
+	case Double:
+		return "double"
+	case Varchar:
+		return "varchar"
+	case Char:
+		return "char"
+	case Text:
+		return "text"
+	case Binary:
+		return "binary"
+	case VarBinary:
+		return "varbinary"
+	case Blob:
+		return "blob"
+	case Date:
+		return "date"
+	case Time:
+		return "time"
+	case Timestamp:
+		return "timestamp"
+	case Uuid:
+		return "uuid"
+	case Json:
+		return "json"
+	case Xml:
+		return "xml"
+	case RowVersion:
+		return "rowversion"
+	case Enum:
+		return "enum"
+	case Set:
+		return "set"
+	case Array:
+		return "array"
+	case Spatial:
+		return "spatial"
+	case Raw:
+		return "raw"
+	default:
+		return "unknown"
+	}
 }

--- a/internal/canonical/oracle_pg_test.go
+++ b/internal/canonical/oracle_pg_test.go
@@ -28,7 +28,8 @@ func corpus() []tcase {
 		return tcase{src: src, typ: typ, meta: m, col: driver.Column{
 			Name: "c", DataType: typ, MaxLength: m.MaxLength, Precision: m.Precision,
 			Scale: m.Scale, DatetimePrecision: m.DatetimePrecision, IsUnsigned: m.IsUnsigned,
-			DisplayWidth: m.DisplayWidth, EnumValues: m.EnumValues,
+			DisplayWidth: m.DisplayWidth, EnumValues: m.EnumValues, SRID: m.SRID,
+			SpatialSubType: m.SpatialSubType,
 		}}
 	}
 	var c []tcase
@@ -88,6 +89,8 @@ func corpus() []tcase {
 	add(mk("mssql", "uniqueidentifier", canonical.TypeMeta{}))
 	add(mk("mysql", "json", canonical.TypeMeta{}))
 	add(mk("mysql", "enum", canonical.TypeMeta{MaxLength: 8, EnumValues: []string{"a", "b"}}))
+	add(mk("mssql", "geometry", canonical.TypeMeta{SRID: 4326}))
+	add(mk("mysql", "point", canonical.TypeMeta{SRID: 4326}))
 	return c
 }
 

--- a/internal/canonical/to_canonical.go
+++ b/internal/canonical/to_canonical.go
@@ -22,6 +22,10 @@ func ToCanonical(typeName string, m TypeMeta, dialect string) CanonicalType {
 	dt := strings.ToLower(strings.TrimSpace(typeName))
 	mysql := isMySQL(dialect)
 
+	if ct, ok := toSpatial(dt, m, dialect); ok {
+		return ct
+	}
+
 	switch dt {
 	// ---- integers / booleans -------------------------------------------
 	case "tinyint":
@@ -161,6 +165,82 @@ func ToCanonical(typeName string, m TypeMeta, dialect string) CanonicalType {
 	default:
 		return CanonicalType{Kind: Raw, Raw: dt}
 	}
+}
+
+func toSpatial(dt string, m TypeMeta, dialect string) (CanonicalType, bool) {
+	base, subtype, srid := parseSpatialType(dt, m)
+	if base == "" {
+		return CanonicalType{}, false
+	}
+	switch base {
+	case "geography":
+		return CanonicalType{Kind: Spatial, SpatialType: "geography", SpatialSubType: subtype, SRID: srid}, true
+	case "geometry":
+		return CanonicalType{Kind: Spatial, SpatialType: "geometry", SpatialSubType: subtype, SRID: srid}, true
+	case "point", "linestring", "polygon", "multipoint", "multilinestring", "multipolygon", "geometrycollection":
+		if !isMySQL(dialect) {
+			return CanonicalType{}, false
+		}
+		return CanonicalType{Kind: Spatial, SpatialType: "geometry", SpatialSubType: base, SRID: srid}, true
+	default:
+		return CanonicalType{}, false
+	}
+}
+
+func parseSpatialType(dt string, m TypeMeta) (base, subtype string, srid int) {
+	srid = m.SRID
+	base = strings.ToLower(strings.TrimSpace(dt))
+	if i := strings.Index(base, "("); i >= 0 && strings.HasSuffix(base, ")") {
+		rawBase := strings.TrimSpace(base[:i])
+		inner := strings.TrimSpace(base[i+1 : len(base)-1])
+		parts := strings.Split(inner, ",")
+		if len(parts) > 0 {
+			subtype = normalizeSpatialSubType(parts[0])
+		}
+		if len(parts) > 1 {
+			if parsed, ok := atoiPositive(strings.TrimSpace(parts[1])); ok {
+				srid = parsed
+			}
+		}
+		base = rawBase
+	}
+	if subtype == "" {
+		subtype = normalizeSpatialSubType(m.SpatialSubType)
+	}
+	return base, subtype, srid
+}
+
+func normalizeSpatialSubType(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.TrimPrefix(s, "st_")
+	s = strings.ReplaceAll(s, " ", "")
+	switch s {
+	case "geometry", "geography":
+		return ""
+	default:
+		return s
+	}
+}
+
+func atoiPositive(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n, true
+}
+
+// IsSpatialTypeName reports whether a dialect type name belongs to a supported
+// spatial family. It accepts bare names and PostGIS-style geometry(...).
+func IsSpatialTypeName(typeName string) bool {
+	_, ok := toSpatial(strings.ToLower(strings.TrimSpace(typeName)), TypeMeta{}, "mysql")
+	return ok
 }
 
 func isMySQL(dialect string) bool {

--- a/internal/canonical/to_canonical_test.go
+++ b/internal/canonical/to_canonical_test.go
@@ -1,6 +1,9 @@
 package canonical
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestToCanonical_Core(t *testing.T) {
 	fsp6 := 6
@@ -27,7 +30,12 @@ func TestToCanonical_Core(t *testing.T) {
 		{"datetimeoffset is tz-aware", "datetimeoffset", TypeMeta{}, "mssql", CanonicalType{Kind: Timestamp, WithTZ: true}},
 		{"uniqueidentifier is uuid", "uniqueidentifier", TypeMeta{}, "mssql", CanonicalType{Kind: Uuid}},
 		{"enum carries values", "enum", TypeMeta{EnumValues: []string{"a", "b"}}, "mysql", CanonicalType{Kind: Enum, EnumValues: []string{"a", "b"}}},
-		{"unknown is raw", "geography", TypeMeta{}, "mssql", CanonicalType{Kind: Raw, Raw: "geography"}},
+		{"mssql geography is spatial", "geography", TypeMeta{SRID: 4326}, "mssql", CanonicalType{Kind: Spatial, SpatialType: "geography", SRID: 4326}},
+		{"mysql point is spatial subtype", "point", TypeMeta{SRID: 3857}, "mysql", CanonicalType{Kind: Spatial, SpatialType: "geometry", SpatialSubType: "point", SRID: 3857}},
+		{"postgis geometry carries subtype and srid", "geometry(Point,4326)", TypeMeta{}, "postgres", CanonicalType{Kind: Spatial, SpatialType: "geometry", SpatialSubType: "point", SRID: 4326}},
+		{"postgis metadata supplies subtype", "geometry", TypeMeta{SpatialSubType: "Polygon", SRID: 3857}, "postgres", CanonicalType{Kind: Spatial, SpatialType: "geometry", SpatialSubType: "polygon", SRID: 3857}},
+		{"postgres built-in point is not postgis", "point", TypeMeta{}, "postgres", CanonicalType{Kind: Raw, Raw: "point"}},
+		{"unknown is raw", "hierarchyid", TypeMeta{}, "mssql", CanonicalType{Kind: Raw, Raw: "hierarchyid"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -36,8 +44,74 @@ func TestToCanonical_Core(t *testing.T) {
 				got.Precision != tc.want.Precision || got.Scale != tc.want.Scale ||
 				got.WithTZ != tc.want.WithTZ || got.Unsigned != tc.want.Unsigned ||
 				got.UTCNormalized != tc.want.UTCNormalized || got.Raw != tc.want.Raw ||
+				got.SpatialType != tc.want.SpatialType || got.SpatialSubType != tc.want.SpatialSubType ||
+				got.SRID != tc.want.SRID ||
 				!eqFsp(got.Fsp, tc.want.Fsp) || !eqStrs(got.EnumValues, tc.want.EnumValues) {
 				t.Errorf("ToCanonical(%q,%s) = %+v, want %+v", tc.typ, tc.dialect, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFromCanonical_Spatial(t *testing.T) {
+	ct := CanonicalType{Kind: Spatial, SpatialType: "geometry", SpatialSubType: "point", SRID: 4326}
+	cases := []struct {
+		target string
+		want   string
+	}{
+		{"postgres", "geometry(Point,4326)"},
+		{"mssql", "GEOMETRY"},
+		{"mysql", "POINT SRID 4326"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.target, func(t *testing.T) {
+			got, err := FromCanonical(ct, tc.target, RenderOpts{})
+			if err != nil {
+				t.Fatalf("FromCanonical: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("FromCanonical spatial to %s = %q, want %q", tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFromCanonicalWithWarnings_Lossy(t *testing.T) {
+	fsp7 := 7
+	cases := []struct {
+		name       string
+		ct         CanonicalType
+		target     string
+		wantType   string
+		wantReason string
+	}{
+		{"unsigned bigint to pg decimal", CanonicalType{Kind: BigInt, Unsigned: true}, "postgres", "numeric(20,0)", "unsigned 64-bit"},
+		{"unsigned integer widening", CanonicalType{Kind: Integer, Unsigned: true}, "postgres", "bigint", "unsigned integer flag"},
+		{"mediumint widening", CanonicalType{Kind: MediumInt}, "mssql", "INT", "24-bit"},
+		{"tinyint widening", CanonicalType{Kind: TinyInt}, "postgres", "smallint", "8-bit"},
+		{"tz-aware timestamp to mysql", CanonicalType{Kind: Timestamp, WithTZ: true}, "mysql", "DATETIME(6)", "time-zone-aware"},
+		{"mysql timestamp to pg", CanonicalType{Kind: Timestamp, UTCNormalized: true}, "postgres", "timestamp without time zone", "UTC-normalization"},
+		{"fsp clamp", CanonicalType{Kind: Timestamp, Fsp: &fsp7}, "postgres", "timestamp(6) without time zone", "clamped"},
+		{"mysql text tier to pg", CanonicalType{Kind: Text, Length: baseCap}, "postgres", "text", "LOB capacity tier"},
+		{"postgis dependency", CanonicalType{Kind: Spatial, SpatialType: "geometry"}, "postgres", "geometry", "PostGIS"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, warnings, err := FromCanonicalWithWarnings(tc.ct, tc.target, RenderOpts{})
+			if err != nil {
+				t.Fatalf("FromCanonicalWithWarnings: %v", err)
+			}
+			if got != tc.wantType {
+				t.Fatalf("rendered type = %q, want %q", got, tc.wantType)
+			}
+			if len(warnings) == 0 {
+				t.Fatalf("expected warning, got none")
+			}
+			if warnings[0].Kind == "" || warnings[0].TargetDialect != tc.target {
+				t.Fatalf("warning metadata = %#v", warnings[0])
+			}
+			if !strings.Contains(warnings[0].Reason, tc.wantReason) {
+				t.Fatalf("warning reason = %q, want substring %q", warnings[0].Reason, tc.wantReason)
 			}
 		})
 	}

--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -11,6 +11,7 @@ import (
 	"smt/internal/canonical"
 	"smt/internal/driver"
 	pgddl "smt/internal/driver/postgres"
+	"smt/internal/logging"
 )
 
 // RendererVersion identifies the deterministic renderer's output contract.
@@ -24,7 +25,8 @@ import (
 // source-dialect-aware, so the rendered DDL changed for some inputs vs "1"
 // (e.g. MySQL tinyint(1) -> BIT/boolean, dialect-correct float/real precision,
 // MySQL mediumint and time-with-tz no longer rejected on a pg target).
-const RendererVersion = "2"
+// "3": canonical spatial rendering and mapping warnings (#121/#122).
+const RendererVersion = "3"
 
 type Renderer struct {
 	target            string
@@ -583,7 +585,7 @@ func (r Renderer) mysqlColumnType(col driver.Column, dt string) (string, error) 
 // Non-portable (Raw) types fall through to the unknown-type policy.
 func (r Renderer) canonicalColumnType(col driver.Column, dt, target string) (string, error) {
 	ct := canonical.ToCanonical(dt, driver.MetaOf(col), r.source)
-	typ, err := canonical.FromCanonical(ct, target, canonical.RenderOpts{IsIdentity: col.IsIdentity})
+	typ, warnings, err := canonical.FromCanonicalWithWarnings(ct, target, canonical.RenderOpts{IsIdentity: col.IsIdentity})
 	switch {
 	case errors.Is(err, canonical.ErrUnknownType):
 		return r.unknownType(dt)
@@ -596,7 +598,17 @@ func (r Renderer) canonicalColumnType(col driver.Column, dt, target string) (str
 		}
 		return "", fmt.Errorf("%s column %s is missing allowed values", strings.ToLower(dt), col.Name)
 	}
+	for _, w := range warnings {
+		logMappingWarning(col.Name, r.source, target, typ, w)
+	}
 	return typ, err
+}
+
+func logMappingWarning(column, source, target, rendered string, w canonical.MappingWarning) {
+	if source == "" {
+		source = "unknown"
+	}
+	logging.Warn("deterministic type mapper: %s→%s column %s rendered as %s with warning: %s", source, target, column, rendered, w.Reason)
 }
 
 func (r Renderer) Expression(expr string, tableColumns []driver.Column) (string, error) {

--- a/internal/driver/mysql/reader.go
+++ b/internal/driver/mysql/reader.go
@@ -391,7 +391,43 @@ func (r *Reader) loadColumns(ctx context.Context, t *driver.Table) error {
 		}
 		t.Columns = append(t.Columns, c)
 	}
-	return rows.Err()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	return r.loadSpatialColumns(ctx, t)
+}
+
+func (r *Reader) loadSpatialColumns(ctx context.Context, t *driver.Table) error {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT COLUMN_NAME, COALESCE(SRS_ID, 0)
+		FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
+		  AND DATA_TYPE IN ('geometry','point','linestring','polygon','multipoint','multilinestring','multipolygon','geometrycollection')
+	`, t.Schema, t.Name)
+	if err != nil {
+		logging.Debug("skipping MySQL spatial SRID metadata for %s.%s: %v", t.Schema, t.Name, err)
+		return nil
+	}
+	defer rows.Close()
+
+	srids := make(map[string]int)
+	for rows.Next() {
+		var name string
+		var srid int
+		if err := rows.Scan(&name, &srid); err != nil {
+			return fmt.Errorf("scanning spatial metadata: %w", err)
+		}
+		srids[strings.ToLower(name)] = srid
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating spatial metadata: %w", err)
+	}
+	for i := range t.Columns {
+		if srid, ok := srids[strings.ToLower(t.Columns[i].Name)]; ok {
+			t.Columns[i].SRID = srid
+		}
+	}
+	return nil
 }
 
 func (r *Reader) loadPrimaryKey(ctx context.Context, t *driver.Table) error {

--- a/internal/driver/postgres/deterministic.go
+++ b/internal/driver/postgres/deterministic.go
@@ -370,7 +370,7 @@ func (r deterministicDDL) columnType(col driver.Column) (string, error) {
 	dt := strings.ToLower(strings.TrimSpace(col.DataType))
 
 	ct := canonical.ToCanonical(dt, driver.MetaOf(col), r.sourceDialect)
-	typ, err := canonical.FromCanonical(ct, "postgres", canonical.RenderOpts{IsIdentity: col.IsIdentity})
+	typ, warnings, err := canonical.FromCanonicalWithWarnings(ct, "postgres", canonical.RenderOpts{IsIdentity: col.IsIdentity})
 	if err != nil {
 		if errors.Is(err, canonical.ErrUnknownType) {
 			switch r.unknownTypePolicy {
@@ -383,6 +383,13 @@ func (r deterministicDDL) columnType(col driver.Column) (string, error) {
 			return "", fmt.Errorf("unsupported source type %q", col.DataType)
 		}
 		return "", err
+	}
+	for _, w := range warnings {
+		source := r.sourceDialect
+		if source == "" {
+			source = "unknown"
+		}
+		logging.Warn("deterministic PostgreSQL type mapper: %s→postgres column %s rendered as %s with warning: %s", source, col.Name, typ, w.Reason)
 	}
 
 	if col.IsIdentity {

--- a/internal/driver/postgres/reader.go
+++ b/internal/driver/postgres/reader.go
@@ -369,7 +369,57 @@ func (r *Reader) loadColumns(ctx context.Context, t *driver.Table) error {
 		}
 		t.Columns = append(t.Columns, c)
 	}
-	return rows.Err()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	return r.loadSpatialColumns(ctx, t)
+}
+
+func (r *Reader) loadSpatialColumns(ctx context.Context, t *driver.Table) error {
+	if err := r.loadPostGISSpatialView(ctx, t, "geometry_columns", "f_geometry_column", "geometry"); err != nil {
+		return err
+	}
+	return r.loadPostGISSpatialView(ctx, t, "geography_columns", "f_geography_column", "geography")
+}
+
+func (r *Reader) loadPostGISSpatialView(ctx context.Context, t *driver.Table, view, columnField, family string) error {
+	query := fmt.Sprintf(`
+		SELECT %s, COALESCE(type, ''), COALESCE(srid, 0)
+		FROM %s
+		WHERE f_table_schema = $1 AND f_table_name = $2
+	`, columnField, view)
+	rows, err := r.sqlDB.QueryContext(ctx, query, t.Schema, t.Name)
+	if err != nil {
+		logging.Debug("skipping PostgreSQL %s metadata for %s.%s: %v", view, t.Schema, t.Name, err)
+		return nil
+	}
+	defer rows.Close()
+
+	type spatialMeta struct {
+		family  string
+		subtype string
+		srid    int
+	}
+	metadata := make(map[string]spatialMeta)
+	for rows.Next() {
+		var name, subtype string
+		var srid int
+		if err := rows.Scan(&name, &subtype, &srid); err != nil {
+			return fmt.Errorf("scanning %s metadata: %w", view, err)
+		}
+		metadata[strings.ToLower(name)] = spatialMeta{family: family, subtype: subtype, srid: srid}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating %s metadata: %w", view, err)
+	}
+	for i := range t.Columns {
+		if m, ok := metadata[strings.ToLower(t.Columns[i].Name)]; ok {
+			t.Columns[i].DataType = m.family
+			t.Columns[i].SpatialSubType = m.subtype
+			t.Columns[i].SRID = m.srid
+		}
+	}
+	return nil
 }
 
 func (r *Reader) loadPrimaryKey(ctx context.Context, t *driver.Table) error {

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -133,6 +133,7 @@ type Column struct {
 	ComputedPersisted         bool     `json:"computed_persisted,omitempty"`   // true if computed value is persisted/stored (vs virtual)
 	EnumValues                []string `json:"enum_values,omitempty"`          // allowed values for MySQL ENUM/SET columns
 	SRID                      int      `json:"srid,omitempty"`                 // Spatial Reference ID for geography/geometry columns (0 = default/unset)
+	SpatialSubType            string   `json:"spatial_subtype,omitempty"`      // Spatial subtype (point, polygon, etc.) when the catalog exposes it
 	SampleValues              []string `json:"sample_values,omitempty"`        // Sample data values for AI type mapping context
 }
 
@@ -166,6 +167,8 @@ func MetaOf(col Column) canonical.TypeMeta {
 		IsUnsigned:        col.IsUnsigned,
 		DisplayWidth:      col.DisplayWidth,
 		EnumValues:        col.EnumValues,
+		SRID:              col.SRID,
+		SpatialSubType:    col.SpatialSubType,
 	}
 }
 
@@ -278,7 +281,7 @@ func (c *Column) GoValueBytes() int64 {
 		return sizeofStringHeader + dataLen
 
 	// Spatial types → string serialization
-	case dt == "geography" || dt == "geometry":
+	case canonical.IsSpatialTypeName(dt):
 		return sizeofStringHeader + 512
 
 	default:
@@ -316,11 +319,7 @@ func (t *Table) GoHeapBytesPerRow() int64 {
 
 // IsSpatialType returns true if the column is a spatial type.
 func (c *Column) IsSpatialType() bool {
-	switch c.DataType {
-	case "geography", "geometry":
-		return true
-	}
-	return false
+	return canonical.IsSpatialTypeName(c.DataType)
 }
 
 // Partition represents a data partition for parallel processing.

--- a/internal/driver/verify_compare.go
+++ b/internal/driver/verify_compare.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"smt/internal/canonical"
 )
 
 // fspNowArgPattern matches a bare function name with a single numeric
@@ -32,6 +34,8 @@ var fspNowArgPattern = regexp.MustCompile(`^([a-z_]+)\([0-9]+\)$`)
 // CONVERT(date, GETDATE()) default classify by its result (a date) rather than
 // the inner now-function, mirroring a PG <expr>::date cast.
 var convertTemporalRE = regexp.MustCompile(`(?i)^convert\(\s*[\["]?\s*(date|time)\s*[\]"]?\s*,\s*(.+?)\s*\)$`)
+
+var renderedTypeArgsRE = regexp.MustCompile(`\([^)]*\)`)
 
 // ColumnDelta records a single per-(column, criterion) mismatch from
 // CompareColumns. Format() renders it in the same wire shape #53's prompt
@@ -48,9 +52,9 @@ func (d ColumnDelta) String() string {
 	return fmt.Sprintf("%s: %s — %s vs %s", d.Column, d.Criterion, d.SourceVal, d.TargetVal)
 }
 
-// CompareColumns runs the six per-column criteria deterministically. Returns
+// CompareColumns runs the per-column criteria deterministically. Returns
 // an empty slice when the parsed target columns preserve the source under
-// every criterion the harness applies (max_length, precision, scale,
+// every criterion the harness applies (type, max_length, precision, scale,
 // nullability, identity, TZ class, default class). Caller's responsibility:
 // pass *parsed* target columns whose attributes faithfully reflect the
 // proposed DDL — i.e. the AI's parse step must round-trip the DDL into a
@@ -115,13 +119,70 @@ func CompareColumns(src, tgt []Column, srcDialect, tgtDialect string) []ColumnDe
 			}
 			fns = append(fns, cmpDefaultClass)
 		}
+		var columnDeltas []ColumnDelta
 		for _, fn := range fns {
 			if d := fn(s, t, srcDialect, tgtDialect); d != nil {
+				deltas = append(deltas, *d)
+				columnDeltas = append(columnDeltas, *d)
+			}
+		}
+		if !sameFixedClass && !hasTypeShapeDelta(columnDeltas) {
+			if d := cmpCanonicalType(s, t, srcDialect, tgtDialect); d != nil {
 				deltas = append(deltas, *d)
 			}
 		}
 	}
 	return deltas
+}
+
+func hasTypeShapeDelta(ds []ColumnDelta) bool {
+	for _, d := range ds {
+		switch d.Criterion {
+		case "max_length", "precision", "scale", "tz_class":
+			return true
+		}
+	}
+	return false
+}
+
+func cmpCanonicalType(src, tgt Column, srcDialect, tgtDialect string) *ColumnDelta {
+	expected, ok := renderedCanonicalType(src, srcDialect, tgtDialect)
+	if !ok {
+		return nil
+	}
+	actual, ok := renderedCanonicalType(tgt, tgtDialect, tgtDialect)
+	if !ok {
+		return nil
+	}
+	if (src.IsComputed || tgt.IsComputed) && normalizeRenderedTypeBase(expected) == normalizeRenderedTypeBase(actual) {
+		return nil
+	}
+	if normalizeRenderedType(expected) == normalizeRenderedType(actual) {
+		return nil
+	}
+	return &ColumnDelta{
+		Column:    src.Name,
+		Criterion: "type",
+		SourceVal: expected,
+		TargetVal: actual,
+	}
+}
+
+func renderedCanonicalType(col Column, sourceDialect, targetDialect string) (string, bool) {
+	ct := canonical.ToCanonical(col.DataType, MetaOf(col), sourceDialect)
+	typ, err := canonical.FromCanonical(ct, targetDialect, canonical.RenderOpts{IsIdentity: col.IsIdentity})
+	if err != nil {
+		return "", false
+	}
+	return typ, true
+}
+
+func normalizeRenderedType(s string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(s))), " ")
+}
+
+func normalizeRenderedTypeBase(s string) string {
+	return strings.Join(strings.Fields(renderedTypeArgsRE.ReplaceAllString(strings.ToLower(strings.TrimSpace(s)), "")), " ")
 }
 
 // cmpMaxLength enforces criterion 1 (length): source max_length must round-

--- a/internal/driver/verify_compare_test.go
+++ b/internal/driver/verify_compare_test.go
@@ -377,6 +377,27 @@ func TestCompareColumns_MissingColumn(t *testing.T) {
 	}
 }
 
+func TestCompareColumns_CanonicalTypeMismatch(t *testing.T) {
+	src := []Column{{Name: "amount", DataType: "int"}}
+	tgt := []Column{{Name: "amount", DataType: "text"}}
+	deltas := CompareColumns(src, tgt, "mssql", "postgres")
+	if len(deltas) != 1 || deltas[0].Criterion != "type" {
+		t.Fatalf("expected one canonical type delta, got %v", deltas)
+	}
+	if !strings.Contains(deltas[0].String(), "integer vs text") {
+		t.Errorf("type delta should compare rendered target types, got %q", deltas[0].String())
+	}
+}
+
+func TestCompareColumns_CanonicalTypeCatchesMySQLUnsigned(t *testing.T) {
+	src := []Column{{Name: "n", DataType: "int", IsUnsigned: true}}
+	tgt := []Column{{Name: "n", DataType: "int"}}
+	deltas := CompareColumns(src, tgt, "mysql", "mysql")
+	if len(deltas) != 1 || deltas[0].Criterion != "type" {
+		t.Fatalf("expected one canonical type delta for lost unsigned flag, got %v", deltas)
+	}
+}
+
 // TestCompareColumns_UUIDClassEquivalence pins the cross-dialect UUID
 // storage equivalence. The matrix run that motivated this fix exhausted
 // retries on `external_id: max_length — 0 vs 36`: source is mssql

--- a/internal/orchestrator/ddl_plan.go
+++ b/internal/orchestrator/ddl_plan.go
@@ -134,6 +134,7 @@ type createDDLRenderer struct {
 	ddlRenderer          ddl.Renderer
 	aiReviewEnabled      bool
 	aiReviewMode         string
+	reviewWarnings       *reviewWarningRecorder
 	tableVerifier        driver.TableDDLReviewer
 	finalizationVerifier driver.FinalizationDDLReviewer
 }
@@ -188,6 +189,7 @@ func (o *Orchestrator) newCreateDDLRenderer() (createDDLRenderer, error) {
 		ddlRenderer:          ddlRenderer,
 		aiReviewEnabled:      reviewEnabled,
 		aiReviewMode:         o.config.AIReview.Mode,
+		reviewWarnings:       &reviewWarningRecorder{},
 		tableVerifier:        tableVerifier,
 		finalizationVerifier: finalizationVerifier,
 	}, nil
@@ -396,7 +398,7 @@ func (r createDDLRenderer) reviewTable(ctx context.Context, t *driver.Table, ddl
 	if err != nil {
 		return fmt.Errorf("AI review failed for table %s: %w", t.FullName(), err)
 	}
-	return handleReviewVerdict(r.aiReviewMode, fmt.Sprintf("table %s", t.FullName()), verdict)
+	return r.handleReviewVerdict(fmt.Sprintf("table %s", t.FullName()), verdict)
 }
 
 func (r createDDLRenderer) reviewFinalization(ctx context.Context, ddlType driver.DDLType, t *driver.Table, idx *driver.Index, fk *driver.ForeignKey, chk *driver.CheckConstraint, ddl string) error {
@@ -421,10 +423,18 @@ func (r createDDLRenderer) reviewFinalization(ctx context.Context, ddlType drive
 	if err != nil {
 		return fmt.Errorf("AI review failed for %s on %s: %w", ddlType, t.FullName(), err)
 	}
-	return handleReviewVerdict(r.aiReviewMode, fmt.Sprintf("%s on %s", ddlType, t.FullName()), verdict)
+	return r.handleReviewVerdict(fmt.Sprintf("%s on %s", ddlType, t.FullName()), verdict)
 }
 
 func handleReviewVerdict(mode, label string, verdict *driver.VerifyResult) error {
+	return handleReviewVerdictRecorded(mode, label, verdict, nil)
+}
+
+func (r createDDLRenderer) handleReviewVerdict(label string, verdict *driver.VerifyResult) error {
+	return handleReviewVerdictRecorded(r.aiReviewMode, label, verdict, r.reviewWarnings)
+}
+
+func handleReviewVerdictRecorded(mode, label string, verdict *driver.VerifyResult, warnings *reviewWarningRecorder) error {
 	// A nil verdict with no error is a reviewer-contract violation: review is
 	// enabled but produced no audit result. Fail closed (regardless of mode,
 	// like a provider failure) rather than letting apply proceed unreviewed.
@@ -438,6 +448,9 @@ func handleReviewVerdict(mode, label string, verdict *driver.VerifyResult) error
 	msg := strings.Join(verdict.Issues, "\n  ")
 	if strings.EqualFold(mode, "fail") {
 		return fmt.Errorf("AI review flagged %d issue(s) on %s:\n  %s", len(verdict.Issues), label, msg)
+	}
+	if warnings != nil {
+		warnings.Record(label, verdict.Issues)
 	}
 	logging.Warn("AI review flagged %d issue(s) on %s:\n  %s", len(verdict.Issues), label, msg)
 	return nil

--- a/internal/orchestrator/manifest.go
+++ b/internal/orchestrator/manifest.go
@@ -30,17 +30,19 @@ import (
 const manifestArtifactName = "manifest.json"
 
 type runManifest struct {
-	SMTVersion        string `json:"smt_version"`
-	RendererVersion   string `json:"renderer_version"`
-	SourceDialect     string `json:"source_dialect"`
-	TargetDialect     string `json:"target_dialect"`
-	TargetSchema      string `json:"target_schema"`
-	UnknownTypePolicy string `json:"unknown_type_policy"`
-	AIReviewEnabled   bool   `json:"ai_review_enabled"`
-	AIReviewMode      string `json:"ai_review_mode,omitempty"`
-	TableCount        int    `json:"table_count"`
-	SourceFingerprint string `json:"source_schema_fingerprint"`
-	PlanFingerprint   string `json:"plan_fingerprint"`
+	SMTVersion        string            `json:"smt_version"`
+	RendererVersion   string            `json:"renderer_version"`
+	SourceDialect     string            `json:"source_dialect"`
+	TargetDialect     string            `json:"target_dialect"`
+	TargetSchema      string            `json:"target_schema"`
+	UnknownTypePolicy string            `json:"unknown_type_policy"`
+	AIReviewEnabled   bool              `json:"ai_review_enabled"`
+	AIReviewMode      string            `json:"ai_review_mode,omitempty"`
+	AIReviewWarnings  []aiReviewWarning `json:"ai_review_warnings,omitempty"`
+	MappingWarnings   []mappingWarning  `json:"mapping_warnings,omitempty"`
+	TableCount        int               `json:"table_count"`
+	SourceFingerprint string            `json:"source_schema_fingerprint"`
+	PlanFingerprint   string            `json:"plan_fingerprint"`
 }
 
 // writeRunManifest fingerprints the source schema and the rendered SQL and
@@ -63,6 +65,8 @@ func (o *Orchestrator) writeRunManifest(ctx context.Context, runID string, r cre
 		UnknownTypePolicy: r.unknownTypePolicy,
 		AIReviewEnabled:   r.aiReviewEnabled,
 		AIReviewMode:      r.aiReviewMode,
+		AIReviewWarnings:  snapshotReviewWarnings(r.reviewWarnings),
+		MappingWarnings:   collectMappingWarnings(o.tables, r.sourceType, r.targetType),
 		TableCount:        len(o.tables),
 		SourceFingerprint: srcFP,
 		PlanFingerprint:   fingerprintBytes([]byte(planSQL)),
@@ -76,6 +80,13 @@ func (o *Orchestrator) writeRunManifest(ctx context.Context, runID string, r cre
 		return err
 	}
 	return os.WriteFile(filepath.Join(dir, manifestArtifactName), append(data, '\n'), 0600)
+}
+
+func snapshotReviewWarnings(r *reviewWarningRecorder) []aiReviewWarning {
+	if r == nil {
+		return nil
+	}
+	return r.Snapshot()
 }
 
 // canonicalSourceSnapshot returns a copy of the in-scope source tables loaded

--- a/internal/orchestrator/manifest_test.go
+++ b/internal/orchestrator/manifest_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -81,5 +82,35 @@ func TestFingerprintBytes(t *testing.T) {
 	second := fingerprintBytes([]byte("same"))
 	if first != second {
 		t.Error("identical bytes hashed to different fingerprints")
+	}
+}
+
+func TestCollectMappingWarningsForManifest(t *testing.T) {
+	tables := []driver.Table{{
+		Schema: "dbo",
+		Name:   "Accounts",
+		Columns: []driver.Column{{
+			Name:       "ExternalId",
+			DataType:   "bigint",
+			IsUnsigned: true,
+		}},
+	}}
+	warnings := collectMappingWarnings(tables, "mysql", "postgres")
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %d, want 1: %#v", len(warnings), warnings)
+	}
+	if warnings[0].Table != "dbo.Accounts" || warnings[0].Column != "ExternalId" {
+		t.Fatalf("warning location = %#v", warnings[0])
+	}
+	if warnings[0].TargetType != "numeric(20,0)" || warnings[0].Kind != "bigint" {
+		t.Fatalf("warning mapping = %#v", warnings[0])
+	}
+
+	blob, err := json.Marshal(runManifest{MappingWarnings: warnings})
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if !strings.Contains(string(blob), "mapping_warnings") {
+		t.Fatalf("manifest JSON did not include mapping_warnings: %s", blob)
 	}
 }

--- a/internal/orchestrator/mapping_warnings.go
+++ b/internal/orchestrator/mapping_warnings.go
@@ -1,0 +1,53 @@
+package orchestrator
+
+import (
+	"strings"
+
+	"smt/internal/canonical"
+	"smt/internal/driver"
+)
+
+type mappingWarning struct {
+	Table         string `json:"table"`
+	Column        string `json:"column"`
+	SourceDialect string `json:"source_dialect"`
+	TargetDialect string `json:"target_dialect"`
+	SourceType    string `json:"source_type"`
+	TargetType    string `json:"target_type"`
+	Kind          string `json:"kind"`
+	Reason        string `json:"reason"`
+}
+
+func collectMappingWarnings(tables []driver.Table, sourceDialect, targetDialect string) []mappingWarning {
+	var out []mappingWarning
+	for _, t := range tables {
+		for _, col := range t.Columns {
+			ct := canonical.ToCanonical(col.DataType, driver.MetaOf(col), sourceDialect)
+			targetType, warnings, err := canonical.FromCanonicalWithWarnings(
+				ct, targetDialect, canonical.RenderOpts{IsIdentity: col.IsIdentity})
+			if err != nil {
+				continue
+			}
+			for _, w := range warnings {
+				out = append(out, mappingWarning{
+					Table:         tableLabel(t),
+					Column:        col.Name,
+					SourceDialect: strings.TrimSpace(sourceDialect),
+					TargetDialect: strings.TrimSpace(targetDialect),
+					SourceType:    col.DataType,
+					TargetType:    targetType,
+					Kind:          w.Kind,
+					Reason:        w.Reason,
+				})
+			}
+		}
+	}
+	return out
+}
+
+func tableLabel(t driver.Table) string {
+	if strings.TrimSpace(t.Schema) == "" {
+		return t.Name
+	}
+	return t.FullName()
+}

--- a/internal/orchestrator/review_contract_test.go
+++ b/internal/orchestrator/review_contract_test.go
@@ -9,6 +9,7 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -42,6 +43,7 @@ func reviewerFor(f *fakeReviewer, enabled bool, mode string) createDDLRenderer {
 		targetSchema:         "public",
 		aiReviewEnabled:      enabled,
 		aiReviewMode:         mode,
+		reviewWarnings:       &reviewWarningRecorder{},
 		tableVerifier:        f,
 		finalizationVerifier: f,
 	}
@@ -139,6 +141,43 @@ func TestReview_CannotRewriteDDL(t *testing.T) {
 	var vr driver.VerifyResult = *f.verdict
 	_ = vr.OK
 	_ = vr.Issues
+}
+
+func TestReview_WarnModeRecordsWarningsForManifest(t *testing.T) {
+	f := &fakeReviewer{verdict: &driver.VerifyResult{OK: false, Issues: []string{"missing index", "nullable changed"}}}
+	r := reviewerFor(f, true, "warn")
+	if err := r.reviewTable(context.Background(), sampleTable(), "CREATE TABLE ..."); err != nil {
+		t.Fatalf("warn verdict should not block: %v", err)
+	}
+	warnings := r.reviewWarnings.Snapshot()
+	if len(warnings) != 1 {
+		t.Fatalf("recorded warnings = %d, want 1", len(warnings))
+	}
+	if warnings[0].Label != "table dbo.Users" {
+		t.Fatalf("warning label = %q", warnings[0].Label)
+	}
+	if got := strings.Join(warnings[0].Issues, "|"); got != "missing index|nullable changed" {
+		t.Fatalf("warning issues = %q", got)
+	}
+
+	blob, err := json.Marshal(runManifest{AIReviewWarnings: warnings})
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if !strings.Contains(string(blob), "ai_review_warnings") {
+		t.Fatalf("manifest JSON did not include ai_review_warnings: %s", blob)
+	}
+}
+
+func TestReview_FailModeDoesNotRecordWarningsBeforeBlocking(t *testing.T) {
+	f := &fakeReviewer{verdict: &driver.VerifyResult{OK: false, Issues: []string{"bad DDL"}}}
+	r := reviewerFor(f, true, "fail")
+	if err := r.reviewTable(context.Background(), sampleTable(), "CREATE TABLE ..."); err == nil {
+		t.Fatal("fail verdict should block")
+	}
+	if got := r.reviewWarnings.Snapshot(); len(got) != 0 {
+		t.Fatalf("fail-mode warnings recorded despite blocking: %#v", got)
+	}
 }
 
 // handleReviewVerdict is the shared decision point; pin it directly too.

--- a/internal/orchestrator/review_warnings.go
+++ b/internal/orchestrator/review_warnings.go
@@ -1,0 +1,39 @@
+package orchestrator
+
+import "sync"
+
+type aiReviewWarning struct {
+	Label  string   `json:"label"`
+	Issues []string `json:"issues"`
+}
+
+type reviewWarningRecorder struct {
+	mu       sync.Mutex
+	warnings []aiReviewWarning
+}
+
+func (r *reviewWarningRecorder) Record(label string, issues []string) {
+	if r == nil {
+		return
+	}
+	copied := append([]string(nil), issues...)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.warnings = append(r.warnings, aiReviewWarning{Label: label, Issues: copied})
+}
+
+func (r *reviewWarningRecorder) Snapshot() []aiReviewWarning {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]aiReviewWarning, len(r.warnings))
+	for i := range r.warnings {
+		out[i] = aiReviewWarning{
+			Label:  r.warnings[i].Label,
+			Issues: append([]string(nil), r.warnings[i].Issues...),
+		}
+	}
+	return out
+}

--- a/internal/schemadiff/diff_test.go
+++ b/internal/schemadiff/diff_test.go
@@ -175,6 +175,35 @@ func TestRenderDeterministic_AddedColumnPostgres(t *testing.T) {
 	}
 }
 
+func TestRenderDeterministic_SQLIncludesMappingWarnings(t *testing.T) {
+	d := Diff{ChangedTables: []TableDiff{{
+		Name: "users",
+		Curr: driver.Table{Name: "users", Columns: []driver.Column{{Name: "account_id", DataType: "bigint", IsUnsigned: true}}},
+		AddedColumns: []driver.Column{{
+			Name:       "account_id",
+			DataType:   "bigint",
+			IsUnsigned: true,
+			IsNullable: true,
+		}},
+	}}}
+	plan, err := RenderDeterministicWithOptions(d, RenderOptions{
+		TargetSchema:      "public",
+		TargetDialect:     "postgres",
+		SourceDialect:     "mysql",
+		UnknownTypePolicy: "fail",
+	})
+	if err != nil {
+		t.Fatalf("RenderDeterministicWithOptions: %v", err)
+	}
+	if len(plan.Statements) != 1 || len(plan.Statements[0].Warnings) == 0 {
+		t.Fatalf("expected mapping warning on added column statement, got %+v", plan.Statements)
+	}
+	if sql := plan.SQL(); !strings.Contains(sql, "-- warning: column account_id") ||
+		!strings.Contains(sql, "target has no unsigned 64-bit integer") {
+		t.Fatalf("plan SQL did not include mapping warning:\n%s", sql)
+	}
+}
+
 func TestRenderDeterministic_AddedTableIncludesSideObjects(t *testing.T) {
 	prev := Snapshot{Tables: []driver.Table{table("Users", col("Id", "int", false))}}
 	audit := driver.Table{

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -43,7 +43,7 @@ type TableDrift struct {
 	// destructive.
 	ExtraColumns []string
 	// ColumnDeltas are columns present on both sides whose metadata differs
-	// (type class, length, precision, nullability, identity, default class).
+	// (canonical type, length, precision, nullability, identity, default class).
 	// Each entry is a human-readable description from the deterministic
 	// comparator.
 	ColumnDeltas []string
@@ -245,30 +245,10 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, op
 		td.ColumnDeltas = append(td.ColumnDeltas, delta.String())
 	}
 
-	// CompareColumns checks length/precision/nullability/identity/TZ/default
-	// but not the general type family, so an `int` → `text` change (both with
-	// no length/default/identity) slips through. Flag a high-confidence family
-	// mismatch on matched columns. Deliberately conservative — only the strict
-	// families participate, and a flag fires ONLY when BOTH sides resolve to a
-	// known, differing family. This avoids false positives on a freshly created
-	// target, which is the bar drift must clear: SMT's own mappings must read
-	// as "no drift." Cases left to the comparator's existing equivalence rules
-	// (and therefore NOT family-flagged) include bit/boolean (mssql bit → pg
-	// boolean, mysql tinyint(1) → pg smallint — SMT maps these differently per
-	// target, so "boolean" is not a portable family here), uuid (uniqueidentifier
-	// → char(36)), and json/xml.
-	//
-	// Known limitations, all rooted in the lack of a canonical concrete-type /
-	// expression model (#62): a SAME-family type change (integer→bigint,
-	// varchar(20)→char(20)), a one-sided class change involving an unrecognized
-	// type (int→uuid, bit→integer), a datetime fractional-seconds change
-	// (DATETIME(6)→DATETIME(0)) — comparing it cleanly needs target-max-fsp
-	// awareness to not false-flag a legit clamp like mssql datetime2(7)→pg
-	// timestamp(6) — a same-dialect ENUM→TEXT change or ENUM value-list change,
-	// and per-column EXPRESSION/value details whose text differs across dialects
-	// (computed-expression bodies, ON UPDATE expressions, spatial SRID). Drift
-	// catches presence/structure (computed Y/N + storage class, type family,
-	// length/nullability/identity/TZ/default) today.
+	// CompareColumns handles canonical type equivalence plus length/precision/
+	// nullability/identity/TZ/default. Drift adds only schema-object facts the
+	// column comparator intentionally does not cover: target-only columns,
+	// computed storage class, PKs, indexes, FKs, and CHECK counts.
 	haveByName := make(map[string]driver.Column, len(have.Columns))
 	for _, c := range have.Columns {
 		haveByName[strings.ToLower(c.Name)] = c
@@ -279,20 +259,6 @@ func tableDrift(want, have driver.Table, sourceDialect, targetDialect string, op
 			continue
 		}
 		name := strings.ToLower(sc.Name)
-		if sf, tf := strictTypeFamily(sc.DataType), strictTypeFamily(tc.DataType); sf != "" && tf != "" && sf != tf {
-			td.ColumnDeltas = append(td.ColumnDeltas,
-				name+" type class: source="+sf+" target="+tf)
-		}
-		// MySQL UNSIGNED is a structured flag (Column.IsUnsigned) the readers
-		// populate and the renderer preserves. INT UNSIGNED → INT halves the
-		// positive range, so a same-dialect change must drift. Only compared
-		// MySQL→MySQL: cross-dialect, unsigned is absorbed into a wider target
-		// type (mysql int unsigned → pg bigint), where the target legitimately
-		// carries no unsigned flag and a comparison would false-flag.
-		if isMySQLDialect(sourceDialect) && isMySQLDialect(targetDialect) && sc.IsUnsigned != tc.IsUnsigned {
-			td.ColumnDeltas = append(td.ColumnDeltas,
-				name+" unsigned: source="+boolStr(sc.IsUnsigned)+" target="+boolStr(tc.IsUnsigned))
-		}
 		// Generated/computed status and storage class are cross-dialect
 		// structural facts CompareColumns doesn't cover: a column that's
 		// generated in the source must stay generated on the target, and a
@@ -407,15 +373,6 @@ func targetSupportsVirtualComputed(dialect string) bool {
 	}
 }
 
-func isMySQLDialect(dialect string) bool {
-	switch strings.ToLower(strings.TrimSpace(dialect)) {
-	case "mysql", "mariadb":
-		return true
-	default:
-		return false
-	}
-}
-
 func boolStr(b bool) string {
 	if b {
 		return "true"
@@ -453,36 +410,6 @@ func fkKeys(fks []driver.ForeignKey, ownerSchema string) []string {
 			"|"+normAction(fk.OnDelete)+"|"+normAction(fk.OnUpdate))
 	}
 	return out
-}
-
-// strictTypeFamily classifies a data type into one of the families where a
-// cross-family change is unambiguously incompatible (numeric/string/temporal/
-// binary). Types with known cross-dialect equivalences that span families —
-// boolean (handled by isBooleanType), uuid (uniqueidentifier↔char(36)), json,
-// xml — and anything unrecognized return "" so they are left to the
-// deterministic comparator and never produce a false family mismatch.
-func strictTypeFamily(dataType string) string {
-	switch strings.ToLower(strings.TrimSpace(dataType)) {
-	case "tinyint", "smallint", "mediumint", "int", "integer", "bigint",
-		"int2", "int4", "int8", "serial", "bigserial", "smallserial",
-		"decimal", "numeric", "number", "money", "smallmoney",
-		"float", "double", "double precision", "real", "float4", "float8":
-		return "numeric"
-	case "char", "nchar", "character", "bpchar", "varchar", "nvarchar",
-		"character varying", "text", "ntext", "tinytext", "mediumtext",
-		"longtext", "enum", "set":
-		return "string"
-	case "date", "time", "timetz", "datetime", "datetime2", "smalldatetime",
-		"timestamp", "timestamptz", "datetimeoffset",
-		"timestamp without time zone", "timestamp with time zone",
-		"time without time zone", "time with time zone":
-		return "temporal"
-	case "binary", "varbinary", "image", "bytea", "rowversion",
-		"blob", "tinyblob", "mediumblob", "longblob":
-		return "binary"
-	default:
-		return ""
-	}
 }
 
 // orderedCols joins columns lowercased but order-preserved.

--- a/internal/schemadiff/drift_test.go
+++ b/internal/schemadiff/drift_test.go
@@ -205,8 +205,8 @@ func TestComputeDrift_TypeFamilyMismatch(t *testing.T) {
 		t.Fatalf("expected 1 changed table, got %d: %+v", len(d.ChangedTables), d.ChangedTables)
 	}
 	deltas := strings.Join(d.ChangedTables[0].ColumnDeltas, "\n")
-	if !strings.Contains(deltas, "a type class: source=numeric target=string") {
-		t.Errorf("missing int->text type-class delta, got: %v", d.ChangedTables[0].ColumnDeltas)
+	if !strings.Contains(deltas, "a: type") {
+		t.Errorf("missing int->text canonical type delta, got: %v", d.ChangedTables[0].ColumnDeltas)
 	}
 	if strings.Contains(deltas, "flag") {
 		t.Errorf("bit->boolean false-flagged as type drift: %v", d.ChangedTables[0].ColumnDeltas)
@@ -480,7 +480,7 @@ func TestComputeDrift_MySQLUnsigned(t *testing.T) {
 	tgtSigned := []driver.Table{{Name: "t", Columns: []driver.Column{{Name: "n", DataType: "int", IsUnsigned: false}}}}
 
 	d := ComputeDrift(src, tgtSigned, "mysql", "mysql", DefaultDriftOptions())
-	if len(d.ChangedTables) != 1 || !strings.Contains(strings.Join(d.ChangedTables[0].ColumnDeltas, " "), "unsigned") {
+	if len(d.ChangedTables) != 1 || !strings.Contains(strings.Join(d.ChangedTables[0].ColumnDeltas, " "), "type") {
 		t.Errorf("mysql int unsigned → int should drift, got %+v", d.ChangedTables)
 	}
 	// Cross-dialect: pg bigint target carries no unsigned flag — must not drift.

--- a/internal/schemadiff/render.go
+++ b/internal/schemadiff/render.go
@@ -18,11 +18,12 @@ const (
 
 // Statement is one DDL statement plus its metadata.
 type Statement struct {
-	Table       string `json:"table"`
-	Description string `json:"description"`
-	SQL         string `json:"sql"`
-	Risk        Risk   `json:"risk"`
-	RiskNotes   string `json:"risk_notes,omitempty"`
+	Table       string   `json:"table"`
+	Description string   `json:"description"`
+	SQL         string   `json:"sql"`
+	Risk        Risk     `json:"risk"`
+	RiskNotes   string   `json:"risk_notes,omitempty"`
+	Warnings    []string `json:"warnings,omitempty"`
 	// Kind and Object classify the created object so `create --apply` can
 	// gate execution on target existence (idempotent re-runs, #87). Object
 	// is the target-normalized object name (table/index/FK/check). Sync-
@@ -60,6 +61,9 @@ func (p Plan) SQL() string {
 		fmt.Fprintf(&b, "-- [%s] %s\n", s.Risk, s.Description)
 		if s.RiskNotes != "" {
 			fmt.Fprintf(&b, "-- note: %s\n", s.RiskNotes)
+		}
+		for _, warning := range s.Warnings {
+			fmt.Fprintf(&b, "-- warning: %s\n", warning)
 		}
 		b.WriteString(s.SQL)
 		b.WriteString(";\n\n")

--- a/internal/schemadiff/render_deterministic.go
+++ b/internal/schemadiff/render_deterministic.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"smt/internal/canonical"
 	"smt/internal/ddl"
 	"smt/internal/driver"
 )
@@ -43,8 +44,9 @@ func RenderDeterministicWithOptions(diff Diff, opts RenderOptions) (Plan, error)
 }
 
 type deterministicRenderer struct {
-	target   string
-	renderer ddl.Renderer
+	target        string
+	sourceDialect string
+	renderer      ddl.Renderer
 }
 
 func newDeterministicRenderer(opts RenderOptions) (deterministicRenderer, error) {
@@ -53,7 +55,29 @@ func newDeterministicRenderer(opts RenderOptions) (deterministicRenderer, error)
 		return deterministicRenderer{}, err
 	}
 	r = r.WithSource(opts.SourceDialect)
-	return deterministicRenderer{target: r.Target(), renderer: r}, nil
+	return deterministicRenderer{target: r.Target(), sourceDialect: opts.SourceDialect, renderer: r}, nil
+}
+
+func (r deterministicRenderer) tableMappingWarnings(t driver.Table) []string {
+	var out []string
+	for _, col := range t.Columns {
+		out = append(out, r.columnMappingWarnings(col)...)
+	}
+	return out
+}
+
+func (r deterministicRenderer) columnMappingWarnings(col driver.Column) []string {
+	ct := canonical.ToCanonical(col.DataType, driver.MetaOf(col), r.sourceDialect)
+	targetType, warnings, err := canonical.FromCanonicalWithWarnings(
+		ct, r.target, canonical.RenderOpts{IsIdentity: col.IsIdentity})
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(warnings))
+	for _, warning := range warnings {
+		out = append(out, fmt.Sprintf("column %s (%s -> %s): %s", col.Name, col.DataType, targetType, warning.Reason))
+	}
+	return out
 }
 
 func (r deterministicRenderer) render(diff Diff) (Plan, error) {
@@ -220,6 +244,7 @@ func (r deterministicRenderer) renderAddedTableDefinition(plan *Plan, t driver.T
 		Description: fmt.Sprintf("create table %s", t.Name),
 		SQL:         sql,
 		Risk:        RiskSafe,
+		Warnings:    r.tableMappingWarnings(t),
 	})
 	return nil
 }
@@ -294,6 +319,7 @@ func (r deterministicRenderer) renderTableDiff(plan *Plan, td TableDiff) error {
 			SQL:         sql,
 			Risk:        risk,
 			RiskNotes:   notes,
+			Warnings:    r.columnMappingWarnings(c),
 		})
 	}
 
@@ -372,6 +398,7 @@ func (r deterministicRenderer) renderColumnChange(plan *Plan, tableName string, 
 			SQL:         sql,
 			Risk:        RiskRebuildNeeded,
 			RiskNotes:   "type changes may rewrite the table and can fail if existing values cannot be cast",
+			Warnings:    r.columnMappingWarnings(cc.New),
 		})
 	}
 	if cc.Old.IsNullable != cc.New.IsNullable {


### PR DESCRIPTION
## Summary
- add canonical spatial support for geography/geometry/PostGIS/MySQL spatial types, including SRID/subtype metadata where catalogs expose it
- add warning-aware canonical type rendering and surface lossy mapping warnings in create manifests, renderer logs, and sync dry-run SQL comments
- route column type drift/comparison through canonical rendering and remove schemadiff's separate strict type-family/unsigned checks
- persist warn-mode AI review findings in run manifests

Closes #57
Closes #58
Closes #121
Closes #122
Closes #123

Does not close #69 or #59: review confirmed sync still does not render/apply a live-target-introspected diff plan; that remains separate work.

## Verification
- go test -count=1 ./...
- self-review agent pass completed; actionable findings addressed except #69/#59 scope, which remains open
- CRM live matrix was not run because the required CRM database containers (mssql-bench/pg-bench/mysql-test) are not running in this workspace