### PR TITLE
[codex] Resolve live-target sync planner

### DIFF
--- a/cmd/smt/sync.go
+++ b/cmd/smt/sync.go
@@ -2,18 +2,19 @@ package main
 
 // `smt snapshot` and `smt sync` — the schema-diff feature.
 //
-// snapshot: extract the current source schema, store it in the SMT state DB
-//   so future `sync` runs can diff against it.
+// snapshot: extract the current source schema and store it in the SMT state DB
+//   as a source-schema baseline/history artifact.
 //
-// sync: extract the current source schema, load the latest snapshot, render
-//   the structural diff as ALTER statements, and either write the SQL to a
-//   file (default) or apply it against the target (--apply).
+// sync: extract the current source schema, introspect the live target schema,
+//   render the structural diff as ALTER statements, and either write the SQL
+//   to a file (default) or apply it against the target (--apply).
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -22,6 +23,7 @@ import (
 	"smt/internal/driver"
 	"smt/internal/logging"
 	"smt/internal/orchestrator"
+	"smt/internal/pool"
 	"smt/internal/schemadiff"
 )
 
@@ -99,7 +101,7 @@ func runSnapshot(c *cli.Context) error {
 func syncCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "sync",
-		Usage: "Diff source schema against last snapshot and (optionally) apply ALTERs",
+		Usage: "Diff source schema against the live target and (optionally) apply ALTERs",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{Name: "apply", Usage: "Execute ALTERs against the target (default: emit SQL for review)"},
 			&cli.StringFlag{Name: "out", Aliases: []string{"o"}, Value: "migration.sql", Usage: "Output file when not applying"},
@@ -117,8 +119,7 @@ func runSync(c *cli.Context) error {
 	}
 
 	orch, err := orchestrator.NewWithOptions(cfg, orchestrator.Options{
-		StateFile:  c.String("state-file"),
-		SourceOnly: !c.Bool("apply"),
+		StateFile: c.String("state-file"),
 	})
 	if err != nil {
 		return err
@@ -129,14 +130,21 @@ func runSync(c *cli.Context) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	state, ok := orch.State().(*checkpoint.State)
-	if !ok {
-		return fmt.Errorf("sync requires the SQLite state backend")
+	var state *checkpoint.State
+	if c.Bool("save-snapshot") {
+		var ok bool
+		state, ok = orch.State().(*checkpoint.State)
+		if !ok {
+			return fmt.Errorf("saving snapshots requires the SQLite state backend")
+		}
 	}
 
-	prevSnap, err := loadPreviousSnapshot(state, cfg.Source.Type, cfg.Source.Schema)
-	if err != nil {
-		return err
+	sourceDialect := driver.Canonicalize(cfg.Source.Type)
+	targetDialect := driver.Canonicalize(cfg.Target.Type)
+	opts := schemadiff.DriftOptions{
+		CompareIndexes:     cfg.Migration.CreateIndexes,
+		CompareForeignKeys: cfg.Migration.CreateForeignKeys,
+		CompareChecks:      cfg.Migration.CreateCheckConstraints,
 	}
 
 	logging.Info("extracting current source schema")
@@ -156,34 +164,46 @@ func runSync(c *cli.Context) error {
 		Tables:     currTables,
 	}
 
-	diff := schemadiff.Compute(prevSnap, currSnap)
-	if diff.IsEmpty() {
-		fmt.Println("No schema changes since last snapshot.")
-		return nil
+	norm := func(name string) string { return driver.NormalizeIdentifier(targetDialect, name) }
+	allSourceNorm := make(map[string]bool, len(currTables))
+	for _, t := range currTables {
+		allSourceNorm[strings.ToLower(norm(t.Name))] = true
+	}
+	desired := filterDesiredScope(currTables, cfg.Migration.IncludeTables, cfg.Migration.ExcludeTables)
+	desired = schemadiff.NormalizeIdentifiers(desired, norm)
+	desired = schemadiff.RetargetSchema(desired, cfg.Target.Schema)
+
+	logging.Info("introspecting target schema (%s)", cfg.Target.Schema)
+	targetReader, err := pool.NewSourcePool(targetAsSource(cfg), 4)
+	if err != nil {
+		return fmt.Errorf("opening target reader: %w", err)
+	}
+	defer targetReader.Close()
+	existing, err := targetReader.ExtractSchema(ctx, cfg.Target.Schema)
+	if err != nil {
+		return fmt.Errorf("introspecting target: %w", err)
+	}
+	if len(cfg.Migration.IncludeTables) > 0 || len(cfg.Migration.ExcludeTables) > 0 {
+		existing = filterToManagedSet(existing, desired, allSourceNorm)
+	}
+	if err := loadConstraintsGated(ctx, targetReader, existing, opts); err != nil {
+		return err
 	}
 
-	// Re-write source-original identifiers (e.g. MSSQL "Posts") to whatever
-	// the target dialect actually uses on disk (PG lowercases to "posts").
-	// Without this the renderer emits ALTERs against names the target doesn't have.
-	// See driver.NormalizeIdentifier for the per-dialect rules.
-	diff = diff.Normalize(func(name string) string {
-		return driver.NormalizeIdentifier(cfg.Target.Type, name)
-	})
-
-	// Point every table in the diff at the target schema. The diff carries
-	// source-side metadata in Table.Schema (e.g. the MySQL database name),
-	// and renderers use that for the ALTER TABLE qualifier unless we override
-	// it. Without this, MySQL→MSSQL produces ALTER TABLE [smt_src_test].[Posts]
-	// against an MSSQL target whose schema is dbo. See issue #4.
-	diff = diff.WithTargetSchema(cfg.Target.Schema)
+	diff := schemadiff.ComputeLiveDiff(desired, existing, sourceDialect, targetDialect, opts)
+	if diff.IsEmpty() {
+		fmt.Println("No schema drift: target matches the source-derived schema.")
+		return nil
+	}
 
 	fmt.Printf("Diff: %s\n", diff.Summary())
 
 	logging.Info("rendering diff deterministically as %s SQL...", cfg.Target.Type)
 	plan, err := schemadiff.RenderDeterministicWithOptions(diff, schemadiff.RenderOptions{
 		TargetSchema:      cfg.Target.Schema,
-		TargetDialect:     cfg.Target.Type,
-		SourceDialect:     cfg.Source.Type,
+		TargetDialect:     targetDialect,
+		SourceDialect:     sourceDialect,
+		ExistingDialect:   targetDialect,
 		UnknownTypePolicy: cfg.SchemaGeneration.UnknownTypePolicy,
 	})
 	if err != nil {
@@ -193,6 +213,7 @@ func runSync(c *cli.Context) error {
 		fmt.Println("Renderer returned no statements; nothing to apply.")
 		return nil
 	}
+	printPlanSummary(plan)
 
 	if !c.Bool("apply") {
 		out := c.String("out")
@@ -202,6 +223,11 @@ func runSync(c *cli.Context) error {
 		fmt.Printf("%d statement(s) written to %s for review.\n", len(plan.Statements), out)
 		fmt.Println("Run again with --apply to execute against the target.")
 		return nil
+	}
+
+	if len(plan.Unsupported) > 0 {
+		printUnsupportedChanges(plan.Unsupported)
+		return fmt.Errorf("refusing to apply plan with unsupported change(s)")
 	}
 
 	if !c.Bool("allow-data-loss") {
@@ -216,7 +242,7 @@ func runSync(c *cli.Context) error {
 	if err := applyPlan(ctx, orch.Target(), plan); err != nil {
 		return err
 	}
-	fmt.Printf("Applied %d statement(s) successfully.\n", len(plan.Statements))
+	fmt.Printf("Applied %d statement(s) successfully; skipped 0 unsupported change(s).\n", len(plan.Statements))
 
 	if c.Bool("save-snapshot") {
 		payload, _ := json.Marshal(currSnap)
@@ -230,10 +256,8 @@ func runSync(c *cli.Context) error {
 }
 
 // loadPreviousSnapshot returns the most recent stored snapshot for this
-// (sourceType, schema). If none exists, an empty snapshot is returned —
-// in that case `sync` would treat every current table as new, which is
-// usually not what the operator wants, so we error out and tell them to
-// run `snapshot` first.
+// (sourceType, schema). Kept for snapshot-history callers and tests; live
+// target sync planning does not require a previous snapshot.
 func loadPreviousSnapshot(state *checkpoint.State, sourceType, schema string) (schemadiff.Snapshot, error) {
 	snapRow, err := state.GetLatestSnapshot(sourceType, schema)
 	if err != nil {
@@ -294,4 +318,39 @@ func applyPlan(ctx context.Context, tgt sqlExecutor, plan schemadiff.Plan) error
 		}
 	}
 	return nil
+}
+
+func printPlanSummary(plan schemadiff.Plan) {
+	var safe, blocking, rebuild, destructive int
+	for _, stmt := range plan.Statements {
+		switch stmt.Risk {
+		case schemadiff.RiskSafe:
+			safe++
+		case schemadiff.RiskBlocking:
+			blocking++
+		case schemadiff.RiskRebuildNeeded:
+			rebuild++
+		case schemadiff.RiskDataLoss:
+			destructive++
+		}
+	}
+	fmt.Printf("Plan: %d statement(s): %d safe, %d blocking, %d rebuild, %d destructive; %d unsupported change(s).\n",
+		len(plan.Statements), safe, blocking, rebuild, destructive, len(plan.Unsupported))
+}
+
+func printUnsupportedChanges(changes []schemadiff.UnsupportedChange) {
+	if len(changes) == 0 {
+		return
+	}
+	fmt.Printf("Unsupported change(s) skipped: %d\n", len(changes))
+	for _, change := range changes {
+		parts := []string{change.Description}
+		if strings.TrimSpace(change.Table) != "" {
+			parts = append(parts, "table "+change.Table)
+		}
+		if strings.TrimSpace(change.Reason) != "" {
+			parts = append(parts, change.Reason)
+		}
+		fmt.Printf("  - %s\n", strings.Join(parts, " - "))
+	}
 }

--- a/internal/schemadiff/diff.go
+++ b/internal/schemadiff/diff.go
@@ -20,9 +20,10 @@ type Diff struct {
 	PrevCapturedAt time.Time `json:"prev_captured_at"`
 	CurrCapturedAt time.Time `json:"curr_captured_at"`
 
-	AddedTables   []driver.Table `json:"added_tables"`
-	RemovedTables []driver.Table `json:"removed_tables"`
-	ChangedTables []TableDiff    `json:"changed_tables"`
+	AddedTables   []driver.Table      `json:"added_tables"`
+	RemovedTables []driver.Table      `json:"removed_tables"`
+	ChangedTables []TableDiff         `json:"changed_tables"`
+	Unsupported   []UnsupportedChange `json:"unsupported,omitempty"`
 }
 
 // TableDiff captures all per-table changes in one place.
@@ -48,14 +49,18 @@ type TableDiff struct {
 // ColumnChange describes a column that exists in both snapshots but with
 // different attributes (type, nullability, length, etc.).
 type ColumnChange struct {
-	Name string        `json:"name"`
-	Old  driver.Column `json:"old"`
-	New  driver.Column `json:"new"`
+	Name     string        `json:"name"`
+	Old      driver.Column `json:"old"`
+	New      driver.Column `json:"new"`
+	Criteria []string      `json:"criteria,omitempty"`
 }
 
 // IsEmpty returns true if the diff would produce no DDL.
 func (d Diff) IsEmpty() bool {
 	if len(d.AddedTables) > 0 || len(d.RemovedTables) > 0 {
+		return false
+	}
+	if len(d.Unsupported) > 0 {
 		return false
 	}
 	for _, td := range d.ChangedTables {
@@ -85,14 +90,17 @@ func (d Diff) Summary() string {
 		return "no schema changes"
 	}
 	var b strings.Builder
-	if len(d.AddedTables) > 0 {
-		fmt.Fprintf(&b, "%d table(s) added, ", len(d.AddedTables))
+	if n := len(d.AddedTables); n > 0 {
+		fmt.Fprintf(&b, "%d table(s) added, ", n)
 	}
-	if len(d.RemovedTables) > 0 {
-		fmt.Fprintf(&b, "%d table(s) removed, ", len(d.RemovedTables))
+	if n := len(d.RemovedTables); n > 0 {
+		fmt.Fprintf(&b, "%d table(s) removed, ", n)
 	}
-	if len(d.ChangedTables) > 0 {
-		fmt.Fprintf(&b, "%d table(s) changed", len(d.ChangedTables))
+	if n := len(d.ChangedTables); n > 0 {
+		fmt.Fprintf(&b, "%d table(s) changed, ", n)
+	}
+	if n := len(d.Unsupported); n > 0 {
+		fmt.Fprintf(&b, "%d unsupported change(s), ", n)
 	}
 	return strings.TrimSuffix(strings.TrimSpace(b.String()), ",")
 }
@@ -111,6 +119,7 @@ func (d Diff) Normalize(norm func(string) string) Diff {
 	out := Diff{
 		PrevCapturedAt: d.PrevCapturedAt,
 		CurrCapturedAt: d.CurrCapturedAt,
+		Unsupported:    append([]UnsupportedChange(nil), d.Unsupported...),
 	}
 	for _, t := range d.AddedTables {
 		out.AddedTables = append(out.AddedTables, normalizeTable(t, norm))
@@ -144,6 +153,7 @@ func (d Diff) WithTargetSchema(targetSchema string) Diff {
 	out := Diff{
 		PrevCapturedAt: d.PrevCapturedAt,
 		CurrCapturedAt: d.CurrCapturedAt,
+		Unsupported:    append([]UnsupportedChange(nil), d.Unsupported...),
 	}
 	for _, t := range d.AddedTables {
 		retargetTable(&t, targetSchema)

--- a/internal/schemadiff/live_diff.go
+++ b/internal/schemadiff/live_diff.go
@@ -1,0 +1,347 @@
+package schemadiff
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"smt/internal/driver"
+)
+
+// ComputeLiveDiff compares the desired target schema derived from the current
+// source against the existing live target schema. Desired tables should already
+// have target-normalized identifiers and target schema references; existing
+// tables should come from target introspection.
+func ComputeLiveDiff(desired, existing []driver.Table, sourceDialect, targetDialect string, opts DriftOptions) Diff {
+	desiredByName := indexByLowerName(desired)
+	existingByName := indexByLowerName(existing)
+
+	var d Diff
+	for _, name := range sortedLowerKeys(desiredByName) {
+		want := desiredByName[name]
+		have, ok := existingByName[name]
+		if !ok {
+			d.AddedTables = append(d.AddedTables, addedTableForOptions(want, opts))
+			continue
+		}
+		td, unsupported := liveTableDiff(want, have, sourceDialect, targetDialect, opts)
+		d.Unsupported = append(d.Unsupported, unsupported...)
+		if !td.IsEmpty() {
+			d.ChangedTables = append(d.ChangedTables, td)
+		}
+	}
+	for _, name := range sortedLowerKeys(existingByName) {
+		if _, ok := desiredByName[name]; !ok {
+			d.RemovedTables = append(d.RemovedTables, existingByName[name])
+		}
+	}
+	return d
+}
+
+func liveTableDiff(want, have driver.Table, sourceDialect, targetDialect string, opts DriftOptions) (TableDiff, []UnsupportedChange) {
+	td := TableDiff{Schema: want.Schema, Name: want.Name, Curr: want}
+	var unsupported []UnsupportedChange
+
+	wantByName := columnByLowerName(want.Columns)
+	haveByName := columnByLowerName(have.Columns)
+
+	for _, wc := range want.Columns {
+		hc, ok := haveByName[strings.ToLower(wc.Name)]
+		if !ok {
+			td.AddedColumns = append(td.AddedColumns, wc)
+			continue
+		}
+		criteria := columnDeltaCriteria(driver.CompareColumns([]driver.Column{wc}, []driver.Column{hc}, sourceDialect, targetDialect))
+		if wc.IsComputed != hc.IsComputed {
+			criteria = appendIfMissing(criteria, "computed")
+		} else if wc.IsComputed && wc.ComputedPersisted != hc.ComputedPersisted && targetSupportsVirtualComputed(targetDialect) {
+			criteria = appendIfMissing(criteria, "computed_storage")
+		}
+		criteria = append(criteria, unsupportedColumnMetadataCriteria(wc, hc, sourceDialect, targetDialect)...)
+		if len(criteria) == 0 {
+			continue
+		}
+		if reason := liveColumnChangeUnsupportedReason(criteria); reason != "" {
+			unsupported = append(unsupported, UnsupportedChange{
+				Table:       want.Name,
+				Description: fmt.Sprintf("change column %s", wc.Name),
+				Reason:      reason,
+			})
+			continue
+		}
+		td.ChangedColumns = append(td.ChangedColumns, ColumnChange{Name: wc.Name, Old: hc, New: wc, Criteria: criteria})
+	}
+	for _, hc := range have.Columns {
+		if _, ok := wantByName[strings.ToLower(hc.Name)]; !ok {
+			td.RemovedColumns = append(td.RemovedColumns, hc)
+		}
+	}
+
+	if !sameColSetCI(want.PrimaryKey, have.PrimaryKey) {
+		unsupported = append(unsupported, UnsupportedChange{
+			Table:       want.Name,
+			Description: "change primary key",
+			Reason:      "primary key add/drop/re-key is not supported by deterministic sync",
+		})
+	}
+
+	if opts.CompareIndexes {
+		td.AddedIndexes, td.RemovedIndexes = liveIndexDiff(want.Indexes, have.Indexes)
+	}
+	if opts.CompareForeignKeys {
+		td.AddedForeignKeys, td.RemovedForeignKeys = liveForeignKeyDiff(want.ForeignKeys, have.ForeignKeys, want.Schema, have.Schema)
+	}
+	if opts.CompareChecks {
+		switch {
+		case len(want.CheckConstraints) > len(have.CheckConstraints):
+			unsupported = append(unsupported, UnsupportedChange{
+				Table:       want.Name,
+				Description: "reconcile check constraints",
+				Reason:      "live target check predicates are dialect-rewritten; deterministic sync compares counts but cannot safely identify which check to add",
+			})
+		case len(want.CheckConstraints) < len(have.CheckConstraints):
+			unsupported = append(unsupported, UnsupportedChange{
+				Table:       want.Name,
+				Description: "reconcile check constraints",
+				Reason:      "dropping target-only check constraints is not supported by deterministic sync",
+			})
+		case sameDialect(sourceDialect, targetDialect) && !sameCheckDefinitions(want.CheckConstraints, have.CheckConstraints):
+			unsupported = append(unsupported, UnsupportedChange{
+				Table:       want.Name,
+				Description: "reconcile check constraints",
+				Reason:      "same-dialect check predicate changes are detected but not rendered by deterministic sync",
+			})
+		}
+	}
+
+	sort.Slice(td.AddedColumns, func(i, j int) bool {
+		return strings.ToLower(td.AddedColumns[i].Name) < strings.ToLower(td.AddedColumns[j].Name)
+	})
+	sort.Slice(td.RemovedColumns, func(i, j int) bool {
+		return strings.ToLower(td.RemovedColumns[i].Name) < strings.ToLower(td.RemovedColumns[j].Name)
+	})
+	sort.Slice(td.ChangedColumns, func(i, j int) bool {
+		return strings.ToLower(td.ChangedColumns[i].Name) < strings.ToLower(td.ChangedColumns[j].Name)
+	})
+	return td, unsupported
+}
+
+func addedTableForOptions(t driver.Table, opts DriftOptions) driver.Table {
+	out := deepCopyTable(t)
+	if !opts.CompareIndexes {
+		out.Indexes = nil
+	}
+	if !opts.CompareForeignKeys {
+		out.ForeignKeys = nil
+	}
+	if !opts.CompareChecks {
+		out.CheckConstraints = nil
+	}
+	return out
+}
+
+func columnByLowerName(cols []driver.Column) map[string]driver.Column {
+	out := make(map[string]driver.Column, len(cols))
+	for _, c := range cols {
+		out[strings.ToLower(c.Name)] = c
+	}
+	return out
+}
+
+func columnDeltaCriteria(deltas []driver.ColumnDelta) []string {
+	seen := make(map[string]bool, len(deltas))
+	var out []string
+	for _, d := range deltas {
+		if d.Criterion == "missing" || seen[d.Criterion] {
+			continue
+		}
+		seen[d.Criterion] = true
+		out = append(out, d.Criterion)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func appendIfMissing(in []string, criterion string) []string {
+	for _, c := range in {
+		if c == criterion {
+			return in
+		}
+	}
+	return append(in, criterion)
+}
+
+func unsupportedColumnMetadataCriteria(want, have driver.Column, sourceDialect, targetDialect string) []string {
+	var criteria []string
+	if strings.TrimSpace(want.OnUpdateExpression) != strings.TrimSpace(have.OnUpdateExpression) {
+		criteria = append(criteria, "on_update")
+	}
+	if want.SRID != have.SRID {
+		criteria = append(criteria, "srid")
+	}
+	if sameDialect(sourceDialect, targetDialect) {
+		if !stringSlicesEqual(want.EnumValues, have.EnumValues) {
+			criteria = append(criteria, "enum_values")
+		}
+		if want.DisplayWidth != have.DisplayWidth {
+			criteria = append(criteria, "display_width")
+		}
+		if want.IsComputed && have.IsComputed && normalizedExpression(want.ComputedExpression) != normalizedExpression(have.ComputedExpression) {
+			criteria = append(criteria, "computed_expression")
+		}
+	}
+	return criteria
+}
+
+func liveColumnChangeUnsupportedReason(criteria []string) string {
+	reasons := make(map[string]bool)
+	for _, c := range criteria {
+		switch c {
+		case "identity":
+			reasons["identity changes are not supported by deterministic sync"] = true
+		case "computed", "computed_storage", "computed_expression":
+			reasons["computed-column changes are not supported by deterministic sync"] = true
+		case "on_update":
+			reasons["ON UPDATE clause changes are detected but not rendered by deterministic sync"] = true
+		case "enum_values":
+			reasons["ENUM/SET value-list changes are detected but not rendered by deterministic sync"] = true
+		case "srid":
+			reasons["spatial SRID changes are detected but not rendered by deterministic sync"] = true
+		case "display_width":
+			reasons["display-width changes are detected but not rendered by deterministic sync"] = true
+		}
+	}
+	if len(reasons) == 0 {
+		return ""
+	}
+	out := make([]string, 0, len(reasons))
+	for reason := range reasons {
+		out = append(out, reason)
+	}
+	sort.Strings(out)
+	return strings.Join(out, "; ")
+}
+
+func sameDialect(a, b string) bool {
+	return driver.Canonicalize(a) == driver.Canonicalize(b)
+}
+
+func sameCheckDefinitions(want, have []driver.CheckConstraint) bool {
+	if len(want) != len(have) {
+		return false
+	}
+	wantDefs := normalizedCheckDefinitions(want)
+	haveDefs := normalizedCheckDefinitions(have)
+	for i := range wantDefs {
+		if wantDefs[i] != haveDefs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizedCheckDefinitions(checks []driver.CheckConstraint) []string {
+	out := make([]string, len(checks))
+	for i, chk := range checks {
+		out[i] = normalizedExpression(chk.Definition)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func normalizedExpression(expr string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(expr)), " "))
+}
+
+func liveIndexDiff(want, have []driver.Index) (added, removed []driver.Index) {
+	wantByKey := make(map[string]driver.Index, len(want))
+	for _, idx := range want {
+		wantByKey[indexKey(idx)] = idx
+	}
+	haveByKey := make(map[string]driver.Index, len(have))
+	for _, idx := range have {
+		haveByKey[indexKey(idx)] = idx
+	}
+	for _, key := range sortedIndexKeys(wantByKey) {
+		if _, ok := haveByKey[key]; !ok {
+			added = append(added, wantByKey[key])
+		}
+	}
+	for _, key := range sortedIndexKeys(haveByKey) {
+		if _, ok := wantByKey[key]; !ok {
+			removed = append(removed, haveByKey[key])
+		}
+	}
+	return added, removed
+}
+
+func indexKey(idx driver.Index) string {
+	key := orderedCols(idx.Columns)
+	if len(idx.IncludeCols) > 0 {
+		key += "/include:" + orderedCols(idx.IncludeCols)
+	}
+	if strings.TrimSpace(idx.Filter) != "" {
+		key += "/filtered"
+	}
+	if idx.IsUnique {
+		key = "unique:" + key
+	}
+	return key
+}
+
+func sortedIndexKeys(m map[string]driver.Index) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func liveForeignKeyDiff(want, have []driver.ForeignKey, wantSchema, haveSchema string) (added, removed []driver.ForeignKey) {
+	wantByKey := make(map[string]driver.ForeignKey, len(want))
+	for _, fk := range want {
+		wantByKey[foreignKeyKey(fk, wantSchema)] = fk
+	}
+	haveByKey := make(map[string]driver.ForeignKey, len(have))
+	for _, fk := range have {
+		haveByKey[foreignKeyKey(fk, haveSchema)] = fk
+	}
+	for _, key := range sortedForeignKeyKeys(wantByKey) {
+		if _, ok := haveByKey[key]; !ok {
+			added = append(added, wantByKey[key])
+		}
+	}
+	for _, key := range sortedForeignKeyKeys(haveByKey) {
+		if _, ok := wantByKey[key]; !ok {
+			removed = append(removed, haveByKey[key])
+		}
+	}
+	return added, removed
+}
+
+func foreignKeyKey(fk driver.ForeignKey, ownerSchema string) string {
+	pairs := make([]string, len(fk.Columns))
+	for i, c := range fk.Columns {
+		ref := ""
+		if i < len(fk.RefColumns) {
+			ref = strings.ToLower(fk.RefColumns[i])
+		}
+		pairs[i] = strings.ToLower(c) + ":" + ref
+	}
+	schema := "self"
+	if s := strings.TrimSpace(fk.RefSchema); s != "" && !strings.EqualFold(s, ownerSchema) {
+		schema = strings.ToLower(s)
+	}
+	return strings.Join(pairs, ",") + "->" + schema + "." + strings.ToLower(fk.RefTable) +
+		"|" + normAction(fk.OnDelete) + "|" + normAction(fk.OnUpdate)
+}
+
+func sortedForeignKeyKeys(m map[string]driver.ForeignKey) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/schemadiff/live_diff_test.go
+++ b/internal/schemadiff/live_diff_test.go
@@ -1,0 +1,218 @@
+package schemadiff
+
+import (
+	"strings"
+	"testing"
+
+	"smt/internal/driver"
+)
+
+func TestComputeLiveDiff_NoFalsePositiveCrossDialect(t *testing.T) {
+	desired := []driver.Table{{Schema: "public", Name: "users", Columns: []driver.Column{
+		{Name: "id", DataType: "int", IsNullable: false},
+		{Name: "name", DataType: "varchar", MaxLength: 20, IsNullable: true},
+	}}}
+	existing := []driver.Table{{Schema: "public", Name: "users", Columns: []driver.Column{
+		{Name: "id", DataType: "integer", IsNullable: false},
+		{Name: "name", DataType: "character varying", MaxLength: 20, IsNullable: true},
+	}}}
+
+	d := ComputeLiveDiff(desired, existing, "mssql", "postgres", DefaultDriftOptions())
+	if !d.IsEmpty() {
+		t.Fatalf("equivalent live target should not produce a plan: %+v", d)
+	}
+}
+
+func TestComputeLiveDiff_ClassifiesStructuredChanges(t *testing.T) {
+	desired := []driver.Table{{Schema: "public", Name: "users", PrimaryKey: []string{"id"}, Columns: []driver.Column{
+		{Name: "id", DataType: "int", IsNullable: false},
+		{Name: "email", DataType: "varchar", MaxLength: 100, IsNullable: true},
+		{Name: "age", DataType: "int", IsNullable: true},
+	}}}
+	existing := []driver.Table{{Schema: "public", Name: "users", Columns: []driver.Column{
+		{Name: "id", DataType: "integer", IsNullable: false},
+		{Name: "legacy", DataType: "text", IsNullable: true},
+		{Name: "age", DataType: "text", IsNullable: true},
+	}}}
+
+	d := ComputeLiveDiff(desired, existing, "mssql", "postgres", DefaultDriftOptions())
+	if len(d.ChangedTables) != 1 {
+		t.Fatalf("expected one changed table, got %+v", d)
+	}
+	td := d.ChangedTables[0]
+	if len(td.AddedColumns) != 1 || td.AddedColumns[0].Name != "email" {
+		t.Fatalf("expected email added, got %+v", td.AddedColumns)
+	}
+	if len(td.RemovedColumns) != 1 || td.RemovedColumns[0].Name != "legacy" {
+		t.Fatalf("expected legacy removed, got %+v", td.RemovedColumns)
+	}
+	if len(td.ChangedColumns) != 1 || td.ChangedColumns[0].Name != "age" ||
+		!containsString(td.ChangedColumns[0].Criteria, "type") {
+		t.Fatalf("expected age type change, got %+v", td.ChangedColumns)
+	}
+	if len(d.Unsupported) != 1 || !strings.Contains(d.Unsupported[0].Description, "primary key") {
+		t.Fatalf("expected unsupported PK change, got %+v", d.Unsupported)
+	}
+}
+
+func TestComputeLiveDiff_IdentityChangeUnsupported(t *testing.T) {
+	desired := []driver.Table{{Schema: "public", Name: "users", Columns: []driver.Column{
+		{Name: "id", DataType: "int", IsIdentity: true},
+	}}}
+	existing := []driver.Table{{Schema: "public", Name: "users", Columns: []driver.Column{
+		{Name: "id", DataType: "integer", IsIdentity: false},
+	}}}
+
+	d := ComputeLiveDiff(desired, existing, "mssql", "postgres", DefaultDriftOptions())
+	if len(d.Unsupported) != 1 || !strings.Contains(d.Unsupported[0].Reason, "identity") {
+		t.Fatalf("identity change should be unsupported, got %+v", d.Unsupported)
+	}
+	if len(d.ChangedTables) != 0 {
+		t.Fatalf("unsupported identity change should not emit partial column DDL: %+v", d.ChangedTables)
+	}
+}
+
+func TestComputeLiveDiff_AddedTableHonorsUnmanagedKinds(t *testing.T) {
+	desired := []driver.Table{{
+		Schema:  "public",
+		Name:    "orders",
+		Columns: []driver.Column{{Name: "id", DataType: "int", IsNullable: false}},
+		Indexes: []driver.Index{{
+			Name:    "ix_orders_id",
+			Columns: []string{"id"},
+		}},
+		ForeignKeys: []driver.ForeignKey{{
+			Name:       "fk_orders_customer",
+			Columns:    []string{"id"},
+			RefTable:   "customers",
+			RefColumns: []string{"id"},
+		}},
+		CheckConstraints: []driver.CheckConstraint{{
+			Name:       "ck_orders_id",
+			Definition: "id > 0",
+		}},
+	}}
+
+	d := ComputeLiveDiff(desired, nil, "mssql", "postgres", DriftOptions{
+		CompareIndexes:     false,
+		CompareForeignKeys: false,
+		CompareChecks:      false,
+	})
+	if len(d.AddedTables) != 1 {
+		t.Fatalf("expected one added table, got %+v", d.AddedTables)
+	}
+	added := d.AddedTables[0]
+	if len(added.Indexes) != 0 || len(added.ForeignKeys) != 0 || len(added.CheckConstraints) != 0 {
+		t.Fatalf("unmanaged side objects should be stripped from added table diff: %+v", added)
+	}
+
+	plan, err := RenderDeterministicWithOptions(d, RenderOptions{
+		TargetSchema:      "public",
+		TargetDialect:     "postgres",
+		SourceDialect:     "mssql",
+		UnknownTypePolicy: "fail",
+	})
+	if err != nil {
+		t.Fatalf("RenderDeterministicWithOptions: %v", err)
+	}
+	if len(plan.Statements) != 1 || plan.Statements[0].Description != "create table orders" {
+		t.Fatalf("expected only create-table statement, got %+v", plan.Statements)
+	}
+}
+
+func TestComputeLiveDiff_MetadataChangeUnsupported(t *testing.T) {
+	desired := []driver.Table{{Schema: "app", Name: "events", Columns: []driver.Column{
+		{Name: "updated_at", DataType: "timestamp", DefaultExpression: "CURRENT_TIMESTAMP", OnUpdateExpression: "CURRENT_TIMESTAMP"},
+		{Name: "status", DataType: "enum", EnumValues: []string{"new", "done"}},
+	}}}
+	existing := []driver.Table{{Schema: "app", Name: "events", Columns: []driver.Column{
+		{Name: "updated_at", DataType: "timestamp", DefaultExpression: "CURRENT_TIMESTAMP"},
+		{Name: "status", DataType: "enum", EnumValues: []string{"new"}},
+	}}}
+
+	d := ComputeLiveDiff(desired, existing, "mysql", "mysql", DefaultDriftOptions())
+	if len(d.Unsupported) != 2 {
+		t.Fatalf("metadata changes should be unsupported, got %+v", d.Unsupported)
+	}
+	reasons := d.Unsupported[0].Reason + " " + d.Unsupported[1].Reason
+	if !strings.Contains(reasons, "ON UPDATE") || !strings.Contains(reasons, "ENUM/SET") {
+		t.Fatalf("unsupported metadata reasons missing detail: %+v", d.Unsupported)
+	}
+	if len(d.ChangedTables) != 0 {
+		t.Fatalf("unsupported metadata changes should not emit partial column DDL: %+v", d.ChangedTables)
+	}
+}
+
+func TestComputeLiveDiff_SameDialectCheckDefinitionUnsupported(t *testing.T) {
+	desired := []driver.Table{{Schema: "public", Name: "accounts",
+		Columns:          []driver.Column{{Name: "balance", DataType: "int"}},
+		CheckConstraints: []driver.CheckConstraint{{Name: "ck_balance", Definition: "balance >= 0"}},
+	}}
+	existing := []driver.Table{{Schema: "public", Name: "accounts",
+		Columns:          []driver.Column{{Name: "balance", DataType: "int"}},
+		CheckConstraints: []driver.CheckConstraint{{Name: "ck_balance", Definition: "balance > 0"}},
+	}}
+
+	d := ComputeLiveDiff(desired, existing, "postgres", "postgres", DefaultDriftOptions())
+	if len(d.Unsupported) != 1 || !strings.Contains(d.Unsupported[0].Reason, "check predicate") {
+		t.Fatalf("same-dialect check definition drift should be unsupported, got %+v", d.Unsupported)
+	}
+
+	if d := ComputeLiveDiff(desired, existing, "mssql", "postgres", DefaultDriftOptions()); !d.IsEmpty() {
+		t.Fatalf("cross-dialect same-count check predicates should remain count-based, got %+v", d)
+	}
+}
+
+func TestRenderDeterministic_LiveColumnChangeUsesExistingDialect(t *testing.T) {
+	d := Diff{ChangedTables: []TableDiff{{
+		Name: "users",
+		Curr: driver.Table{Name: "users", Columns: []driver.Column{{Name: "name", DataType: "varchar", MaxLength: 20}}},
+		ChangedColumns: []ColumnChange{{
+			Name:     "name",
+			Old:      driver.Column{Name: "name", DataType: "character varying", MaxLength: 10},
+			New:      driver.Column{Name: "name", DataType: "varchar", MaxLength: 20},
+			Criteria: []string{"max_length"},
+		}},
+	}}}
+	plan, err := RenderDeterministicWithOptions(d, RenderOptions{
+		TargetSchema:      "public",
+		TargetDialect:     "postgres",
+		SourceDialect:     "mssql",
+		ExistingDialect:   "postgres",
+		UnknownTypePolicy: "fail",
+	})
+	if err != nil {
+		t.Fatalf("RenderDeterministicWithOptions: %v", err)
+	}
+	if len(plan.Statements) != 1 {
+		t.Fatalf("expected one type-change statement, got %+v", plan.Statements)
+	}
+	if !strings.Contains(plan.Statements[0].SQL, `character varying(20)`) {
+		t.Fatalf("unexpected type-change SQL: %s", plan.Statements[0].SQL)
+	}
+}
+
+func TestPlanSQLIncludesUnsupportedChanges(t *testing.T) {
+	plan := Plan{Unsupported: []UnsupportedChange{{
+		Table:       "users",
+		Description: "change primary key",
+		Reason:      "not supported",
+	}}}
+	sql := plan.SQL()
+	if !strings.Contains(sql, "-- [unsupported] change primary key") ||
+		!strings.Contains(sql, "-- reason: not supported") {
+		t.Fatalf("unsupported change missing from plan SQL:\n%s", sql)
+	}
+	if plan.IsEmpty() {
+		t.Fatal("plan with unsupported changes must not be empty")
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/schemadiff/render.go
+++ b/internal/schemadiff/render.go
@@ -32,6 +32,14 @@ type Statement struct {
 	Object string        `json:"object,omitempty"`
 }
 
+// UnsupportedChange is a schema delta SMT can identify deterministically but
+// does not know how to render safely as DDL yet.
+type UnsupportedChange struct {
+	Table       string `json:"table,omitempty"`
+	Description string `json:"description"`
+	Reason      string `json:"reason"`
+}
+
 // StatementKind classifies a plan statement for execution-time gating.
 type StatementKind string
 
@@ -46,11 +54,12 @@ const (
 // Plan is the ordered list of statements that, applied in order, brings
 // the target schema in line with the current source schema.
 type Plan struct {
-	Statements []Statement `json:"statements"`
+	Statements  []Statement         `json:"statements"`
+	Unsupported []UnsupportedChange `json:"unsupported,omitempty"`
 }
 
 // IsEmpty returns true if the plan has no statements.
-func (p Plan) IsEmpty() bool { return len(p.Statements) == 0 }
+func (p Plan) IsEmpty() bool { return len(p.Statements) == 0 && len(p.Unsupported) == 0 }
 
 // SQL returns the plan as a single semicolon-terminated SQL script with
 // one comment per statement showing what it does and the classified risk.
@@ -68,6 +77,16 @@ func (p Plan) SQL() string {
 		b.WriteString(s.SQL)
 		b.WriteString(";\n\n")
 	}
+	for _, u := range p.Unsupported {
+		fmt.Fprintf(&b, "-- [unsupported] %s\n", u.Description)
+		if u.Table != "" {
+			fmt.Fprintf(&b, "-- table: %s\n", u.Table)
+		}
+		if u.Reason != "" {
+			fmt.Fprintf(&b, "-- reason: %s\n", u.Reason)
+		}
+		b.WriteString("\n")
+	}
 	return b.String()
 }
 
@@ -84,7 +103,7 @@ func (p Plan) FilterByRisk(maxRisk Risk) Plan {
 		RiskUnknown:       3,
 	}
 	limit := rank[maxRisk]
-	out := Plan{}
+	out := Plan{Unsupported: append([]UnsupportedChange(nil), p.Unsupported...)}
 	for _, s := range p.Statements {
 		if rank[s.Risk] <= limit {
 			out.Statements = append(out.Statements, s)

--- a/internal/schemadiff/render_deterministic.go
+++ b/internal/schemadiff/render_deterministic.go
@@ -28,6 +28,7 @@ type RenderOptions struct {
 	TargetSchema      string
 	TargetDialect     string
 	SourceDialect     string // enables same-dialect type passthrough in the renderer; empty = cross-dialect mappings only
+	ExistingDialect   string // dialect of ColumnChange.Old; defaults to SourceDialect for snapshot diffs
 	UnknownTypePolicy string
 }
 
@@ -44,9 +45,10 @@ func RenderDeterministicWithOptions(diff Diff, opts RenderOptions) (Plan, error)
 }
 
 type deterministicRenderer struct {
-	target        string
-	sourceDialect string
-	renderer      ddl.Renderer
+	target          string
+	sourceDialect   string
+	existingDialect string
+	renderer        ddl.Renderer
 }
 
 func newDeterministicRenderer(opts RenderOptions) (deterministicRenderer, error) {
@@ -55,7 +57,11 @@ func newDeterministicRenderer(opts RenderOptions) (deterministicRenderer, error)
 		return deterministicRenderer{}, err
 	}
 	r = r.WithSource(opts.SourceDialect)
-	return deterministicRenderer{target: r.Target(), sourceDialect: opts.SourceDialect, renderer: r}, nil
+	existingDialect := opts.ExistingDialect
+	if strings.TrimSpace(existingDialect) == "" {
+		existingDialect = opts.SourceDialect
+	}
+	return deterministicRenderer{target: r.Target(), sourceDialect: opts.SourceDialect, existingDialect: existingDialect, renderer: r}, nil
 }
 
 func (r deterministicRenderer) tableMappingWarnings(t driver.Table) []string {
@@ -81,7 +87,7 @@ func (r deterministicRenderer) columnMappingWarnings(col driver.Column) []string
 }
 
 func (r deterministicRenderer) render(diff Diff) (Plan, error) {
-	var plan Plan
+	plan := Plan{Unsupported: append([]UnsupportedChange(nil), diff.Unsupported...)}
 
 	for _, t := range diff.AddedTables {
 		if err := r.renderAddedTableDefinition(&plan, t); err != nil {
@@ -363,11 +369,11 @@ func (r deterministicRenderer) renderColumnChange(plan *Plan, tableName string, 
 		return fmt.Errorf("computed column %s changes are not supported by deterministic %s sync", cc.Name, r.target)
 	}
 
-	oldType, err := r.renderer.ColumnType(cc.Old)
+	oldType, err := r.columnTypeWithSource(cc.Old, r.existingDialect)
 	if err != nil {
 		return err
 	}
-	newType, err := r.renderer.ColumnType(cc.New)
+	newType, err := r.columnTypeWithSource(cc.New, r.sourceDialect)
 	if err != nil {
 		return err
 	}
@@ -376,6 +382,12 @@ func (r deterministicRenderer) renderColumnChange(plan *Plan, tableName string, 
 	newDefault := strings.TrimSpace(cc.New.DefaultExpression)
 	typeChanged := oldType != newType
 	defaultChanged := oldDefault != newDefault
+	nullabilityChanged := cc.Old.IsNullable != cc.New.IsNullable
+	if len(cc.Criteria) > 0 {
+		typeChanged = hasAnyCriterion(cc.Criteria, "type", "max_length", "precision", "scale", "tz_class")
+		defaultChanged = hasAnyCriterion(cc.Criteria, "default")
+		nullabilityChanged = hasAnyCriterion(cc.Criteria, "nullability")
+	}
 	preDropDefault := oldDefault != "" && (typeChanged || (r.target == "mssql" && defaultChanged))
 
 	if preDropDefault {
@@ -401,7 +413,7 @@ func (r deterministicRenderer) renderColumnChange(plan *Plan, tableName string, 
 			Warnings:    r.columnMappingWarnings(cc.New),
 		})
 	}
-	if cc.Old.IsNullable != cc.New.IsNullable {
+	if nullabilityChanged {
 		risk := RiskSafe
 		notes := ""
 		if !cc.New.IsNullable {
@@ -445,6 +457,22 @@ func (r deterministicRenderer) renderColumnChange(plan *Plan, tableName string, 
 		}
 	}
 	return nil
+}
+
+func (r deterministicRenderer) columnTypeWithSource(col driver.Column, sourceDialect string) (string, error) {
+	renderer := r.renderer.WithSource(sourceDialect)
+	return renderer.ColumnType(col)
+}
+
+func hasAnyCriterion(got []string, want ...string) bool {
+	for _, g := range got {
+		for _, w := range want {
+			if g == w {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (r deterministicRenderer) renderAddedIndex(plan *Plan, t driver.Table, idx driver.Index) error {


### PR DESCRIPTION
## Summary

- change `smt sync` from snapshot-vs-source history diffing to live target introspection plus deterministic live diff planning
- add `ComputeLiveDiff` to classify added, removed, changed, destructive, and unsupported target drift with stable ordering
- carry unsupported changes into dry-run SQL comments and refuse `--apply` when unsupported changes are present
- render live column changes with the target dialect for existing column metadata, avoiding false default/type churn across dialects
- honor `create_indexes`, `create_foreign_keys`, and `create_check_constraints` for missing target tables

Closes #69
Closes #59

## Verification

- self-review agent completed; high-confidence findings were fixed before commit
- `go test -count=1 ./...`
- `git diff --check`

## Notes

- Dry-run output remains the deterministic review artifact; AI does not author or silently rewrite sync ALTER statements.
