### PR TITLE
Add config wizard (smt init + TUI /init) — closes #160

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ migrations/
 
 # SO2010 acceptance-test artifact (make test-so2010)
 so2010_verification.json
+
+# Local Claude Code settings (personal permission overrides)
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ PostgreSQL, SQL Server, MySQL — both as source and target. New engines are add
 
 ```bash
 make build
-cp config.yaml.example config.yaml  # edit source; set target.type/schema if needed
+./smt init                          # guided wizard → writes config.yaml
+# (or: cp config.yaml.example config.yaml and edit by hand)
 ./smt health-check
 ./smt create                        # write target DDL to schema.sql
 ./smt create --apply                # execute DDL against the configured target
@@ -28,6 +29,7 @@ Run `./smt` with no arguments to launch the TUI. See `./smt --help` for the full
 
 | command | what it does |
 |---------|--------------|
+| `smt init` | build a `config.yaml` with a guided wizard (`--non-interactive` + per-field flags for scripting; `--print` to stdout) |
 | `smt create` | extract source schema and emit CREATE TABLE / CREATE INDEX / etc to `schema.sql` |
 | `smt create --apply` | also execute the generated DDL against the configured target |
 | `smt snapshot` | save the current source schema as a baseline for future diffing |

--- a/cmd/smt/init.go
+++ b/cmd/smt/init.go
@@ -1,0 +1,328 @@
+package main
+
+// `smt init` is the config wizard: it builds a config.yaml interactively (or
+// from flags for scripting/CI) by driving the shared wizard core, so prompts,
+// defaults, and validation are defined once in internal/wizard.
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	xterm "github.com/charmbracelet/x/term"
+	"github.com/urfave/cli/v2"
+
+	"smt/internal/orchestrator"
+	"smt/internal/wizard"
+)
+
+func initCommand() *cli.Command {
+	flags := []cli.Flag{
+		&cli.StringFlag{Name: "out", Aliases: []string{"o"}, Value: "config.yaml", Usage: "Output path"},
+		&cli.BoolFlag{Name: "force", Aliases: []string{"f"}, Usage: "Overwrite an existing file"},
+		&cli.BoolFlag{Name: "print", Usage: "Write the config to stdout instead of a file"},
+		&cli.BoolFlag{Name: "non-interactive", Aliases: []string{"y"}, Usage: "Do not prompt; take values from flags and defaults"},
+		&cli.BoolFlag{Name: "health-check", Usage: "Test the connection after writing (implied prompt when interactive)"},
+		&cli.BoolFlag{Name: "save-profile", Usage: "Save the result as an encrypted profile (needs SMT_MASTER_KEY)"},
+	}
+	// One string flag per wizard field, named by its key, so a non-interactive
+	// run can supply any answer. yes/no fields accept "yes"/"no".
+	for _, f := range wizard.Steps() {
+		flags = append(flags, &cli.StringFlag{Name: f.Key, Usage: fieldFlagUsage(f)})
+	}
+	return &cli.Command{
+		Name:      "init",
+		Usage:     "Create a config.yaml with a guided wizard",
+		ArgsUsage: " ",
+		Flags:     flags,
+		Action:    runInit,
+	}
+}
+
+func fieldFlagUsage(f wizard.Field) string {
+	a := wizard.NewAnswers()
+	u := f.Prompt(a)
+	if f.Options != nil {
+		if opts := f.Options(a); len(opts) > 0 {
+			u += " [" + strings.Join(opts, "|") + "]"
+		}
+	}
+	return u
+}
+
+func runInit(c *cli.Context) error {
+	out := c.String("out")
+	interactive := !c.Bool("non-interactive")
+
+	if !c.Bool("print") && !c.Bool("force") {
+		if _, err := os.Stat(out); err == nil {
+			return fmt.Errorf("%s already exists (use --force to overwrite, or --print)", out)
+		}
+	}
+
+	a := wizard.NewAnswers()
+	var p *prompter
+	if interactive {
+		// Prompts go to stderr so stdout carries only the config (keeps
+		// `smt init --print > config.yaml` clean).
+		p = newPrompter(os.Stdin, os.Stderr)
+		fmt.Fprintln(p.out, "smt init — let's build your config.yaml. Press Enter to accept the (default).")
+	}
+
+	var section string
+	for _, f := range wizard.Steps() {
+		if f.IsSkipped(a) {
+			// A per-field flag for a disabled section would otherwise be dropped
+			// silently, producing a config missing requested settings.
+			if !interactive && c.IsSet(f.Key) {
+				return fmt.Errorf("--%s was set but its section is off; enable it first with --%s yes",
+					f.Key, gateFor(f.Key))
+			}
+			continue
+		}
+		if interactive {
+			if s := sectionOf(f.Key); s != section {
+				section = s
+				fmt.Fprintf(p.out, "\n── %s ──\n", section)
+			}
+			if err := p.ask(f, a); err != nil {
+				return err
+			}
+			continue
+		}
+		// Non-interactive: flag value if set, else default.
+		raw := f.DefaultValue(a)
+		if c.IsSet(f.Key) {
+			raw = c.String(f.Key)
+		}
+		if err := f.Parse(raw, a); err != nil {
+			return fmt.Errorf("--%s: %w", f.Key, err)
+		}
+	}
+
+	data, err := wizard.RenderYAML(a)
+	if err != nil {
+		return err
+	}
+
+	if c.Bool("print") {
+		_, err := os.Stdout.Write(data)
+		return err
+	}
+
+	if err := os.WriteFile(out, data, 0o600); err != nil {
+		return fmt.Errorf("writing %s: %w", out, err)
+	}
+	// WriteFile keeps an existing file's mode on overwrite, so a --force rewrite
+	// of a 0644 file would stay world-readable. Enforce 0600 explicitly since the
+	// config may carry a literal password.
+	if err := os.Chmod(out, 0o600); err != nil {
+		return fmt.Errorf("securing %s: %w", out, err)
+	}
+	fmt.Printf("\nWrote %s\n", out)
+
+	// Optional post-steps. When requested via flag they are explicit
+	// post-conditions, so their failures propagate; when offered via an
+	// interactive prompt they are best-effort.
+	if run, strict := postStep(c, p, "health-check", "Test the connection now?"); run {
+		if err := initHealthCheck(c, a); err != nil {
+			if strict {
+				return err
+			}
+			fmt.Printf("Health check error: %v\n", err)
+		}
+	}
+	if run, strict := postStep(c, p, "save-profile", "Save this as an encrypted profile?"); run {
+		if err := initSaveProfile(a, data); err != nil {
+			if strict {
+				return err
+			}
+			fmt.Printf("Profile not saved: %v\n", err)
+		}
+	}
+	return nil
+}
+
+// postStep decides whether an optional post-step runs and whether its failure
+// is fatal. A flag makes it run and strict (explicit post-condition); an
+// interactive yes makes it run best-effort. Non-interactive runs never prompt.
+func postStep(c *cli.Context, p *prompter, flag, prompt string) (run, strict bool) {
+	if c.Bool(flag) {
+		return true, true
+	}
+	if p == nil {
+		return false, false
+	}
+	return p.confirm(prompt, false), false
+}
+
+// gateFor returns the enabling flag for a gated per-field flag key.
+func gateFor(key string) string {
+	switch {
+	case strings.HasPrefix(key, "target."):
+		return "target.configure"
+	case strings.HasPrefix(key, "ai_review."):
+		return "ai_review"
+	case strings.HasPrefix(key, "migration."):
+		return "migration"
+	case strings.HasPrefix(key, "slack."):
+		return "slack"
+	default:
+		return key
+	}
+}
+
+func initHealthCheck(c *cli.Context, a *wizard.Answers) error {
+	cfg, err := wizard.Build(a)
+	if err != nil {
+		return err
+	}
+	orch, err := orchestrator.NewWithOptions(cfg, orchestrator.Options{
+		StateFile:  c.String("state-file"),
+		SourceOnly: !cfg.HasTargetConnection(),
+	})
+	if err != nil {
+		return err
+	}
+	defer orch.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	r, err := orch.HealthCheck(ctx)
+	if err != nil {
+		return err
+	}
+	printHealth(r)
+	if !r.Healthy {
+		return fmt.Errorf("health check failed")
+	}
+	return nil
+}
+
+func initSaveProfile(a *wizard.Answers, data []byte) error {
+	name := a.ProfileName
+	if name == "" {
+		name = a.Source.Database
+	}
+	if name == "" {
+		return fmt.Errorf("no profile name (set profile.name)")
+	}
+	state, err := openProfileStore()
+	if err != nil {
+		return err
+	}
+	defer state.Close()
+	if err := state.SaveProfile(name, a.ProfileDescription, data); err != nil {
+		if strings.Contains(err.Error(), "SMT_MASTER_KEY is not set") {
+			return fmt.Errorf("SMT_MASTER_KEY is not set; export it before saving profiles")
+		}
+		return err
+	}
+	fmt.Printf("Saved profile %q\n", name)
+	return nil
+}
+
+// sectionOf maps a field key to a display section header.
+func sectionOf(key string) string {
+	switch {
+	case strings.HasPrefix(key, "source."):
+		return "Source database"
+	case strings.HasPrefix(key, "target."):
+		return "Target database"
+	case strings.HasPrefix(key, "ai_review"):
+		return "AI review (optional)"
+	case strings.HasPrefix(key, "migration"):
+		return "Migration overrides (optional)"
+	case strings.HasPrefix(key, "slack"):
+		return "Slack notifications (optional)"
+	case strings.HasPrefix(key, "profile"):
+		return "Profile (optional)"
+	default:
+		return "Schema generation"
+	}
+}
+
+// prompter reads answers from a reader and writes prompts to a writer.
+type prompter struct {
+	in  *bufio.Reader
+	out io.Writer
+	fd  uintptr // stdin fd for TTY detection / no-echo reads
+	tty bool
+}
+
+func newPrompter(stdin *os.File, out io.Writer) *prompter {
+	return &prompter{
+		in:  bufio.NewReader(stdin),
+		out: out,
+		fd:  stdin.Fd(),
+		tty: xterm.IsTerminal(stdin.Fd()),
+	}
+}
+
+// ask prompts for one field, re-prompting until Parse accepts the value.
+func (p *prompter) ask(f wizard.Field, a *wizard.Answers) error {
+	if f.Help != "" {
+		fmt.Fprintf(p.out, "  (%s)\n", f.Help)
+	}
+	for {
+		def := f.DefaultValue(a)
+		secret := f.Secret != nil && f.Secret(a)
+		label := f.Prompt(a)
+		if f.Options != nil {
+			if opts := f.Options(a); len(opts) > 0 {
+				label += " [" + strings.Join(opts, "/") + "]"
+			}
+		}
+		if def != "" && !secret {
+			label += fmt.Sprintf(" (%s)", def)
+		}
+		fmt.Fprintf(p.out, "%s: ", label)
+
+		raw, err := p.read(secret)
+		if err != nil && raw == "" {
+			return fmt.Errorf("input closed before %s was answered", f.Key)
+		}
+		raw = strings.TrimRight(raw, "\r\n")
+		if strings.TrimSpace(raw) == "" {
+			raw = def
+		}
+		if perr := f.Parse(raw, a); perr != nil {
+			fmt.Fprintf(p.out, "  ! %v\n", perr)
+			continue
+		}
+		return nil
+	}
+}
+
+// read returns one line of input. Secret fields on a real terminal are read
+// without echo; otherwise (piped/non-TTY) a normal buffered line is read.
+func (p *prompter) read(secret bool) (string, error) {
+	if secret && p.tty {
+		b, err := xterm.ReadPassword(p.fd)
+		fmt.Fprintln(p.out)
+		return string(b), err
+	}
+	return p.in.ReadString('\n')
+}
+
+// confirm asks a yes/no question, returning def on blank input.
+func (p *prompter) confirm(prompt string, def bool) bool {
+	suffix := " [y/N]"
+	if def {
+		suffix = " [Y/n]"
+	}
+	fmt.Fprintf(p.out, "%s%s: ", prompt, suffix)
+	raw, _ := p.in.ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "":
+		return def
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/smt/main.go
+++ b/cmd/smt/main.go
@@ -135,6 +135,7 @@ func cliFlagInfo() tui.CLIFlagInfo {
 
 func commands() []*cli.Command {
 	return []*cli.Command{
+		initCommand(),
 		createCommand(),
 		syncCommand(),
 		driftCommand(),

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/term v0.2.2
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2
@@ -23,7 +24,6 @@ require (
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
-	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -49,6 +49,7 @@ type AppMode int
 const (
 	ModeNormal AppMode = iota
 	ModeMigration
+	ModeWizard
 )
 
 // Model is the main TUI model - simplified single-viewport architecture
@@ -82,6 +83,9 @@ type Model struct {
 	// Single migration state (one at a time)
 	migrationCancel context.CancelFunc
 	migrationStatus string // "", "running", "completed", "failed", "cancelled"
+
+	// Active config wizard (ModeWizard), nil otherwise.
+	wiz *wizardState
 }
 
 type commandInfo struct {
@@ -90,6 +94,7 @@ type commandInfo struct {
 }
 
 var availableCommands = []commandInfo{
+	{"/init", "Create a config.yaml with a guided wizard"},
 	{"/create", "Generate target DDL from the source"},
 	{"/sync", "Diff source vs snapshot and emit/apply ALTERs"},
 	{"/snapshot", "Capture current source schema for future diffing"},
@@ -214,6 +219,11 @@ func (m Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		// The wizard takes over key handling while active.
+		if m.mode == ModeWizard {
+			return m.updateWizard(msg)
+		}
+
 		// Handle suggestion navigation if active
 		if len(m.suggestions) > 0 {
 			switch msg.Type {
@@ -527,7 +537,7 @@ func (m *Model) autocompleteCommand() {
 		}
 	}
 
-	commands := []string{"/create", "/sync", "/snapshot", "/config", "/history", "/logs", "/profile", "/verbosity", "/about", "/clear", "/quit", "/help"}
+	commands := []string{"/init", "/create", "/sync", "/snapshot", "/config", "/history", "/logs", "/profile", "/verbosity", "/about", "/clear", "/quit", "/help"}
 
 	for _, cmd := range commands {
 		if strings.HasPrefix(cmd, input) {
@@ -639,8 +649,16 @@ func (m Model) welcomeMessage() string {
  Type /help to see available commands.
 `
 
