### PR TITLE
Prune DMT-era migration_defaults from the secrets file — closes #156

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to SMT are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- **DMT-era `migration_defaults` keys dropped from the secrets file** ([#156]).
+  The global `migration_defaults` block in `~/.secrets/smt-config.yaml` no longer
+  carries data-transfer tuning that SMT (a schema tool) never consumed:
+  `workers`, `max_memory_mb`, `read_ahead_buffers`, `write_ahead_writers`,
+  `parallel_readers`, `strict_consistency`, `sample_validation`, `sample_size`,
+  `checkpoint_frequency`, `max_retries`, `history_retention_days`, `ai_adjust`,
+  and `ai_adjust_interval`. The v1-supported shape is `max_source_connections`,
+  `max_target_connections`, `create_indexes`, `create_foreign_keys`,
+  `create_check_constraints`, and `data_dir`. Existing secrets files that still
+  list a removed key load fine — the key is ignored and a single warning names
+  the dropped keys (warn-and-ignore, not a hard failure). `smt init-secrets`
+  emits only the supported shape.
+
 ## [0.11.0] - 2026-06-14
 
 Headline: **optional AI failure assistance** — when SMT's deterministic renderer
@@ -102,6 +119,7 @@ history since v0.9.0:
 [#131]: https://github.com/johndauphine/smt/issues/131
 [#133]: https://github.com/johndauphine/smt/pull/133
 [#134]: https://github.com/johndauphine/smt/issues/134
+[#156]: https://github.com/johndauphine/smt/issues/156
 [#46]: https://github.com/johndauphine/smt/issues/46
 [#57]: https://github.com/johndauphine/smt/issues/57
 [#58]: https://github.com/johndauphine/smt/issues/58

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ If you find yourself looking for these in SMT, they're intentionally gone:
 - `internal/driver/dbtuning/` — database-level data-transfer parameter tuning.
 - `internal/driver/ai_smartconfig.go` — AI suggestions for data-transfer parameters.
 - `cmd/migrate/...` paths — SMT's binary is `cmd/smt/`.
-- `MigrationDefaults` workers/chunk_size/buffers fields are still defined in `internal/secrets/secrets.go` (kept to avoid breaking the secrets file format) but unused.
+- `MigrationDefaults` (secrets file) DMT-era data-transfer tuning — removed in #156. The v1 `migration_defaults` shape is `max_source_connections`, `max_target_connections`, `create_{indexes,foreign_keys,check_constraints}`, and `data_dir`; removed keys (`workers`, `max_memory_mb`, buffers/readers/writers, `strict_consistency`, `sample_*`, `checkpoint_frequency`, `max_retries`, `history_retention_days`, `ai_adjust*`) warn-and-ignore on load.
 - `validator.go` — DMT's row-count validator. Schema validation lives in `schemadiff`.
 
 ## Reading the source
@@ -133,10 +133,6 @@ Active work is tracked in GitHub issues. Run `gh issue list --state open` and re
 - **#57 (deterministic DDL generation)** — core is done (no-AI schema path, deterministic renderer, repeat-stable). Remaining children: **#62** (UVG-style canonical type layer — largely behavioral-equivalent today; a refactor question), **#64** (renderer/mapper version fingerprints on persisted artifacts), **#65** (SO2010 MSSQL→PG no-AI acceptance test).
 - **#58 (optional AI review)** — review is optional, default-off, inspect-only; the verifier-feedback retry loop is gone. Remaining child: **#68** (reviewer contract + provider-failure tests).
 - **#59 (deterministic sync)** — snapshot diff, deterministic ALTERs, dry-run + risk gating, golden tests all landed. Remaining child: **#69** (target-side introspection + three-way source/desired/existing diff — the substantive open feature).
-
-Older non-issue follow-ups:
-
-- `MigrationDefaults` in `internal/secrets/secrets.go` carries unused workers/chunk_size/buffer fields. Safe to drop once we're confident no DMT secrets file in the wild needs them.
 
 ### Cross-engine coverage status
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -423,27 +423,12 @@ func (c *Config) applyGlobalDefaults() {
 		return
 	}
 
-	// Performance settings - only apply if not set in migration config
-	if c.Migration.Workers == 0 && defaults.Workers > 0 {
-		c.Migration.Workers = defaults.Workers
-	}
+	// Connection pool sizing - only apply if not set in migration config
 	if c.Migration.MaxSourceConnections == 0 && defaults.MaxSourceConnections > 0 {
 		c.Migration.MaxSourceConnections = defaults.MaxSourceConnections
 	}
 	if c.Migration.MaxTargetConnections == 0 && defaults.MaxTargetConnections > 0 {
 		c.Migration.MaxTargetConnections = defaults.MaxTargetConnections
-	}
-	if c.Migration.MaxMemoryMB == 0 && defaults.MaxMemoryMB > 0 {
-		c.Migration.MaxMemoryMB = defaults.MaxMemoryMB
-	}
-	if c.Migration.ReadAheadBuffers == 0 && defaults.ReadAheadBuffers > 0 {
-		c.Migration.ReadAheadBuffers = defaults.ReadAheadBuffers
-	}
-	if c.Migration.WriteAheadWriters == 0 && defaults.WriteAheadWriters > 0 {
-		c.Migration.WriteAheadWriters = defaults.WriteAheadWriters
-	}
-	if c.Migration.ParallelReaders == 0 && defaults.ParallelReaders > 0 {
-		c.Migration.ParallelReaders = defaults.ParallelReaders
 	}
 
 	// Schema-object defaults use YAML key presence so explicit false in a
@@ -459,30 +444,6 @@ func (c *Config) applyGlobalDefaults() {
 	if defaults.CreateCheckConstraints != nil && !c.hasMigrationKey("create_check_constraints") {
 		c.Migration.CreateCheckConstraints = *defaults.CreateCheckConstraints
 		c.markMigrationDefault("create_check_constraints")
-	}
-
-	// Other booleans retain the historical bool limitation: global true wins
-	// over an unset/false migration value because these fields do not track
-	// YAML key presence yet.
-	if defaults.StrictConsistency != nil && !c.Migration.StrictConsistency {
-		c.Migration.StrictConsistency = *defaults.StrictConsistency
-	}
-	if defaults.SampleValidation != nil && !c.Migration.SampleValidation {
-		c.Migration.SampleValidation = *defaults.SampleValidation
-	}
-	if c.Migration.SampleSize == 0 && defaults.SampleSize > 0 {
-		c.Migration.SampleSize = defaults.SampleSize
-	}
-
-	// Checkpoint and recovery
-	if c.Migration.CheckpointFrequency == 0 && defaults.CheckpointFrequency > 0 {
-		c.Migration.CheckpointFrequency = defaults.CheckpointFrequency
-	}
-	if c.Migration.MaxRetries == 0 && defaults.MaxRetries > 0 {
-		c.Migration.MaxRetries = defaults.MaxRetries
-	}
-	if c.Migration.HistoryRetentionDays == 0 && defaults.HistoryRetentionDays > 0 {
-		c.Migration.HistoryRetentionDays = defaults.HistoryRetentionDays
 	}
 
 	// Data directory

--- a/internal/secrets/migration_defaults_test.go
+++ b/internal/secrets/migration_defaults_test.go
@@ -1,0 +1,148 @@
+package secrets
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"smt/internal/logging"
+)
+
+// TestMigrationDefaultsV1Shape pins the v1 migration_defaults contract: exactly
+// the fields SMT consumes, and none of the removed DMT-era keys as struct fields.
+func TestMigrationDefaultsV1Shape(t *testing.T) {
+	want := []string{
+		"create_check_constraints",
+		"create_foreign_keys",
+		"create_indexes",
+		"data_dir",
+		"max_source_connections",
+		"max_target_connections",
+	}
+	typ := reflect.TypeOf(MigrationDefaults{})
+	var got []string
+	for i := 0; i < typ.NumField(); i++ {
+		got = append(got, strings.Split(typ.Field(i).Tag.Get("yaml"), ",")[0])
+	}
+	sort.Strings(got)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("migration_defaults shape drifted:\n got  %v\n want %v", got, want)
+	}
+
+	// No removed key may sneak back as a struct field.
+	gotSet := map[string]bool{}
+	for _, k := range got {
+		gotSet[k] = true
+	}
+	for _, k := range legacyMigrationDefaultKeys {
+		if gotSet[k] {
+			t.Errorf("removed DMT-era key %q is still a MigrationDefaults field", k)
+		}
+	}
+}
+
+// TestLoadWarnsAndIgnoresLegacyKeys: a secrets file carrying removed keys loads
+// successfully (supported fields applied), emitting a single warning that names
+// the removed keys.
+func TestLoadWarnsAndIgnoresLegacyKeys(t *testing.T) {
+	tmp := t.TempDir()
+	f := filepath.Join(tmp, "secrets.yaml")
+	content := `
+ai:
+  default_provider: anthropic
+  providers:
+    anthropic:
+      api_key: "k"
+encryption:
+  master_key: "mk"
+migration_defaults:
+  workers: 8
+  max_memory_mb: 4096
+  history_retention_days: 30
+  ai_adjust: true
+  max_source_connections: 5
+  create_indexes: false
+`
+	if err := os.WriteFile(f, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(SecretsFileEnvVar, f)
+	Reset()
+
+	var buf bytes.Buffer
+	logging.SetOutput(&buf)
+	defer logging.SetOutput(nil)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("load with legacy keys should not fail: %v", err)
+	}
+
+	// Supported fields still apply.
+	if cfg.MigrationDefaults.MaxSourceConnections != 5 {
+		t.Errorf("max_source_connections = %d, want 5", cfg.MigrationDefaults.MaxSourceConnections)
+	}
+	if cfg.MigrationDefaults.CreateIndexes == nil || *cfg.MigrationDefaults.CreateIndexes {
+		t.Errorf("create_indexes = %v, want explicit false", cfg.MigrationDefaults.CreateIndexes)
+	}
+
+	out := buf.String()
+	for _, k := range []string{"workers", "max_memory_mb", "history_retention_days", "ai_adjust"} {
+		if !strings.Contains(out, k) {
+			t.Errorf("warning should name removed key %q; got:\n%s", k, out)
+		}
+	}
+	// Exactly one warning line about migration_defaults.
+	if n := strings.Count(out, "removed migration_defaults keys"); n != 1 {
+		t.Errorf("expected exactly 1 legacy-keys warning, got %d:\n%s", n, out)
+	}
+}
+
+// TestNoLegacyKeysNoWarning: a clean v1 file produces no legacy warning.
+func TestNoLegacyKeysNoWarning(t *testing.T) {
+	tmp := t.TempDir()
+	f := filepath.Join(tmp, "secrets.yaml")
+	content := `
+encryption:
+  master_key: "mk"
+migration_defaults:
+  create_indexes: true
+  max_source_connections: 4
+`
+	if err := os.WriteFile(f, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(SecretsFileEnvVar, f)
+	Reset()
+
+	var buf bytes.Buffer
+	logging.SetOutput(&buf)
+	defer logging.SetOutput(nil)
+
+	if _, err := Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if strings.Contains(buf.String(), "removed migration_defaults keys") {
+		t.Errorf("clean v1 file should not warn:\n%s", buf.String())
+	}
+}
+
+// TestTemplateEmitsOnlyV1MigrationDefaults: the init-secrets template advertises
+// supported keys and none of the removed ones.
+func TestTemplateEmitsOnlyV1MigrationDefaults(t *testing.T) {
+	tpl := GenerateTemplate()
+	for _, k := range []string{"create_indexes", "create_foreign_keys", "create_check_constraints"} {
+		if !strings.Contains(tpl, k) {
+			t.Errorf("template missing supported key %q", k)
+		}
+	}
+	for _, k := range legacyMigrationDefaultKeys {
+		if strings.Contains(tpl, k+":") {
+			t.Errorf("template still emits removed key %q", k)
+		}
+	}
+}

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 
 	"gopkg.in/yaml.v3"
+
+	"smt/internal/logging"
 )
 
 const (
@@ -32,39 +34,35 @@ type Config struct {
 	MigrationDefaults MigrationDefaults   `yaml:"migration_defaults"`
 }
 
-// MigrationDefaults holds global default settings for migrations.
-// These can be overridden in individual migration config files.
+// MigrationDefaults holds global default settings applied to every migration,
+// overridable per-migration in a config.yaml. This is the v1-supported shape:
+// only fields SMT actually consumes survive here. The broad DMT-era
+// data-transfer tuning surface (workers, memory/buffer/reader/writer counts,
+// chunk-checkpoint, table-retry, row-sample validation, AI runtime adjustment)
+// was removed in v1 — SMT runs DDL, not row transfer. Legacy keys still present
+// in a secrets file are warned about once and ignored (see legacyMigrationDefaultKeys).
 type MigrationDefaults struct {
-	// Performance settings (machine-dependent)
-	Workers              int   `yaml:"workers,omitempty"`                // Number of parallel workers (default: auto based on CPU)
-	MaxSourceConnections int   `yaml:"max_source_connections,omitempty"` // Max source DB connections
-	MaxTargetConnections int   `yaml:"max_target_connections,omitempty"` // Max target DB connections
-	MaxMemoryMB          int64 `yaml:"max_memory_mb,omitempty"`          // Max memory usage in MB
-	ReadAheadBuffers     int   `yaml:"read_ahead_buffers,omitempty"`     // Chunks to buffer ahead
-	WriteAheadWriters    int   `yaml:"write_ahead_writers,omitempty"`    // Parallel writers per job
-	ParallelReaders      int   `yaml:"parallel_readers,omitempty"`       // Parallel readers per job
+	// Connection pool sizing (applied to the schema source/target pools).
+	MaxSourceConnections int `yaml:"max_source_connections,omitempty"` // Max source DB connections
+	MaxTargetConnections int `yaml:"max_target_connections,omitempty"` // Max target DB connections
 
-	// Schema creation defaults (use *bool to distinguish "not set" from "false")
+	// Schema-object defaults (use *bool to distinguish "not set" from "false").
 	CreateIndexes          *bool `yaml:"create_indexes,omitempty"`           // Create non-PK indexes (default: true)
 	CreateForeignKeys      *bool `yaml:"create_foreign_keys,omitempty"`      // Create FK constraints (default: true)
 	CreateCheckConstraints *bool `yaml:"create_check_constraints,omitempty"` // Create CHECK constraints (default: false)
 
-	// Consistency and validation
-	StrictConsistency *bool `yaml:"strict_consistency,omitempty"` // Use table locks instead of NOLOCK
-	SampleValidation  *bool `yaml:"sample_validation,omitempty"`  // Enable sample data validation
-	SampleSize        int   `yaml:"sample_size,omitempty"`        // Rows to sample for validation
+	// Directory for the SMT state DB, snapshots, and run artifacts.
+	DataDir string `yaml:"data_dir,omitempty"`
+}
 
-	// Checkpoint and recovery
-	CheckpointFrequency  int `yaml:"checkpoint_frequency,omitempty"`   // Save progress every N chunks
-	MaxRetries           int `yaml:"max_retries,omitempty"`            // Retry failed tables N times
-	HistoryRetentionDays int `yaml:"history_retention_days,omitempty"` // Keep run history for N days
-
-	// AI features (enabled by default when AI provider is configured)
-	AIAdjust         *bool  `yaml:"ai_adjust,omitempty"`          // Enable AI-driven parameter adjustment (default: true)
-	AIAdjustInterval string `yaml:"ai_adjust_interval,omitempty"` // How often AI evaluates metrics (default: 30s)
-
-	// Data directory
-	DataDir string `yaml:"data_dir,omitempty"` // Directory for state/checkpoint files
+// legacyMigrationDefaultKeys are migration_defaults keys SMT no longer honors
+// (DMT-era data-transfer tuning, removed for v1). They are warned about once on
+// load and otherwise ignored — see warnLegacyMigrationDefaults.
+var legacyMigrationDefaultKeys = []string{
+	"workers", "max_memory_mb", "read_ahead_buffers", "write_ahead_writers",
+	"parallel_readers", "strict_consistency", "sample_validation", "sample_size",
+	"checkpoint_frequency", "max_retries", "history_retention_days",
+	"ai_adjust", "ai_adjust_interval",
 }
 
 // AIConfig holds AI provider configuration
@@ -259,12 +257,37 @@ func loadFromFile() (*Config, error) {
 		return nil, fmt.Errorf("parsing secrets file: %w", err)
 	}
 
+	// Warn (once) about removed DMT-era migration_defaults keys still present in
+	// the file. They are ignored, not fatal — keep old secrets files loadable.
+	warnLegacyMigrationDefaults(data)
+
 	// Validate configuration
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
 
 	return &config, nil
+}
+
+// warnLegacyMigrationDefaults emits a single warning naming any removed
+// migration_defaults keys present in the raw secrets YAML.
+func warnLegacyMigrationDefaults(data []byte) {
+	var raw struct {
+		MigrationDefaults map[string]any `yaml:"migration_defaults"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil || len(raw.MigrationDefaults) == 0 {
+		return
+	}
+	var found []string
+	for _, key := range legacyMigrationDefaultKeys {
+		if _, ok := raw.MigrationDefaults[key]; ok {
+			found = append(found, key)
+		}
+	}
+	if len(found) > 0 {
+		logging.Warn("secrets: ignoring removed migration_defaults keys (DMT-era, dropped in v1): %s",
+			strings.Join(found, ", "))
+	}
 }
 
 // Save writes the config to the secrets file, preserving existing fields.
@@ -329,44 +352,14 @@ func mergeAIConfig(existing, updates *AIConfig) {
 
 // mergeMigrationDefaults merges non-zero migration defaults.
 func mergeMigrationDefaults(existing, updates *MigrationDefaults) {
-	if updates.Workers > 0 {
-		existing.Workers = updates.Workers
-	}
 	if updates.MaxSourceConnections > 0 {
 		existing.MaxSourceConnections = updates.MaxSourceConnections
 	}
 	if updates.MaxTargetConnections > 0 {
 		existing.MaxTargetConnections = updates.MaxTargetConnections
 	}
-	if updates.MaxMemoryMB > 0 {
-		existing.MaxMemoryMB = updates.MaxMemoryMB
-	}
-	if updates.ReadAheadBuffers > 0 {
-		existing.ReadAheadBuffers = updates.ReadAheadBuffers
-	}
-	if updates.WriteAheadWriters > 0 {
-		existing.WriteAheadWriters = updates.WriteAheadWriters
-	}
-	if updates.ParallelReaders > 0 {
-		existing.ParallelReaders = updates.ParallelReaders
-	}
-	if updates.CheckpointFrequency > 0 {
-		existing.CheckpointFrequency = updates.CheckpointFrequency
-	}
-	if updates.MaxRetries > 0 {
-		existing.MaxRetries = updates.MaxRetries
-	}
-	if updates.SampleSize > 0 {
-		existing.SampleSize = updates.SampleSize
-	}
-	if updates.HistoryRetentionDays > 0 {
-		existing.HistoryRetentionDays = updates.HistoryRetentionDays
-	}
 	if updates.DataDir != "" {
 		existing.DataDir = updates.DataDir
-	}
-	if updates.AIAdjustInterval != "" {
-		existing.AIAdjustInterval = updates.AIAdjustInterval
 	}
 	// Boolean pointers - only update if explicitly set
 	if updates.CreateIndexes != nil {
@@ -377,15 +370,6 @@ func mergeMigrationDefaults(existing, updates *MigrationDefaults) {
 	}
 	if updates.CreateCheckConstraints != nil {
 		existing.CreateCheckConstraints = updates.CreateCheckConstraints
-	}
-	if updates.StrictConsistency != nil {
-		existing.StrictConsistency = updates.StrictConsistency
-	}
-	if updates.SampleValidation != nil {
-		existing.SampleValidation = updates.SampleValidation
-	}
-	if updates.AIAdjust != nil {
-		existing.AIAdjust = updates.AIAdjust
 	}
 }
 
@@ -471,25 +455,9 @@ func (c *Config) GetMasterKey() string {
 	return c.Encryption.MasterKey
 }
 
-// GetMigrationDefaults returns the global migration defaults with smart defaults applied.
-// AI adjust is enabled by default when an AI provider is configured.
+// GetMigrationDefaults returns the global migration defaults.
 func (c *Config) GetMigrationDefaults() *MigrationDefaults {
 	defaults := c.MigrationDefaults
-
-	// Apply smart defaults for AI adjust:
-	// If ai_adjust wasn't explicitly set (nil pointer),
-	// enable it by default when an AI provider is configured
-	if defaults.AIAdjust == nil && defaults.AIAdjustInterval == "" {
-		// Neither ai_adjust nor ai_adjust_interval was set - apply default
-		if provider, _, err := c.GetDefaultProvider(); err == nil && provider != nil {
-			if provider.APIKey != "" || provider.BaseURL != "" {
-				aiAdjust := true
-				defaults.AIAdjust = &aiAdjust
-				defaults.AIAdjustInterval = "30s"
-			}
-		}
-	}
-
 	return &defaults
 }
 
@@ -646,12 +614,14 @@ notifications:
 
 # Global migration defaults (can be overridden per-migration)
 migration_defaults:
-  # Schema creation defaults
+  # Schema-object defaults
   create_indexes: true            # Create non-PK indexes
   create_foreign_keys: true       # Create FK constraints
   create_check_constraints: false # Create CHECK constraints
 
-  # History
-  history_retention_days: 30      # Keep run history for N days
+  # Optional: connection pool sizing and state/artifact directory
+  # max_source_connections: 4
+  # max_target_connections: 4
+  # data_dir: ~/.smt
 `
 }


### PR DESCRIPTION
Closes #156. Part of #144 (v1 readiness).

Freezes the v1-supported `migration_defaults` shape in
`~/.secrets/smt-config.yaml` before the secrets-file contract is locked, by
dropping the broad DMT-era data-transfer tuning surface SMT (a schema tool)
never consumed.

## Classification (by real SMT consumers)

I grepped every field for a consumer in the executable path (excluding
config/secrets/tests):

**Kept — actively used:**
| field | consumer |
|---|---|
| `max_source_connections` / `max_target_connections` | `orchestrator.go` pool sizing |
| `create_indexes` / `create_foreign_keys` / `create_check_constraints` | phase gating (`ddl_plan.go`, `manifest.go`) + `sync`/`drift` compare |
| `data_dir` | state DB / snapshots / run artifacts |

**Removed — zero SMT consumers (DMT transfer-era):**
`workers`, `max_memory_mb`, `read_ahead_buffers`, `write_ahead_writers`,
`parallel_readers`, `strict_consistency`, `sample_validation`, `sample_size`,
`checkpoint_frequency`, `max_retries`, `history_retention_days`, and
`ai_adjust` / `ai_adjust_interval` (the AI runtime tuner already removed in
#42/#43).

## Behavior

- Removed the struct fields plus the `applyGlobalDefaults` / `mergeMigrationDefaults`
  blocks that copied them; dropped the AI-adjust smart-default in
  `GetMigrationDefaults`.
- **Warn-and-ignore** (chosen over hard-fail for compat): an existing secrets
  file that still lists a removed key loads fine — a single warning names the
  dropped keys.
- `smt init-secrets` emits only the v1 shape.

## Scope note

This is the **secrets-file** contract only. The per-migration `MigrationConfig`
(in `config.yaml`) and its auto-tuning still define the old fields — that's a
separate, larger surface (lots of auto-tune tests) and a different contract, so
it's intentionally out of scope here.

## Test plan

- `internal/secrets/migration_defaults_test.go`: reflection test pins the exact
  v1 field set (drift fails the build); warn-and-ignore on a file with legacy
  keys (loads, supported fields applied, single warning naming dropped keys);
  no-warning on a clean v1 file; template emits supported-only.
- Verified the `init-secrets` template output and the warn path end-to-end.
- `gofmt`, `go vet ./...`, `go test ./... -short` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)