+	// First-run nudge: if there's no config in the working directory, point the
+	// user at the wizard before anything else.
+	if _, err := os.Stat("config.yaml"); os.IsNotExist(err) {
+		body += stylePrompt.Render(`
+ No config.yaml here yet — run /init to create one with a guided wizard.
+`)
+	}
+
 	tips := lipgloss.NewStyle().Foreground(colorGray).Render(`
- Tip: /create writes schema DDL. /create --apply executes it.
+ Tip: /init builds a config.yaml. /create writes schema DDL; /create --apply executes it.
       /snapshot captures a source baseline, and /sync emits or applies ALTERs.
       Hold Shift to select text with mouse.`)
 
@@ -661,6 +679,9 @@ func (m *Model) handleCommand(cmdStr string) tea.Cmd {
 	}
 
 	switch cmd {
+	case "/init":
+		return m.startWizard(parts)
+
 	case "/quit", "/exit":
 		return tea.Quit
 
@@ -672,6 +693,7 @@ func (m *Model) handleCommand(cmdStr string) tea.Cmd {
 
 	case "/help":
 		help := `Available Commands:
+  /init [@config]         Create a config.yaml with a guided wizard
   /create [@config]       Generate target DDL from the source
   /create --apply         Execute generated DDL against the target
   /create --profile NAME  Generate using a saved profile

--- a/internal/tui/wizard.go
+++ b/internal/tui/wizard.go
@@ -1,0 +1,225 @@
+package tui
+
+// In-TUI config wizard. `/init` enters ModeWizard, which takes over key input
+// and walks the shared wizard.Steps() one prompt at a time, then writes
+// config.yaml. The prompts/defaults/validation come from internal/wizard, the
+// same core the `smt init` CLI drives, so the two never diverge.
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"smt/internal/wizard"
+)
+
+// wizardState holds the in-progress wizard for ModeWizard.
+type wizardState struct {
+	answers *wizard.Answers
+	steps   []wizard.Field
+	idx     int // index of the current step in steps
+	out     string
+}
+
+// startWizard initializes the wizard and renders the first prompt. It mutates
+// the model into ModeWizard; subsequent keys are routed to updateWizard.
+func (m *Model) startWizard(parts []string) tea.Cmd {
+	out := "config.yaml"
+	for i := 1; i < len(parts); i++ {
+		arg := parts[i]
+		switch {
+		case strings.HasPrefix(arg, "@"):
+			out = arg[1:]
+		case arg == "--out" || arg == "-o":
+			if i+1 < len(parts) {
+				out = parts[i+1]
+				i++
+			}
+		case !strings.HasPrefix(arg, "-"):
+			out = arg
+		}
+	}
+
+	m.suggestions = nil
+	m.wiz = &wizardState{
+		answers: wizard.NewAnswers(),
+		steps:   wizard.Steps(),
+		idx:     -1,
+		out:     out,
+	}
+	m.mode = ModeWizard
+	m.appendOutput(styleSystemOutput.Render(
+		"Config wizard — Enter accepts the (default), Esc cancels.") + "\n")
+
+	m.wizardAdvance()
+	if m.wiz.idx >= len(m.wiz.steps) {
+		m.exitWizard("Nothing to configure.")
+		return nil
+	}
+	m.renderWizardPrompt()
+	return nil
+}
+
+// updateWizard handles a key while in ModeWizard.
+func (m Model) updateWizard(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyCtrlC, tea.KeyEsc:
+		m.exitWizard("Wizard cancelled. No file written.")
+		return m, nil
+	case tea.KeyEnter:
+		val := m.textInput.Value()
+		m.textInput.Reset()
+		return m.wizardSubmit(val)
+	default:
+		var cmd tea.Cmd
+		m.textInput, cmd = m.textInput.Update(msg)
+		return m, cmd
+	}
+}
+
+// wizardSubmit applies an answer to the current step, then advances or finishes.
+func (m Model) wizardSubmit(val string) (tea.Model, tea.Cmd) {
+	f := m.wiz.steps[m.wiz.idx]
+	a := m.wiz.answers
+
+	raw := val
+	if strings.TrimSpace(raw) == "" {
+		raw = f.DefaultValue(a)
+	}
+
+	secret := f.Secret != nil && f.Secret(a)
+	echo := raw
+	if secret {
+		echo = "(hidden)"
+	}
+	m.appendOutput(styleUserInput.Render("> "+echo) + "\n")
+
+	if err := f.Parse(raw, a); err != nil {
+		m.appendOutput(styleError.Render("  ✖ "+err.Error()) + "\n")
+		m.renderWizardPrompt() // re-prompt the same step
+		return m, nil
+	}
+
+	m.wizardAdvance()
+	if m.wiz.idx >= len(m.wiz.steps) {
+		return m.wizardFinish()
+	}
+	m.renderWizardPrompt()
+	return m, nil
+}
+
+// wizardAdvance moves idx to the next non-skipped step (or past the end).
+func (m *Model) wizardAdvance() {
+	m.wiz.idx++
+	for m.wiz.idx < len(m.wiz.steps) && m.wiz.steps[m.wiz.idx].IsSkipped(m.wiz.answers) {
+		m.wiz.idx++
+	}
+}
+
+// renderWizardPrompt prints the current step's question and sets the input echo
+// mode (masked for secret fields).
+func (m *Model) renderWizardPrompt() {
+	f := m.wiz.steps[m.wiz.idx]
+	a := m.wiz.answers
+
+	if f.Help != "" {
+		m.appendOutput(styleSystemOutput.Render("  ("+f.Help+")") + "\n")
+	}
+
+	label := f.Prompt(a)
+	if f.Options != nil {
+		if opts := f.Options(a); len(opts) > 0 {
+			label += " [" + strings.Join(opts, "/") + "]"
+		}
+	}
+	secret := f.Secret != nil && f.Secret(a)
+	if def := f.DefaultValue(a); def != "" && !secret {
+		label += " (" + def + ")"
+	}
+
+	if secret {
+		m.textInput.EchoMode = textinput.EchoPassword
+	} else {
+		m.textInput.EchoMode = textinput.EchoNormal
+	}
+	m.appendOutput(stylePrompt.Render("? ") + styleNormal.Render(label) + "\n")
+}
+
+// wizardFinish renders the YAML, writes it (unless the file exists), shows the
+// result, and returns to ModeNormal.
+func (m Model) wizardFinish() (tea.Model, tea.Cmd) {
+	a := m.wiz.answers
+	out := m.wiz.out
+
+	data, err := wizard.RenderYAML(a)
+	if err != nil {
+		m.appendOutput(styleError.Render("  ✖ "+err.Error()) + "\n")
+		m.exitWizard("")
+		return m, nil
+	}
+	// A literal password is embedded in the YAML; never echo it into scrollback
+	// (which /logs would also export). Show a note instead of the preview.
+	secret := hasLiteralPassword(a)
+
+	if _, statErr := os.Stat(out); statErr == nil {
+		m.appendOutput(styleSystemOutput.Render(fmt.Sprintf(
+			"  %s already exists — not overwriting. Use `smt init --force` to replace it.", out)) + "\n")
+		m.exitWizard("")
+		cmd := previewOrNote(&m, data, secret)
+		return m, cmd
+	}
+
+	if err := os.WriteFile(out, data, 0o600); err != nil {
+		m.appendOutput(styleError.Render("  ✖ writing "+out+": "+err.Error()) + "\n")
+		m.exitWizard("")
+		return m, nil
+	}
+	// WriteFile keeps an existing mode on overwrite; enforce 0600 since the
+	// config may carry a literal password.
+	_ = os.Chmod(out, 0o600)
+
+	m.appendOutput(styleSuccess.Render("✔ Wrote "+out) + "\n")
+	m.appendOutput(styleSystemOutput.Render(
+		"  Next: /create writes DDL, /create --apply executes it. /profile save NAME stores it encrypted.") + "\n")
+	m.exitWizard("")
+	cmd := previewOrNote(&m, data, secret)
+	return m, cmd
+}
+
+// previewOrNote returns a command that boxes the rendered config, unless it
+// holds a literal password — in which case it appends a redaction note (now,
+// before the caller's `return m`) and shows nothing.
+func previewOrNote(m *Model, data []byte, secret bool) tea.Cmd {
+	if secret {
+		m.appendOutput(styleSystemOutput.Render(
+			"  (config preview hidden — it contains a literal password)") + "\n")
+		return nil
+	}
+	return func() tea.Msg { return BoxedOutputMsg(string(data)) }
+}
+
+// exitWizard returns to normal mode and clears wizard state. The input is reset
+// before echo is restored so a half-typed masked password can never resurface
+// as cleartext in the prompt (e.g. on Esc/Ctrl+C mid-field).
+func (m *Model) exitWizard(note string) {
+	m.mode = ModeNormal
+	m.wiz = nil
+	m.textInput.Reset()
+	m.textInput.EchoMode = textinput.EchoNormal
+	if note != "" {
+		m.appendOutput(styleSystemOutput.Render("  "+note) + "\n")
+	}
+}
+
+// hasLiteralPassword reports whether the rendered config embeds a literal
+// password (vs. an ${env:}/${file:} reference). Such configs must not be echoed
+// into scrollback or logs.
+func hasLiteralPassword(a *wizard.Answers) bool {
+	if a.Source.PwMode == wizard.PwLiteral {
+		return true
+	}
+	return a.ConfigureTarget && a.Target.PwMode == wizard.PwLiteral
+}

--- a/internal/tui/wizard_test.go
+++ b/internal/tui/wizard_test.go
@@ -1,0 +1,205 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"smt/internal/config"
+)
+
+// ready returns an initialized model with a sized viewport so appendOutput is
+// exercised the way it is at runtime.
+func ready() Model {
+	m := InitialModel()
+	res, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	return res.(Model)
+}
+
+func TestWizard_StartEntersModeWizard(t *testing.T) {
+	m := ready()
+	m.handleCommand("/init @/tmp/does-not-matter.yaml")
+
+	if m.mode != ModeWizard {
+		t.Fatalf("mode = %v, want ModeWizard", m.mode)
+	}
+	if m.wiz == nil {
+		t.Fatal("wiz state is nil after /init")
+	}
+	if got := m.wiz.steps[m.wiz.idx].Key; got != "source.type" {
+		t.Fatalf("first step = %q, want source.type", got)
+	}
+	if !strings.Contains(m.content.String(), "Source database engine") {
+		t.Errorf("first prompt not rendered:\n%s", m.content.String())
+	}
+}
+
+func TestWizard_EscCancelsWithoutWriting(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "config.yaml")
+	m := ready()
+	m.handleCommand("/init @" + out)
+
+	res, _ := m.updateWizard(tea.KeyMsg{Type: tea.KeyEsc})
+	m = res.(Model)
+
+	if m.mode != ModeNormal {
+		t.Fatalf("mode = %v, want ModeNormal after Esc", m.mode)
+	}
+	if m.wiz != nil {
+		t.Error("wiz state should be cleared after cancel")
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Error("cancelled wizard must not write a file")
+	}
+}
+
+// drive runs the wizard to completion, supplying seed[key] for each step (or
+// the step default when absent). It returns the finished model.
+func drive(t *testing.T, m Model, seed map[string]string) Model {
+	t.Helper()
+	for i := 0; m.mode == ModeWizard; i++ {
+		if i > len(m.wiz.steps)+8 {
+			t.Fatalf("wizard did not terminate (stuck at %q)", m.wiz.steps[m.wiz.idx].Key)
+		}
+		val := seed[m.wiz.steps[m.wiz.idx].Key]
+		res, _ := m.wizardSubmit(val)
+		m = res.(Model)
+	}
+	return m
+}
+
+func TestWizard_FullFlowWritesValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "config.yaml")
+
+	m := ready()
+	m.handleCommand("/init @" + out)
+	m = drive(t, m, map[string]string{
+		"source.database": "StackOverflow2010",
+		"source.user":     "sa",
+		"target.type":     "postgres",
+	})
+
+	if m.mode != ModeNormal {
+		t.Fatalf("mode = %v, want ModeNormal after finish", m.mode)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("config not written: %v", err)
+	}
+	cfg, err := config.LoadBytes(data)
+	if err != nil {
+		t.Fatalf("written config does not load: %v\n%s", err, data)
+	}
+	if cfg.Source.Type != "mssql" || cfg.Target.Type != "postgres" {
+		t.Errorf("got source=%q target=%q", cfg.Source.Type, cfg.Target.Type)
+	}
+	// 0600 enforced.
+	info, _ := os.Stat(out)
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file mode = %o, want 600", perm)
+	}
+}
+
+func TestWizard_DoesNotOverwriteExisting(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(out, []byte("original: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := ready()
+	m.handleCommand("/init @" + out)
+	m = drive(t, m, map[string]string{
+		"source.database": "DB", "source.user": "u", "target.type": "postgres",
+	})
+
+	data, _ := os.ReadFile(out)
+	if string(data) != "original: true\n" {
+		t.Errorf("existing file was overwritten:\n%s", data)
+	}
+}
+
+// TestWizard_SecretFieldMasksInput: choosing a literal password switches the
+// input to masked echo when the password step is rendered.
+func TestWizard_SecretFieldMasksInput(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "config.yaml")
+	m := ready()
+	m.handleCommand("/init @" + out)
+
+	masked := false
+	for i := 0; m.mode == ModeWizard; i++ {
+		if i > len(m.wiz.steps)+8 {
+			t.Fatal("wizard did not terminate")
+		}
+		key := m.wiz.steps[m.wiz.idx].Key
+		val := map[string]string{
+			"source.database":      "DB",
+			"source.user":          "u",
+			"source.password_mode": "literal",
+			"source.password":      "s3cret",
+			"target.type":          "postgres",
+		}[key]
+		// Observe echo mode at the moment the password step is the active prompt.
+		if key == "source.password" && m.textInput.EchoMode == textinput.EchoPassword {
+			masked = true
+		}
+		res, _ := m.wizardSubmit(val)
+		m = res.(Model)
+	}
+	if !masked {
+		t.Error("literal password step did not mask input (EchoPassword expected)")
+	}
+}
+
+// TestWizard_LiteralPasswordNeverInScrollback: a literal password must not land
+// in m.content (which /logs exports) — neither echoed during entry nor shown in
+// the completion preview.
+func TestWizard_LiteralPasswordNeverInScrollback(t *testing.T) {
+	const secret = "sup3rS3cretPW"
+	out := filepath.Join(t.TempDir(), "config.yaml")
+	m := ready()
+	m.handleCommand("/init @" + out)
+	m = drive(t, m, map[string]string{
+		"source.database":      "DB",
+		"source.user":          "u",
+		"source.password_mode": "literal",
+		"source.password":      secret,
+		"target.type":          "postgres",
+	})
+
+	if strings.Contains(m.content.String(), secret) {
+		t.Errorf("literal password leaked into scrollback:\n%s", m.content.String())
+	}
+	// It must still be in the written file (0600), just not on screen.
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), secret) {
+		t.Errorf("password missing from written config:\n%s", data)
+	}
+}
+
+// TestWizard_CancelAfterTypingClearsInput: pressing Esc with text in the buffer
+// resets the input so a half-typed (masked) secret cannot reappear.
+func TestWizard_CancelAfterTypingClearsInput(t *testing.T) {
+	m := ready()
+	m.handleCommand("/init @/tmp/never-written.yaml")
+	m.textInput.SetValue("half-typed-secret")
+
+	res, _ := m.updateWizard(tea.KeyMsg{Type: tea.KeyEsc})
+	m = res.(Model)
+
+	if m.textInput.Value() != "" {
+		t.Errorf("input not cleared on cancel: %q", m.textInput.Value())
+	}
+	if m.textInput.EchoMode != textinput.EchoNormal {
+		t.Error("echo mode not restored to normal on cancel")
+	}
+}

--- a/internal/wizard/answers.go
+++ b/internal/wizard/answers.go
@@ -1,0 +1,385 @@
+// Package wizard holds the UI-agnostic core of SMT's config wizard: the
+// collected Answers, per-engine defaults, deterministic YAML rendering, and a
+// Build helper that validates the rendered config through the real loader.
+//
+// The CLI (`smt init`) and the TUI both drive this one package, so prompts,
+// defaults, and validation are defined exactly once (see steps.go).
+package wizard
+
+import (
+	"fmt"
+	"strings"
+
+	"smt/internal/config"
+)
+
+// Engines are the supported database engines, used for both source and target.
+var Engines = []string{"mssql", "postgres", "mysql"}
+
+// UnknownTypePolicies are the valid schema_generation.unknown_type_policy values.
+var UnknownTypePolicies = []string{"fail", "warn", "text_fallback"}
+
+// AIModes are the valid ai_review.mode values.
+var AIModes = []string{"warn", "fail"}
+
+// PasswordMode selects how a password is stored in the generated config.
+type PasswordMode string
+
+const (
+	// PwEnv stores an ${env:VAR} reference (recommended — no secret in YAML).
+	PwEnv PasswordMode = "env"
+	// PwFile stores a ${file:/path} reference.
+	PwFile PasswordMode = "file"
+	// PwLiteral stores the password verbatim in the YAML.
+	PwLiteral PasswordMode = "literal"
+)
+
+// PasswordModes lists the selectable password modes in display order.
+var PasswordModes = []string{string(PwEnv), string(PwFile), string(PwLiteral)}
+
+// Conn holds one side's connection answers (source or target).
+type Conn struct {
+	Type     string
+	Host     string
+	Port     int
+	Database string
+	User     string
+	PwMode   PasswordMode
+	PwValue  string // env: VAR name; file: path; literal: the password itself
+	Schema   string
+}
+
+// passwordField renders the YAML value for the password line.
+func (c Conn) passwordField() string {
+	switch c.PwMode {
+	case PwFile:
+		if c.PwValue == "" {
+			return ""
+		}
+		return "${file:" + c.PwValue + "}"
+	case PwLiteral:
+		return c.PwValue
+	default: // PwEnv
+		if c.PwValue == "" {
+			return ""
+		}
+		return "${env:" + c.PwValue + "}"
+	}
+}
+
+// Answers is the full set of collected wizard inputs.
+type Answers struct {
+	Source Conn
+
+	// Target always carries Type + Schema. Connection fields are only collected
+	// (and rendered) when ConfigureTarget is true.
+	Target          Conn
+	ConfigureTarget bool
+
+	UnknownTypePolicy string
+
+	// AI review (optional; block omitted entirely unless AIReview is true).
+	AIReview   bool
+	AIMode     string
+	AIModel    string
+	AIDiagnose bool
+	AISuggest  bool
+
+	// Migration overrides (optional; block omitted unless MigrationOverrides).
+	MigrationOverrides bool
+	IncludeTables      []string
+	ExcludeTables      []string
+	CreateIndexes      bool
+	CreateForeignKeys  bool
+	CreateChecks       bool
+
+	// Slack (optional; block omitted unless Slack is true).
+	Slack           bool
+	SlackWebhookVar string
+	SlackChannel    string
+	SlackUsername   string
+
+	// Profile metadata (optional; block omitted unless ProfileName is set).
+	ProfileName        string
+	ProfileDescription string
+}
+
+// NewAnswers returns Answers preloaded with the wizard's defaults so that a
+// fully non-interactive run with no flags still produces a valid config.
+func NewAnswers() *Answers {
+	return &Answers{
+		Source: Conn{Type: "mssql", Host: "localhost", PwMode: PwEnv},
+		Target: Conn{Type: "postgres", PwMode: PwEnv},
+
+		UnknownTypePolicy: "fail",
+
+		AIMode:     "warn",
+		AIDiagnose: false,
+		AISuggest:  false,
+
+		CreateIndexes:     true,
+		CreateForeignKeys: true,
+		CreateChecks:      true,
+
+		SlackUsername: "smt",
+	}
+}
+
+// DefaultPort returns the well-known port for an engine, or 0 if unknown.
+func DefaultPort(engine string) int {
+	switch engine {
+	case "mssql":
+		return 1433
+	case "postgres":
+		return 5432
+	case "mysql":
+		return 3306
+	}
+	return 0
+}
+
+// DefaultSchema returns the conventional schema name for an engine. MySQL has
+// no separate schema namespace, so it defaults to the database name.
+func DefaultSchema(engine, database string) string {
+	switch engine {
+	case "mssql":
+		return "dbo"
+	case "postgres":
+		return "public"
+	case "mysql":
+		return database
+	}
+	return ""
+}
+
+// DefaultPasswordVar returns the conventional env var name for a side's
+// password, e.g. "MSSQL_PASSWORD" for an mssql source.
+func DefaultPasswordVar(engine string) string {
+	e := strings.ToUpper(strings.TrimSpace(engine))
+	if e == "" {
+		e = "DB"
+	}
+	return e + "_PASSWORD"
+}
+
+// Build renders the answers to YAML and parses them back through the real
+// config loader, returning the validated config (or a validation error). The
+// rendered bytes and the returned config are guaranteed consistent because the
+// config is produced from those exact bytes.
+func Build(a *Answers) (*config.Config, error) {
+	data, err := RenderYAML(a)
+	if err != nil {
+		return nil, err
+	}
+	return config.LoadBytes(data)
+}
+
+// RenderYAML produces a clean, commented config.yaml matching the shape of
+// config.yaml.example. Optional blocks are emitted only when opted into.
+func RenderYAML(a *Answers) ([]byte, error) {
+	if err := Validate(a); err != nil {
+		return nil, err
+	}
+
+	var b strings.Builder
+	b.WriteString("# smt — Schema Migration Tool configuration\n")
+	b.WriteString("# Generated by `smt init`. Edit freely; see config.yaml.example for all options.\n\n")
+
+	// --- source ---
+	b.WriteString("source:\n")
+	fmt.Fprintf(&b, "  type: %s\n", a.Source.Type)
+	writeConnBody(&b, a.Source)
+	if a.Source.Schema != "" {
+		fmt.Fprintf(&b, "  schema: %s\n", yamlScalar(a.Source.Schema))
+	}
+	b.WriteString("\n")
+
+	// --- target ---
+	b.WriteString("target:\n")
+	fmt.Fprintf(&b, "  type: %s\n", a.Target.Type)
+	fmt.Fprintf(&b, "  schema: %s\n", yamlScalar(a.Target.Schema))
+	if a.ConfigureTarget {
+		writeConnBody(&b, a.Target)
+	} else {
+		b.WriteString("  # Connection fields are only required for --apply or health-check.\n")
+		b.WriteString("  # Re-run `smt init` or add host/port/database/user/password to enable them.\n")
+	}
+	b.WriteString("\n")
+
+	// --- schema_generation ---
+	b.WriteString("schema_generation:\n")
+	b.WriteString("  mode: deterministic\n")
+	fmt.Fprintf(&b, "  unknown_type_policy: %s\n", a.UnknownTypePolicy)
+	b.WriteString("\n")
+
+	// --- ai_review (optional) ---
+	if a.AIReview {
+		b.WriteString("ai_review:\n")
+		b.WriteString("  enabled: true\n")
+		fmt.Fprintf(&b, "  mode: %s\n", a.AIMode)
+		if a.AIModel != "" {
+			fmt.Fprintf(&b, "  model: %s\n", a.AIModel)
+		}
+		fmt.Fprintf(&b, "  diagnose_failures: %t\n", a.AIDiagnose)
+		// suggest_fixes defaults to diagnose_failures in the loader (an opt-out).
+		// Only emit it when it differs, so the documented default is preserved.
+		if a.AISuggest != a.AIDiagnose {
+			fmt.Fprintf(&b, "  suggest_fixes: %t\n", a.AISuggest)
+		}
+		b.WriteString("\n")
+	}
+
+	// --- migration overrides (optional) ---
+	if a.MigrationOverrides {
+		b.WriteString("migration:\n")
+		writeStringList(&b, "include_tables", a.IncludeTables)
+		writeStringList(&b, "exclude_tables", a.ExcludeTables)
+		fmt.Fprintf(&b, "  create_indexes: %t\n", a.CreateIndexes)
+		fmt.Fprintf(&b, "  create_foreign_keys: %t\n", a.CreateForeignKeys)
+		fmt.Fprintf(&b, "  create_check_constraints: %t\n", a.CreateChecks)
+		b.WriteString("\n")
+	}
+
+	// --- slack (optional) ---
+	if a.Slack {
+		b.WriteString("slack:\n")
+		b.WriteString("  enabled: true\n")
+		if a.SlackWebhookVar != "" {
+			fmt.Fprintf(&b, "  webhook_url: ${env:%s}\n", a.SlackWebhookVar)
+		}
+		if a.SlackChannel != "" {
+			fmt.Fprintf(&b, "  channel: %q\n", a.SlackChannel)
+		}
+		if a.SlackUsername != "" {
+			fmt.Fprintf(&b, "  username: %s\n", yamlScalar(a.SlackUsername))
+		}
+		b.WriteString("\n")
+	}
+
+	// --- profile (optional) ---
+	if a.ProfileName != "" {
+		b.WriteString("profile:\n")
+		fmt.Fprintf(&b, "  name: %s\n", yamlScalar(a.ProfileName))
+		if a.ProfileDescription != "" {
+			fmt.Fprintf(&b, "  description: %q\n", a.ProfileDescription)
+		}
+	}
+
+	return []byte(b.String()), nil
+}
+
+// writeConnBody writes host/port/database/user/password lines. The schema line
+// is written separately by the caller (source after the body, target before it)
+// so the two sides can place it consistently without duplicating the key.
+func writeConnBody(b *strings.Builder, c Conn) {
+	fmt.Fprintf(b, "  host: %s\n", yamlScalar(c.Host))
+	fmt.Fprintf(b, "  port: %d\n", c.Port)
+	fmt.Fprintf(b, "  database: %s\n", yamlScalar(c.Database))
+	fmt.Fprintf(b, "  user: %s\n", yamlScalar(c.User))
+	// Literal passwords are always double-quoted: this preserves leading/trailing
+	// whitespace and stops YAML from reinterpreting values like null, ~, true, or
+	// bare numbers. ${env:}/${file:} references are safe as plain scalars.
+	if c.PwMode == PwLiteral {
+		fmt.Fprintf(b, "  password: %q\n", c.PwValue)
+	} else {
+		fmt.Fprintf(b, "  password: %s\n", c.passwordField())
+	}
+}
+
+// yamlScalar renders a free-form, user-supplied string as a YAML scalar,
+// double-quoting it when a plain scalar would be misparsed (special characters,
+// surrounding whitespace, or a word YAML reads as a non-string like null/true).
+// Clean values (hostnames, schema names) stay unquoted for readability.
+func yamlScalar(s string) string {
+	if needsYAMLQuote(s) {
+		return fmt.Sprintf("%q", s)
+	}
+	return s
+}
+
+func needsYAMLQuote(s string) bool {
+	if s == "" {
+		return true
+	}
+	if strings.TrimSpace(s) != s {
+		return true
+	}
+	if strings.ContainsAny(s, ":#{}[],&*?|<>=!%@`\"'\\\n\t") {
+		return true
+	}
+	switch strings.ToLower(s) {
+	case "null", "~", "true", "false", "yes", "no", "on", "off":
+		return true
+	}
+	return false
+}
+
+func writeStringList(b *strings.Builder, key string, vals []string) {
+	if len(vals) == 0 {
+		fmt.Fprintf(b, "  %s: []\n", key)
+		return
+	}
+	fmt.Fprintf(b, "  %s:\n", key)
+	for _, v := range vals {
+		fmt.Fprintf(b, "    - %q\n", v)
+	}
+}
+
+// Validate checks the assembled answers for internal consistency. It is run by
+// RenderYAML and is safe to call directly (flag-driven mode validates up front).
+func Validate(a *Answers) error {
+	if a == nil {
+		return fmt.Errorf("no answers")
+	}
+	if err := validateEngine("source.type", a.Source.Type); err != nil {
+		return err
+	}
+	if err := validateEngine("target.type", a.Target.Type); err != nil {
+		return err
+	}
+	if a.Source.Database == "" {
+		return fmt.Errorf("source.database is required")
+	}
+	if a.Source.User == "" {
+		return fmt.Errorf("source.user is required")
+	}
+	if a.Source.Port <= 0 {
+		return fmt.Errorf("source.port must be positive")
+	}
+	if a.ConfigureTarget {
+		if a.Target.Database == "" {
+			return fmt.Errorf("target.database is required when configuring the target connection")
+		}
+		if a.Target.User == "" {
+			return fmt.Errorf("target.user is required when configuring the target connection")
+		}
+		if a.Target.Port <= 0 {
+			return fmt.Errorf("target.port must be positive when configuring the target connection")
+		}
+	}
+	if !contains(UnknownTypePolicies, a.UnknownTypePolicy) {
+		return fmt.Errorf("schema_generation.unknown_type_policy %q invalid (want one of %s)",
+			a.UnknownTypePolicy, strings.Join(UnknownTypePolicies, ", "))
+	}
+	if a.AIReview && !contains(AIModes, a.AIMode) {
+		return fmt.Errorf("ai_review.mode %q invalid (want one of %s)",
+			a.AIMode, strings.Join(AIModes, ", "))
+	}
+	return nil
+}
+
+func validateEngine(field, val string) error {
+	if !contains(Engines, val) {
+		return fmt.Errorf("%s %q invalid (want one of %s)", field, val, strings.Join(Engines, ", "))
+	}
+	return nil
+}
+
+func contains(set []string, v string) bool {
+	for _, s := range set {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/wizard/steps.go
+++ b/internal/wizard/steps.go
@@ -1,0 +1,390 @@
+package wizard
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Field is one prompt in the wizard. Front-ends (CLI stdin, TUI) iterate
+// Steps(), and for each non-skipped field obtain a raw string (from the user or
+// a flag), then call Parse to validate-and-apply it into Answers. Defaults,
+// option lists, and validation live here once.
+type Field struct {
+	// Key is a stable identifier, also used as the CLI flag name.
+	Key string
+	// Prompt returns the question text (may depend on prior answers).
+	Prompt func(a *Answers) string
+	// Help is an optional one-line hint shown under the prompt.
+	Help string
+	// Options returns a fixed choice list, or nil for free text.
+	Options func(a *Answers) []string
+	// Default returns the pre-filled value (may depend on prior answers).
+	Default func(a *Answers) string
+	// Secret reports whether the input should be masked / not echoed.
+	Secret func(a *Answers) bool
+	// Skip reports whether this field does not apply given prior answers.
+	Skip func(a *Answers) bool
+	// Parse validates raw and applies it to a. An error means re-prompt
+	// (interactive) or fail (non-interactive).
+	Parse func(raw string, a *Answers) error
+}
+
+// IsSkipped reports whether the field should be skipped for these answers.
+func (f Field) IsSkipped(a *Answers) bool { return f.Skip != nil && f.Skip(a) }
+
+// DefaultValue returns the field's default for these answers ("" if none).
+func (f Field) DefaultValue(a *Answers) string {
+	if f.Default == nil {
+		return ""
+	}
+	return f.Default(a)
+}
+
+// Steps returns the ordered wizard fields. The slice is rebuilt per call so it
+// is safe to mutate Answers between steps.
+func Steps() []Field {
+	return []Field{
+		// ---- source ----
+		choice("source.type", "Source database engine", func(a *Answers) []string { return Engines },
+			func(a *Answers) string { return a.Source.Type },
+			func(v string, a *Answers) { a.Source.Type = v }),
+		text("source.host", "Source host", func(a *Answers) string { return orDefault(a.Source.Host, "localhost") },
+			func(v string, a *Answers) { a.Source.Host = v }, false),
+		port("source.port", "Source port", func(a *Answers) *Conn { return &a.Source }),
+		required("source.database", "Source database name", nil,
+			func(a *Answers) string { return a.Source.Database },
+			func(v string, a *Answers) { a.Source.Database = v }),
+		required("source.user", "Source user", nil,
+			func(a *Answers) string { return a.Source.User },
+			func(v string, a *Answers) { a.Source.User = v }),
+		pwModeField("source.password_mode", "Source password storage", func(a *Answers) *Conn { return &a.Source }),
+		pwValueField("source.password", func(a *Answers) *Conn { return &a.Source }, false),
+		text("source.schema", "Source schema", func(a *Answers) string {
+			return orDefault(a.Source.Schema, DefaultSchema(a.Source.Type, a.Source.Database))
+		}, func(v string, a *Answers) { a.Source.Schema = v }, false),
+
+		// ---- target ----
+		choice("target.type", "Target database engine", func(a *Answers) []string { return Engines },
+			func(a *Answers) string { return a.Target.Type },
+			func(v string, a *Answers) { a.Target.Type = v }),
+		text("target.schema", "Target schema", func(a *Answers) string {
+			return orDefault(a.Target.Schema, DefaultSchema(a.Target.Type, a.Target.Database))
+		}, func(v string, a *Answers) { a.Target.Schema = v }, false),
+		yesNo("target.configure", "Configure the target connection now? (needed for --apply / health-check)",
+			func(a *Answers) bool { return a.ConfigureTarget },
+			func(v bool, a *Answers) { a.ConfigureTarget = v }),
+
+		// target connection (only when configuring)
+		skipUnlessTarget(text("target.host", "Target host",
+			func(a *Answers) string { return orDefault(a.Target.Host, "localhost") },
+			func(v string, a *Answers) { a.Target.Host = v }, false)),
+		skipUnlessTarget(port("target.port", "Target port", func(a *Answers) *Conn { return &a.Target })),
+		skipUnlessTarget(required("target.database", "Target database name", nil,
+			func(a *Answers) string { return a.Target.Database },
+			func(v string, a *Answers) { a.Target.Database = v })),
+		skipUnlessTarget(required("target.user", "Target user", nil,
+			func(a *Answers) string { return a.Target.User },
+			func(v string, a *Answers) { a.Target.User = v })),
+		skipUnlessTarget(pwModeField("target.password_mode", "Target password storage", func(a *Answers) *Conn { return &a.Target })),
+		skipUnlessTarget(pwValueField("target.password", func(a *Answers) *Conn { return &a.Target }, false)),
+
+		// ---- schema generation ----
+		choice("unknown_type_policy", "Unknown source type policy",
+			func(a *Answers) []string { return UnknownTypePolicies },
+			func(a *Answers) string { return orDefault(a.UnknownTypePolicy, "fail") },
+			func(v string, a *Answers) { a.UnknownTypePolicy = v }),
+
+		// ---- ai review (optional) ----
+		yesNo("ai_review", "Enable optional AI review of generated DDL?",
+			func(a *Answers) bool { return a.AIReview },
+			func(v bool, a *Answers) { a.AIReview = v }),
+		skipUnlessAI(choice("ai_review.mode", "AI review mode",
+			func(a *Answers) []string { return AIModes },
+			func(a *Answers) string { return orDefault(a.AIMode, "warn") },
+			func(v string, a *Answers) { a.AIMode = v })),
+		skipUnlessAI(text("ai_review.model", "AI reviewer provider (secrets file entry; blank = default)",
+			func(a *Answers) string { return a.AIModel },
+			func(v string, a *Answers) { a.AIModel = v }, true)),
+		skipUnlessAI(yesNo("ai_review.diagnose_failures", "Let AI advise on extract/render failures?",
+			func(a *Answers) bool { return a.AIDiagnose },
+			func(v bool, a *Answers) { a.AIDiagnose = v })),
+		// suggest_fixes defaults to diagnose_failures (a loader opt-out), so the
+		// prompt default tracks AIDiagnose rather than the zero value.
+		skipUnlessAI(yesNo("ai_review.suggest_fixes", "Let AI suggest fixes (written to schema.suggested.sql; never applied)?",
+			func(a *Answers) bool { return a.AISuggest || a.AIDiagnose },
+			func(v bool, a *Answers) { a.AISuggest = v })),
+
+		// ---- migration overrides (optional) ----
+		yesNo("migration", "Set migration overrides (table filters / object toggles)?",
+			func(a *Answers) bool { return a.MigrationOverrides },
+			func(v bool, a *Answers) { a.MigrationOverrides = v }),
+		skipUnlessMigration(list("migration.include_tables", "Only include these tables (comma-separated globs; blank = all)",
+			func(a *Answers) []string { return a.IncludeTables },
+			func(v []string, a *Answers) { a.IncludeTables = v })),
+		skipUnlessMigration(list("migration.exclude_tables", "Exclude these tables (comma-separated globs)",
+			func(a *Answers) []string { return a.ExcludeTables },
+			func(v []string, a *Answers) { a.ExcludeTables = v })),
+		skipUnlessMigration(yesNo("migration.create_indexes", "Create non-PK indexes?",
+			func(a *Answers) bool { return a.CreateIndexes },
+			func(v bool, a *Answers) { a.CreateIndexes = v })),
+		skipUnlessMigration(yesNo("migration.create_foreign_keys", "Create foreign keys?",
+			func(a *Answers) bool { return a.CreateForeignKeys },
+			func(v bool, a *Answers) { a.CreateForeignKeys = v })),
+		skipUnlessMigration(yesNo("migration.create_check_constraints", "Create CHECK constraints?",
+			func(a *Answers) bool { return a.CreateChecks },
+			func(v bool, a *Answers) { a.CreateChecks = v })),
+
+		// ---- slack (optional) ----
+		yesNo("slack", "Enable Slack notifications?",
+			func(a *Answers) bool { return a.Slack },
+			func(v bool, a *Answers) { a.Slack = v }),
+		skipUnlessSlack(text("slack.webhook_var", "Env var holding the Slack webhook URL",
+			func(a *Answers) string { return orDefault(a.SlackWebhookVar, "SLACK_WEBHOOK_URL") },
+			func(v string, a *Answers) { a.SlackWebhookVar = v }, false)),
+		skipUnlessSlack(text("slack.channel", "Slack channel",
+			func(a *Answers) string { return a.SlackChannel },
+			func(v string, a *Answers) { a.SlackChannel = v }, false)),
+		skipUnlessSlack(text("slack.username", "Slack username",
+			func(a *Answers) string { return orDefault(a.SlackUsername, "smt") },
+			func(v string, a *Answers) { a.SlackUsername = v }, false)),
+
+		// ---- profile (optional) ----
+		text("profile.name", "Profile name (blank = no profile block)",
+			func(a *Answers) string { return a.ProfileName },
+			func(v string, a *Answers) { a.ProfileName = v }, false),
+		text("profile.description", "Profile description",
+			func(a *Answers) string { return a.ProfileDescription },
+			func(v string, a *Answers) { a.ProfileDescription = v }, false),
+	}
+}
+
+// --- field constructors -------------------------------------------------
+
+func text(key, prompt string, def func(a *Answers) string, apply func(string, *Answers), secret bool) Field {
+	return Field{
+		Key:     key,
+		Prompt:  func(*Answers) string { return prompt },
+		Default: def,
+		Secret:  func(*Answers) bool { return secret },
+		Parse: func(raw string, a *Answers) error {
+			apply(strings.TrimSpace(raw), a)
+			return nil
+		},
+	}
+}
+
+func required(key, prompt string, _ func(a *Answers) []string, def func(a *Answers) string, apply func(string, *Answers)) Field {
+	return Field{
+		Key:     key,
+		Prompt:  func(*Answers) string { return prompt },
+		Default: def,
+		Parse: func(raw string, a *Answers) error {
+			v := strings.TrimSpace(raw)
+			if v == "" {
+				return fmt.Errorf("%s is required", key)
+			}
+			apply(v, a)
+			return nil
+		},
+	}
+}
+
+func choice(key, prompt string, opts func(a *Answers) []string, def func(a *Answers) string, apply func(string, *Answers)) Field {
+	return Field{
+		Key:     key,
+		Prompt:  func(*Answers) string { return prompt },
+		Options: opts,
+		Default: def,
+		Parse: func(raw string, a *Answers) error {
+			v := strings.TrimSpace(raw)
+			if v == "" {
+				v = def(a)
+			}
+			if !contains(opts(a), v) {
+				return fmt.Errorf("%s %q invalid (want one of %s)", key, v, strings.Join(opts(a), ", "))
+			}
+			apply(v, a)
+			return nil
+		},
+	}
+}
+
+func yesNo(key, prompt string, def func(a *Answers) bool, apply func(bool, *Answers)) Field {
+	return Field{
+		Key:     key,
+		Prompt:  func(*Answers) string { return prompt },
+		Options: func(*Answers) []string { return []string{"yes", "no"} },
+		Default: func(a *Answers) string {
+			if def(a) {
+				return "yes"
+			}
+			return "no"
+		},
+		Parse: func(raw string, a *Answers) error {
+			v := strings.ToLower(strings.TrimSpace(raw))
+			switch v {
+			case "", "y", "yes", "true":
+				if v == "" {
+					apply(def(a), a)
+					return nil
+				}
+				apply(true, a)
+			case "n", "no", "false":
+				apply(false, a)
+			default:
+				return fmt.Errorf("%s: answer yes or no", key)
+			}
+			return nil
+		},
+	}
+}
+
+func list(key, prompt string, def func(a *Answers) []string, apply func([]string, *Answers)) Field {
+	return Field{
+		Key:    key,
+		Prompt: func(*Answers) string { return prompt },
+		Default: func(a *Answers) string {
+			return strings.Join(def(a), ",")
+		},
+		Parse: func(raw string, a *Answers) error {
+			apply(splitList(raw), a)
+			return nil
+		},
+	}
+}
+
+func port(key, prompt string, side func(a *Answers) *Conn) Field {
+	return Field{
+		Key:    key,
+		Prompt: func(*Answers) string { return prompt },
+		Default: func(a *Answers) string {
+			c := side(a)
+			p := c.Port
+			if p == 0 {
+				p = DefaultPort(c.Type)
+			}
+			if p == 0 {
+				return ""
+			}
+			return strconv.Itoa(p)
+		},
+		Parse: func(raw string, a *Answers) error {
+			c := side(a)
+			v := strings.TrimSpace(raw)
+			if v == "" {
+				c.Port = DefaultPort(c.Type)
+				return nil
+			}
+			n, err := strconv.Atoi(v)
+			if err != nil || n <= 0 {
+				return fmt.Errorf("%s: %q is not a valid port", key, raw)
+			}
+			c.Port = n
+			return nil
+		},
+	}
+}
+
+func pwModeField(key, prompt string, side func(a *Answers) *Conn) Field {
+	return Field{
+		Key:     key,
+		Prompt:  func(*Answers) string { return prompt },
+		Options: func(*Answers) []string { return PasswordModes },
+		Help:    "env = ${env:VAR} reference (recommended); file = ${file:/path}; literal = stored in YAML",
+		Default: func(a *Answers) string {
+			m := string(side(a).PwMode)
+			return orDefault(m, string(PwEnv))
+		},
+		Parse: func(raw string, a *Answers) error {
+			v := strings.ToLower(strings.TrimSpace(raw))
+			if v == "" {
+				v = string(PwEnv)
+			}
+			if !contains(PasswordModes, v) {
+				return fmt.Errorf("%s %q invalid (want one of %s)", key, v, strings.Join(PasswordModes, ", "))
+			}
+			side(a).PwMode = PasswordMode(v)
+			return nil
+		},
+	}
+}
+
+func pwValueField(key string, side func(a *Answers) *Conn, _ bool) Field {
+	return Field{
+		Key: key,
+		Prompt: func(a *Answers) string {
+			switch side(a).PwMode {
+			case PwFile:
+				return "Path to the password file"
+			case PwLiteral:
+				return "Password"
+			default:
+				return "Env var holding the password"
+			}
+		},
+		Default: func(a *Answers) string {
+			c := side(a)
+			if c.PwMode == PwEnv {
+				return orDefault(c.PwValue, DefaultPasswordVar(c.Type))
+			}
+			return c.PwValue
+		},
+		Secret: func(a *Answers) bool { return side(a).PwMode == PwLiteral },
+		Parse: func(raw string, a *Answers) error {
+			c := side(a)
+			// A literal password is kept verbatim (whitespace is significant); env
+			// var names and file paths are trimmed. The prompter already strips the
+			// trailing newline.
+			if c.PwMode == PwLiteral {
+				c.PwValue = raw
+				return nil
+			}
+			v := strings.TrimSpace(raw)
+			if v == "" && c.PwMode == PwEnv {
+				v = DefaultPasswordVar(c.Type)
+			}
+			c.PwValue = v
+			return nil
+		},
+	}
+}
+
+// --- skip wrappers ------------------------------------------------------
+
+func skipUnlessTarget(f Field) Field {
+	return withSkip(f, func(a *Answers) bool { return !a.ConfigureTarget })
+}
+func skipUnlessAI(f Field) Field { return withSkip(f, func(a *Answers) bool { return !a.AIReview }) }
+func skipUnlessMigration(f Field) Field {
+	return withSkip(f, func(a *Answers) bool { return !a.MigrationOverrides })
+}
+func skipUnlessSlack(f Field) Field { return withSkip(f, func(a *Answers) bool { return !a.Slack }) }
+
+func withSkip(f Field, skip func(a *Answers) bool) Field {
+	f.Skip = skip
+	return f
+}
+
+// --- helpers ------------------------------------------------------------
+
+func orDefault(v, def string) string {
+	if strings.TrimSpace(v) == "" {
+		return def
+	}
+	return v
+}
+
+func splitList(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -1,0 +1,238 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+
+	"smt/internal/config"
+)
+
+// fullAnswers returns a maximal set of answers exercising every optional block.
+func fullAnswers() *Answers {
+	a := NewAnswers()
+	a.Source = Conn{Type: "mssql", Host: "localhost", Port: 1433, Database: "StackOverflow2010", User: "sa", PwMode: PwEnv, PwValue: "MSSQL_PASSWORD", Schema: "dbo"}
+	a.Target = Conn{Type: "postgres", Host: "localhost", Port: 5432, Database: "so", User: "postgres", PwMode: PwEnv, PwValue: "PG_PASSWORD", Schema: "public"}
+	a.ConfigureTarget = true
+	a.UnknownTypePolicy = "fail"
+	a.AIReview = true
+	a.AIMode = "warn"
+	a.AIModel = "strong"
+	a.AIDiagnose = true
+	a.AISuggest = true
+	a.MigrationOverrides = true
+	a.ExcludeTables = []string{"__*", "temp_*"}
+	a.CreateIndexes = true
+	a.CreateForeignKeys = true
+	a.CreateChecks = true
+	a.Slack = true
+	a.SlackWebhookVar = "SLACK_WEBHOOK_URL"
+	a.SlackChannel = "#data"
+	a.SlackUsername = "smt"
+	a.ProfileName = "so2010"
+	a.ProfileDescription = "StackOverflow 2010"
+	return a
+}
+
+// minimalAnswers returns the smallest valid set: source + target descriptor only.
+func minimalAnswers() *Answers {
+	a := NewAnswers()
+	a.Source = Conn{Type: "postgres", Host: "localhost", Port: 5432, Database: "app", User: "postgres", PwMode: PwEnv, PwValue: "PG_PASSWORD", Schema: "public"}
+	a.Target = Conn{Type: "mysql", Schema: "app"}
+	a.UnknownTypePolicy = "fail"
+	return a
+}
+
+// TestBuildRoundTrips asserts wizard output parses cleanly through the real
+// loader — the issue's "round-trips through config.Load without warnings" bar.
+func TestBuildRoundTrips(t *testing.T) {
+	for name, a := range map[string]*Answers{"full": fullAnswers(), "minimal": minimalAnswers()} {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := Build(a)
+			if err != nil {
+				data, _ := RenderYAML(a)
+				t.Fatalf("Build: %v\n--- rendered ---\n%s", err, data)
+			}
+			if cfg.Source.Type != a.Source.Type {
+				t.Errorf("source type: got %q want %q", cfg.Source.Type, a.Source.Type)
+			}
+			if cfg.Target.Type != a.Target.Type {
+				t.Errorf("target type: got %q want %q", cfg.Target.Type, a.Target.Type)
+			}
+		})
+	}
+}
+
+// TestRenderMatchesLoadBytes proves the rendered file and the validated config
+// are the same artifact (Build is derived from RenderYAML).
+func TestRenderMatchesLoadBytes(t *testing.T) {
+	a := fullAnswers()
+	data, err := RenderYAML(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.LoadBytes(data)
+	if err != nil {
+		t.Fatalf("LoadBytes on rendered yaml: %v\n%s", err, data)
+	}
+	if !cfg.HasTargetConnection() {
+		t.Error("full answers should yield a usable target connection")
+	}
+}
+
+func TestPasswordModes(t *testing.T) {
+	cases := []struct {
+		mode PasswordMode
+		val  string
+		want string
+	}{
+		{PwEnv, "MSSQL_PASSWORD", "${env:MSSQL_PASSWORD}"},
+		{PwFile, "/run/secrets/db", "${file:/run/secrets/db}"},
+		{PwLiteral, "hunter2", "hunter2"},
+	}
+	for _, c := range cases {
+		got := Conn{PwMode: c.mode, PwValue: c.val}.passwordField()
+		if got != c.want {
+			t.Errorf("mode %s: got %q want %q", c.mode, got, c.want)
+		}
+	}
+}
+
+// TestOptionalBlocksOmitted asserts opt-out blocks never appear in output.
+func TestOptionalBlocksOmitted(t *testing.T) {
+	a := minimalAnswers()
+	data, err := RenderYAML(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	for _, block := range []string{"ai_review:", "migration:", "slack:", "profile:"} {
+		if strings.Contains(s, block) {
+			t.Errorf("minimal config should omit %q\n%s", block, s)
+		}
+	}
+	// Target connection lines must be absent when not configured.
+	if strings.Contains(s, "host: localhost\n  port: 3306") {
+		t.Errorf("unconfigured target should not emit connection fields\n%s", s)
+	}
+}
+
+// TestSuggestFixesOptOut: when suggest tracks diagnose, the key is omitted so
+// the loader's opt-out default applies; when they differ, it is emitted.
+func TestSuggestFixesOptOut(t *testing.T) {
+	a := minimalAnswers()
+	a.AIReview, a.AIMode, a.AIDiagnose, a.AISuggest = true, "warn", true, true
+	data, err := RenderYAML(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "suggest_fixes:") {
+		t.Errorf("suggest==diagnose should omit suggest_fixes\n%s", data)
+	}
+	a.AISuggest = false // diverge from diagnose
+	data, _ = RenderYAML(a)
+	if !strings.Contains(string(data), "suggest_fixes: false") {
+		t.Errorf("suggest!=diagnose should emit suggest_fixes: false\n%s", data)
+	}
+}
+
+// TestLiteralPasswordFidelity: whitespace and YAML-null-like literals survive
+// rendering and the loader round-trip verbatim.
+func TestLiteralPasswordFidelity(t *testing.T) {
+	for _, pw := range []string{" s p a c e ", "null", "~", "true", "0755", "p@ss:#word"} {
+		a := minimalAnswers()
+		a.Source.PwMode = PwLiteral
+		a.Source.PwValue = pw
+		cfg, err := Build(a)
+		if err != nil {
+			data, _ := RenderYAML(a)
+			t.Fatalf("Build with literal %q: %v\n%s", pw, err, data)
+		}
+		if cfg.Source.Password != pw {
+			t.Errorf("literal password %q round-tripped as %q", pw, cfg.Source.Password)
+		}
+	}
+}
+
+// TestFreeFormFieldsRoundTrip: connection fields with YAML-special characters
+// survive rendering + the loader verbatim.
+func TestFreeFormFieldsRoundTrip(t *testing.T) {
+	a := minimalAnswers()
+	a.Source.Database = "sales:reporting" // colon
+	a.Source.User = "domain\\svc#1"       // backslash + hash
+	a.Source.Schema = "no"                // YAML bool-ish
+	cfg, err := Build(a)
+	if err != nil {
+		data, _ := RenderYAML(a)
+		t.Fatalf("Build: %v\n%s", err, data)
+	}
+	if cfg.Source.Database != "sales:reporting" {
+		t.Errorf("database round-tripped as %q", cfg.Source.Database)
+	}
+	if cfg.Source.User != "domain\\svc#1" {
+		t.Errorf("user round-tripped as %q", cfg.Source.User)
+	}
+	if cfg.Source.Schema != "no" {
+		t.Errorf("schema round-tripped as %q", cfg.Source.Schema)
+	}
+}
+
+func TestValidateCatchesBadEngine(t *testing.T) {
+	a := minimalAnswers()
+	a.Source.Type = "oracle"
+	if err := Validate(a); err == nil {
+		t.Fatal("expected error for unsupported source engine")
+	}
+}
+
+func TestValidateRequiresSourceFields(t *testing.T) {
+	a := minimalAnswers()
+	a.Source.Database = ""
+	if err := Validate(a); err == nil {
+		t.Fatal("expected error for missing source.database")
+	}
+}
+
+// TestStepsDriveAnswers simulates a non-interactive run: feed each step its
+// default and confirm the assembled answers validate. This is the same path
+// both front-ends use, so it guards the shared contract.
+func TestStepsDriveAnswers(t *testing.T) {
+	a := NewAnswers()
+	// Seed the required free-text fields the defaults can't supply.
+	seed := map[string]string{
+		"source.database": "StackOverflow2010",
+		"source.user":     "sa",
+		"target.type":     "postgres",
+	}
+	for _, f := range Steps() {
+		if f.IsSkipped(a) {
+			continue
+		}
+		raw, ok := seed[f.Key]
+		if !ok {
+			raw = f.DefaultValue(a)
+		}
+		if err := f.Parse(raw, a); err != nil {
+			t.Fatalf("step %s parse(%q): %v", f.Key, raw, err)
+		}
+	}
+	if err := Validate(a); err != nil {
+		t.Fatalf("assembled answers invalid: %v", err)
+	}
+	if _, err := Build(a); err != nil {
+		t.Fatalf("Build after stepping: %v", err)
+	}
+}
+
+func TestPortStepDefaultsByEngine(t *testing.T) {
+	a := NewAnswers()
+	a.Source.Type = "mysql"
+	for _, f := range Steps() {
+		if f.Key == "source.port" {
+			if got := f.DefaultValue(a); got != "3306" {
+				t.Fatalf("mysql source port default: got %q want 3306", got)
+			}
+			return
+		}
+	}
+	t.Fatal("source.port step not found")
+}


### PR DESCRIPTION
Closes #160.

Adds a guided way to create a `config.yaml`, replacing copy-and-hand-edit of
`config.yaml.example`. Available from both the CLI and the TUI, driven by one
shared core so prompts/defaults/validation are defined exactly once.

## What's here

**`internal/wizard` — shared, UI-agnostic core**
- `Answers`/`Conn` model, per-engine defaults (ports 1433/5432/3306, schemas
  dbo/public/db-name, password env-var names).
- A declarative `Steps()` field list (prompt / options / default / secret / skip
  / validate-apply) — the single source both front-ends iterate.
- `RenderYAML()` emits clean commented YAML with opt-in blocks omitted; `Build()`
  = `config.LoadBytes(RenderYAML())`, so the written file and the validated
  config are provably the same artifact.

**`smt init` — CLI**
- Interactive prompter (sections, defaults, re-prompt) **and** non-interactive
  flag mode driving the same `Steps()`; `--out` / `--force` / `--print`.
- Offered post-steps: health-check (reuses the orchestrator path) and
  save-as-encrypted-profile (reuses the profile store).

**TUI — `/init` + first-run nudge**
- A new `ModeWizard` takes over key input and walks the same `Steps()` one
  prompt at a time; secret fields use masked echo.
- Writes `config.yaml` at 0600, refuses to overwrite, then shows the result.
- When no `config.yaml` exists in the working dir, the welcome screen points the
  user at `/init`.

## Fidelity & security (all from review)

Two codex review rounds on the CLI and one on the TUI; every finding fixed:
- Passwords default to `${env:VAR}`; literal passwords are read no-echo on a TTY
  (CLI) / masked (TUI), kept verbatim (whitespace significant), and always
  YAML-quoted so `null`/`~`/`true`/numbers survive the round-trip.
- Free-form fields (host/database/user/schema/…) are quoted when a plain scalar
  would be misparsed (`#`, `: `).
- `suggest_fixes` is emitted only when it diverges from `diagnose_failures`, so
  the loader's documented opt-out default is preserved.
- Explicitly-set flags for a disabled section error instead of being silently
  dropped; overwrites re-chmod to 0600; explicit `--health-check`/`--save-profile`
  failures propagate (non-zero exit).
- Interactive CLI prompts go to stderr so `smt init --print > config.yaml` stays
  clean.
- **TUI literal-password leaks (both P1):** cancel mid-field resets the input
  before restoring echo; the completion preview is suppressed when the config
  embeds a literal password, so it never reaches scrollback or a `/logs` export.

## Test plan

- `internal/wizard` unit tests: loader round-trip (full + minimal), optional-block
  omission, password modes, literal-password fidelity (whitespace/null), free-form
  special-char round-trip, suggest_fixes opt-out, per-engine port defaults, and a
  test that drives the shared `Steps()` exactly as a front-end does.
- `internal/tui` wizard tests: enters ModeWizard at the right step, Esc cancels
  without writing, full flow writes a config that loads and is 0600, existing
  files aren't overwritten, secret fields mask input, a literal password never
  lands in scrollback (`m.content`), and cancel clears the input buffer.
- `gofmt`, `go vet ./...`, `go test ./... -short` all clean.

## Notes

- New direct dependency `github.com/charmbracelet/x/term` (already in the tree
  indirectly) for no-echo CLI password reads.
- The CLI's literal-password input is masked only on a TTY (non-TTY/piped falls
  back to a normal line read) — by design, since `${env:VAR}` is the default and
  literal mode is the opt-in, discouraged path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)