### PR TITLE
Remove dead DMT-era state-DB tables and checkpoint APIs — closes #158

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
+- **Dead DMT-era state-DB tables and checkpoint APIs** ([#158]). The SQLite
+  state DB no longer creates the `tasks`, `task_outputs`, `transfer_progress`,
+  or `table_sync_timestamps` tables — they backed DMT's row-transfer pipeline
+  (parallel workers, chunk-level resume, date-based incremental sync) and were
+  never written by SMT, which runs DDL. The corresponding `StateBackend` /
+  `State` / `FileState` methods (task tracking, transfer progress, run-resume,
+  sync watermarks) and the `Task` / `TransferProgress` / `TaskWithProgress`
+  types are removed. `smt history <run>` is unchanged (its task section was
+  always empty). Forward-compat: existing `~/.smt` state DBs keep the orphan
+  tables as harmless empties — there is no DROP migration, and a pre-existing DB
+  opens and works unchanged.
 - **DMT-era `migration_defaults` keys dropped from the secrets file** ([#156]).
   The global `migration_defaults` block in `~/.secrets/smt-config.yaml` no longer
   carries data-transfer tuning that SMT (a schema tool) never consumed:
@@ -120,6 +131,7 @@ history since v0.9.0:
 [#133]: https://github.com/johndauphine/smt/pull/133
 [#134]: https://github.com/johndauphine/smt/issues/134
 [#156]: https://github.com/johndauphine/smt/issues/156
+[#158]: https://github.com/johndauphine/smt/issues/158
 [#46]: https://github.com/johndauphine/smt/issues/46
 [#57]: https://github.com/johndauphine/smt/issues/57
 [#58]: https://github.com/johndauphine/smt/issues/58

--- a/internal/checkpoint/backend.go
+++ b/internal/checkpoint/backend.go
@@ -1,9 +1,5 @@
 package checkpoint
 
-import (
-	"time"
-)
-
 // Run kinds distinguish runs that executed DDL against a target from
 // generate-only previews in history and notifications (#90).
 const (
@@ -12,45 +8,27 @@ const (
 )
 
 // StateBackend defines the interface for state persistence.
-// Implementations include SQLite (full featured) and file-based (minimal, for Airflow).
+// Implementations: SQLite (full-featured, with history) and file-based (minimal,
+// for Airflow / headless runs).
+//
+// SMT records each schema run for history; it does not move rows, so the DMT-era
+// task/transfer-progress/resume surface was removed in v1 (#158).
 type StateBackend interface {
 	// Run management
 	CreateRun(id, kind, sourceSchema, targetSchema string, config any, profileName, configPath string) error
-	UpdateRunConfig(id string, config any) error // Persist post-AI-tuning config snapshot
 	CompleteRun(id string, status string, errorMsg string) error
-	GetLastIncompleteRun() (*Run, error)
-	HasSuccessfulRunAfter(run *Run) (bool, error) // Check if a successful run supersedes this incomplete run
-	MarkRunAsResumed(runID string) error
 	UpdatePhase(runID, phase string) error
 
-	// Task management
-	CreateTask(runID, taskType, taskKey string) (int64, error)
-	UpdateTaskStatus(taskID int64, status string, errorMsg string) error
-	MarkTaskComplete(runID, taskKey string) error
-	GetCompletedTables(runID string) (map[string]bool, error)
-	GetRunStats(runID string) (total, pending, running, success, failed int, err error)
-	GetTasksWithProgress(runID string) ([]TaskWithProgress, error)
-
-	// Progress tracking (for chunk-level resume)
-	SaveTransferProgress(taskID int64, tableName string, partitionID *int, lastPK any, rowsDone, rowsTotal int64) error
-	GetTransferProgress(taskID int64) (*TransferProgress, error)
-	ClearTransferProgress(taskID int64) error                     // Clear progress for fresh re-transfer
-	CountPartitionTasks(runID, taskKeyPrefix string) (int, error) // Count partition tasks for a table
-
-	// History (optional - file backend may return empty)
+	// History (optional - file backend may return just the current run)
 	GetAllRuns() ([]Run, error)
 	GetRunByID(runID string) (*Run, error)
-
-	// Date-based incremental sync (optional - file backend returns nil/no-op)
-	GetLastSyncTimestamp(sourceSchema, tableName, targetSchema string) (*time.Time, error)
-	UpdateSyncTimestamp(sourceSchema, tableName, targetSchema string, ts time.Time) error
 
 	// Lifecycle
 	Close() error
 }
 
 // HistoryBackend extends StateBackend with profile management.
-// Only SQLite implements this; file backend does not support profiles.
+// Only SQLite implements this; the file backend does not support profiles.
 type HistoryBackend interface {
 	StateBackend
 

--- a/internal/checkpoint/filestate.go
+++ b/internal/checkpoint/filestate.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -23,38 +22,25 @@ type FileState struct {
 
 // fileStateData is the YAML structure for the state file.
 type fileStateData struct {
-	RunID        string                `yaml:"run_id"`
-	StartedAt    time.Time             `yaml:"started_at"`
-	CompletedAt  *time.Time            `yaml:"completed_at,omitempty"`
-	Status       string                `yaml:"status"` // running, success, failed
-	Phase        string                `yaml:"phase"`  // initializing, transferring, finalizing, validating, complete
-	Error        string                `yaml:"error,omitempty"`
-	SourceSchema string                `yaml:"source_schema"`
-	TargetSchema string                `yaml:"target_schema"`
-	ConfigHash   string                `yaml:"config_hash,omitempty"`
-	ProfileName  string                `yaml:"profile_name,omitempty"`
-	ConfigPath   string                `yaml:"config_path,omitempty"`
-	Tables       map[string]tableState `yaml:"tables"`
-}
-
-// tableState tracks per-table progress.
-type tableState struct {
-	Status    string `yaml:"status"` // pending, running, success, failed
-	LastPK    any    `yaml:"last_pk,omitempty"`
-	RowsDone  int64  `yaml:"rows_done,omitempty"`
-	RowsTotal int64  `yaml:"rows_total,omitempty"`
-	TaskID    int64  `yaml:"task_id,omitempty"` // Synthetic task ID for compatibility
-	Error     string `yaml:"error,omitempty"`
+	RunID        string     `yaml:"run_id"`
+	StartedAt    time.Time  `yaml:"started_at"`
+	CompletedAt  *time.Time `yaml:"completed_at,omitempty"`
+	Status       string     `yaml:"status"` // running, success, failed
+	Phase        string     `yaml:"phase"`  // initializing, finalizing, complete
+	Error        string     `yaml:"error,omitempty"`
+	SourceSchema string     `yaml:"source_schema"`
+	TargetSchema string     `yaml:"target_schema"`
+	ConfigHash   string     `yaml:"config_hash,omitempty"`
+	ProfileName  string     `yaml:"profile_name,omitempty"`
+	ConfigPath   string     `yaml:"config_path,omitempty"`
 }
 
 // NewFileState creates a file-based state manager.
 // If the file exists, it loads the existing state.
 func NewFileState(path string) (*FileState, error) {
 	fs := &FileState{
-		path: path,
-		state: &fileStateData{
-			Tables: make(map[string]tableState),
-		},
+		path:  path,
+		state: &fileStateData{},
 	}
 
 	// Load existing state if file exists
@@ -65,9 +51,6 @@ func NewFileState(path string) (*FileState, error) {
 		}
 		if err := yaml.Unmarshal(data, fs.state); err != nil {
 			return nil, fmt.Errorf("parsing state file: %w", err)
-		}
-		if fs.state.Tables == nil {
-			fs.state.Tables = make(map[string]tableState)
 		}
 	}
 
@@ -106,15 +89,9 @@ func (fs *FileState) CreateRun(id, kind, sourceSchema, targetSchema string, conf
 		ConfigHash:   hex.EncodeToString(hash[:8]), // First 8 bytes
 		ProfileName:  profileName,
 		ConfigPath:   configPath,
-		Tables:       make(map[string]tableState),
 	}
 
 	return fs.save()
-}
-
-// UpdateRunConfig is a no-op for the file backend (it does not persist the full config).
-func (fs *FileState) UpdateRunConfig(id string, config any) error {
-	return nil
 }
 
 // CompleteRun marks the run as complete.
@@ -134,55 +111,6 @@ func (fs *FileState) CompleteRun(id string, status string, errorMsg string) erro
 	return fs.save()
 }
 
-// GetLastIncompleteRun returns the current run if it's incomplete.
-func (fs *FileState) GetLastIncompleteRun() (*Run, error) {
-	fs.mu.RLock()
-	defer fs.mu.RUnlock()
-
-	if fs.state.RunID == "" || fs.state.Status != "running" {
-		return nil, nil
-	}
-
-	phase := fs.state.Phase
-	if phase == "" {
-		phase = "initializing"
-	}
-	return &Run{
-		ID:           fs.state.RunID,
-		StartedAt:    fs.state.StartedAt,
-		Status:       fs.state.Status,
-		Phase:        phase,
-		SourceSchema: fs.state.SourceSchema,
-		TargetSchema: fs.state.TargetSchema,
-		ConfigHash:   fs.state.ConfigHash,
-		ProfileName:  fs.state.ProfileName,
-		ConfigPath:   fs.state.ConfigPath,
-	}, nil
-}
-
-// HasSuccessfulRunAfter checks if there's a successful run that supersedes the given incomplete run.
-// For file state, this always returns false - we only track one run at a time,
-// so if there's an incomplete run, it's the only run we know about.
-func (fs *FileState) HasSuccessfulRunAfter(run *Run) (bool, error) {
-	// File state only tracks one run - if it's incomplete, there's no later successful run
-	return false, nil
-}
-
-// MarkRunAsResumed resets running tasks to pending.
-func (fs *FileState) MarkRunAsResumed(runID string) error {
-	fs.mu.Lock()
-	defer fs.mu.Unlock()
-
-	for key, ts := range fs.state.Tables {
-		if ts.Status == "running" {
-			ts.Status = "pending"
-			fs.state.Tables[key] = ts
-		}
-	}
-
-	return fs.save()
-}
-
 // UpdatePhase updates the current phase of a migration run.
 func (fs *FileState) UpdatePhase(runID, phase string) error {
 	fs.mu.Lock()
@@ -195,225 +123,15 @@ func (fs *FileState) UpdatePhase(runID, phase string) error {
 	return nil
 }
 
-// taskIDCounter generates synthetic task IDs for file-based state.
-var taskIDCounter int64 = 1000
-
-// CreateTask creates or returns an existing task.
-func (fs *FileState) CreateTask(runID, taskType, taskKey string) (int64, error) {
-	fs.mu.Lock()
-	defer fs.mu.Unlock()
-
-	// Check if task exists
-	if ts, ok := fs.state.Tables[taskKey]; ok {
-		return ts.TaskID, nil
-	}
-
-	// Create new task
-	taskIDCounter++
-	fs.state.Tables[taskKey] = tableState{
-		Status: "pending",
-		TaskID: taskIDCounter,
-	}
-
-	if err := fs.save(); err != nil {
-		return 0, err
-	}
-	return taskIDCounter, nil
-}
-
-// UpdateTaskStatus updates a task's status.
-func (fs *FileState) UpdateTaskStatus(taskID int64, status string, errorMsg string) error {
-	fs.mu.Lock()
-	defer fs.mu.Unlock()
-
-	for key, ts := range fs.state.Tables {
-		if ts.TaskID == taskID {
-			ts.Status = status
-			ts.Error = errorMsg
-			fs.state.Tables[key] = ts
-			return fs.save()
-		}
-	}
-
-	return fmt.Errorf("task not found: %d", taskID)
-}
-
-// MarkTaskComplete marks a task as complete by run_id and task_key.
-func (fs *FileState) MarkTaskComplete(runID, taskKey string) error {
-	fs.mu.Lock()
-	defer fs.mu.Unlock()
-
-	if ts, ok := fs.state.Tables[taskKey]; ok {
-		ts.Status = "success"
-		fs.state.Tables[taskKey] = ts
-	} else {
-		// Create if not exists
-		taskIDCounter++
-		fs.state.Tables[taskKey] = tableState{
-			Status: "success",
-			TaskID: taskIDCounter,
-		}
-	}
-
-	return fs.save()
-}
-
-// GetCompletedTables returns table names that completed successfully.
-func (fs *FileState) GetCompletedTables(runID string) (map[string]bool, error) {
-	fs.mu.RLock()
-	defer fs.mu.RUnlock()
-
-	completed := make(map[string]bool)
-	for key, ts := range fs.state.Tables {
-		if ts.Status == "success" {
-			completed[key] = true
-		}
-	}
-	return completed, nil
-}
-
-// GetRunStats returns summary stats for the run.
-func (fs *FileState) GetRunStats(runID string) (total, pending, running, success, failed int, err error) {
-	fs.mu.RLock()
-	defer fs.mu.RUnlock()
-
-	for _, ts := range fs.state.Tables {
-		total++
-		switch ts.Status {
-		case "pending":
-			pending++
-		case "running":
-			running++
-		case "success":
-			success++
-		case "failed":
-			failed++
-		}
-	}
-	return
-}
-
-// SaveTransferProgress saves chunk-level progress.
-func (fs *FileState) SaveTransferProgress(taskID int64, tableName string, partitionID *int, lastPK any, rowsDone, rowsTotal int64) error {
-	fs.mu.Lock()
-	defer fs.mu.Unlock()
-
-	// Find task by ID and update progress
-	for key, ts := range fs.state.Tables {
-		if ts.TaskID == taskID {
-			ts.LastPK = lastPK
-			ts.RowsDone = rowsDone
-			ts.RowsTotal = rowsTotal
-			ts.Status = "running"
-			fs.state.Tables[key] = ts
-			return fs.save()
-		}
-	}
-
-	return nil // Silently ignore if task not found
-}
-
-// GetTransferProgress returns progress for a task.
-func (fs *FileState) GetTransferProgress(taskID int64) (*TransferProgress, error) {
-	fs.mu.RLock()
-	defer fs.mu.RUnlock()
-
-	for tableName, ts := range fs.state.Tables {
-		if ts.TaskID == taskID && ts.LastPK != nil {
-			return &TransferProgress{
-				TaskID:    taskID,
-				TableName: tableName,
-				LastPK:    fmt.Sprintf("%v", ts.LastPK), // Convert to string for compatibility
-				RowsDone:  ts.RowsDone,
-				RowsTotal: ts.RowsTotal,
-			}, nil
-		}
-	}
-
-	return nil, nil
-}
-
-// ClearTransferProgress removes saved progress for a task (for fresh re-transfer).
-func (fs *FileState) ClearTransferProgress(taskID int64) error {
-	fs.mu.Lock()
-	defer fs.mu.Unlock()
-
-	for key, ts := range fs.state.Tables {
-		if ts.TaskID == taskID {
-			ts.LastPK = nil
-			ts.RowsDone = 0
-			ts.RowsTotal = 0
-			ts.Status = "pending"
-			fs.state.Tables[key] = ts
-			return fs.save()
-		}
-	}
-
-	return nil
-}
-
-// CountPartitionTasks counts partition tasks for a table by scanning stored task keys.
-func (fs *FileState) CountPartitionTasks(runID, taskKeyPrefix string) (int, error) {
-	fs.mu.RLock()
-	defer fs.mu.RUnlock()
-
-	prefix := taskKeyPrefix + ":p"
-	count := 0
-	for key := range fs.state.Tables {
-		if strings.HasPrefix(key, prefix) {
-			count++
-		}
-	}
-	return count, nil
-}
-
-// GetAllRuns returns empty slice (file state doesn't track history).
+// GetAllRuns returns the current run only (file state doesn't track history).
 func (fs *FileState) GetAllRuns() ([]Run, error) {
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()
 
-	// Return current run only if it exists
 	if fs.state.RunID != "" {
-		return []Run{
-			{
-				ID:           fs.state.RunID,
-				StartedAt:    fs.state.StartedAt,
-				CompletedAt:  fs.state.CompletedAt,
-				Status:       fs.state.Status,
-				Error:        fs.state.Error,
-				SourceSchema: fs.state.SourceSchema,
-				TargetSchema: fs.state.TargetSchema,
-				ProfileName:  fs.state.ProfileName,
-				ConfigPath:   fs.state.ConfigPath,
-			},
-		}, nil
+		return []Run{fs.currentRun()}, nil
 	}
 	return nil, nil
-}
-
-// GetTasksWithProgress returns all tasks for a run with transfer progress info.
-func (fs *FileState) GetTasksWithProgress(runID string) ([]TaskWithProgress, error) {
-	fs.mu.RLock()
-	defer fs.mu.RUnlock()
-
-	if fs.state.RunID != runID {
-		return nil, nil
-	}
-
-	var tasks []TaskWithProgress
-	for key, ts := range fs.state.Tables {
-		tasks = append(tasks, TaskWithProgress{
-			ID:           ts.TaskID,
-			RunID:        runID,
-			TaskType:     "transfer",
-			TaskKey:      key,
-			Status:       ts.Status,
-			ErrorMessage: ts.Error,
-			RowsDone:     ts.RowsDone,
-			RowsTotal:    ts.RowsTotal,
-		})
-	}
-	return tasks, nil
 }
 
 // GetRunByID returns the run if it matches.
@@ -422,31 +140,27 @@ func (fs *FileState) GetRunByID(runID string) (*Run, error) {
 	defer fs.mu.RUnlock()
 
 	if fs.state.RunID == runID {
-		return &Run{
-			ID:           fs.state.RunID,
-			StartedAt:    fs.state.StartedAt,
-			CompletedAt:  fs.state.CompletedAt,
-			Status:       fs.state.Status,
-			Error:        fs.state.Error,
-			SourceSchema: fs.state.SourceSchema,
-			TargetSchema: fs.state.TargetSchema,
-			ProfileName:  fs.state.ProfileName,
-			ConfigPath:   fs.state.ConfigPath,
-		}, nil
+		r := fs.currentRun()
+		return &r, nil
 	}
-
 	return nil, nil
 }
 
-// GetLastSyncTimestamp is a no-op for file state (doesn't persist sync timestamps).
-// Date-based incremental sync falls back to full sync when using file state backend.
-func (fs *FileState) GetLastSyncTimestamp(sourceSchema, tableName, targetSchema string) (*time.Time, error) {
-	return nil, nil
-}
-
-// UpdateSyncTimestamp is a no-op for file state.
-func (fs *FileState) UpdateSyncTimestamp(sourceSchema, tableName, targetSchema string, ts time.Time) error {
-	return nil
+// currentRun builds a Run from the in-memory state. Caller holds the lock.
+func (fs *FileState) currentRun() Run {
+	return Run{
+		ID:           fs.state.RunID,
+		StartedAt:    fs.state.StartedAt,
+		CompletedAt:  fs.state.CompletedAt,
+		Status:       fs.state.Status,
+		Phase:        fs.state.Phase,
+		Error:        fs.state.Error,
+		SourceSchema: fs.state.SourceSchema,
+		TargetSchema: fs.state.TargetSchema,
+		ConfigHash:   fs.state.ConfigHash,
+		ProfileName:  fs.state.ProfileName,
+		ConfigPath:   fs.state.ConfigPath,
+	}
 }
 
 // Close is a no-op for file state.

--- a/internal/checkpoint/filestate_test.go
+++ b/internal/checkpoint/filestate_test.go
@@ -6,303 +6,76 @@ import (
 	"testing"
 )
 
-func TestFileState_CreateAndResumeRun(t *testing.T) {
-	// Create temp file
-	tmpDir := t.TempDir()
-	stateFile := filepath.Join(tmpDir, "state.yaml")
+func TestFileState_CreateCompleteAndRead(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state.yaml")
 
-	// Create file state
 	fs, err := NewFileState(stateFile)
 	if err != nil {
 		t.Fatalf("NewFileState: %v", err)
 	}
 
-	// Create a run
-	err = fs.CreateRun("test123", RunKindApply, "dbo", "public", map[string]string{"key": "value"}, "myprofile", "")
-	if err != nil {
+	if err := fs.CreateRun("test123", RunKindApply, "dbo", "public", map[string]string{"key": "value"}, "myprofile", "/cfg"); err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
-
-	// Check state file exists
 	if _, err := os.Stat(stateFile); os.IsNotExist(err) {
 		t.Fatal("state file not created")
 	}
 
-	// Read file contents
-	data, _ := os.ReadFile(stateFile)
-	t.Logf("State file contents:\n%s", string(data))
-
-	// Get last incomplete run
-	run, err := fs.GetLastIncompleteRun()
-	if err != nil {
-		t.Fatalf("GetLastIncompleteRun: %v", err)
+	r, err := fs.GetRunByID("test123")
+	if err != nil || r == nil {
+		t.Fatalf("GetRunByID: %v %v", r, err)
 	}
-	if run == nil {
-		t.Fatal("expected incomplete run")
-	}
-	if run.ID != "test123" {
-		t.Errorf("run ID = %q, want %q", run.ID, "test123")
-	}
-	if run.Status != "running" {
-		t.Errorf("run status = %q, want %q", run.Status, "running")
+	if r.Status != "running" || r.ProfileName != "myprofile" {
+		t.Errorf("unexpected run: status=%q profile=%q", r.Status, r.ProfileName)
 	}
 
-	// Create task
-	taskID, err := fs.CreateTask("test123", "transfer", "transfer:dbo.Users")
-	if err != nil {
-		t.Fatalf("CreateTask: %v", err)
+	if err := fs.UpdatePhase("test123", "finalizing"); err != nil {
+		t.Fatalf("UpdatePhase: %v", err)
 	}
-	if taskID == 0 {
-		t.Error("expected non-zero task ID")
-	}
-
-	// Save progress
-	err = fs.SaveTransferProgress(taskID, "Users", nil, 12345, 50000, 100000)
-	if err != nil {
-		t.Fatalf("SaveTransferProgress: %v", err)
-	}
-
-	// Read progress
-	prog, err := fs.GetTransferProgress(taskID)
-	if err != nil {
-		t.Fatalf("GetTransferProgress: %v", err)
-	}
-	if prog == nil {
-		t.Fatal("expected progress")
-	}
-	if prog.RowsDone != 50000 {
-		t.Errorf("RowsDone = %d, want %d", prog.RowsDone, 50000)
-	}
-
-	// Complete the task
-	err = fs.MarkTaskComplete("test123", "transfer:dbo.Users")
-	if err != nil {
-		t.Fatalf("MarkTaskComplete: %v", err)
-	}
-
-	// Check completed tables
-	completed, err := fs.GetCompletedTables("test123")
-	if err != nil {
-		t.Fatalf("GetCompletedTables: %v", err)
-	}
-	if !completed["transfer:dbo.Users"] {
-		t.Error("expected transfer:dbo.Users to be completed")
-	}
-
-	// Complete the run
-	err = fs.CompleteRun("test123", "success", "")
-	if err != nil {
+	if err := fs.CompleteRun("test123", "success", ""); err != nil {
 		t.Fatalf("CompleteRun: %v", err)
 	}
 
-	// Verify no incomplete run
-	run, err = fs.GetLastIncompleteRun()
+	runs, err := fs.GetAllRuns()
 	if err != nil {
-		t.Fatalf("GetLastIncompleteRun after complete: %v", err)
+		t.Fatalf("GetAllRuns: %v", err)
 	}
-	if run != nil {
-		t.Error("expected no incomplete run after completion")
-	}
-
-	// Read final file contents
-	data, _ = os.ReadFile(stateFile)
-	t.Logf("Final state file:\n%s", string(data))
-}
-
-func TestFileState_ClearTransferProgress(t *testing.T) {
-	tmpDir := t.TempDir()
-	stateFile := filepath.Join(tmpDir, "state.yaml")
-
-	// Create file state
-	fs, err := NewFileState(stateFile)
-	if err != nil {
-		t.Fatalf("NewFileState: %v", err)
-	}
-
-	// Create a run and task
-	err = fs.CreateRun("test456", RunKindApply, "dbo", "public", nil, "", "")
-	if err != nil {
-		t.Fatalf("CreateRun: %v", err)
-	}
-
-	taskID, err := fs.CreateTask("test456", "transfer", "transfer:dbo.Users")
-	if err != nil {
-		t.Fatalf("CreateTask: %v", err)
-	}
-
-	// Save progress
-	err = fs.SaveTransferProgress(taskID, "Users", nil, 12345, 50000, 100000)
-	if err != nil {
-		t.Fatalf("SaveTransferProgress: %v", err)
-	}
-
-	// Verify progress exists
-	prog, err := fs.GetTransferProgress(taskID)
-	if err != nil {
-		t.Fatalf("GetTransferProgress: %v", err)
-	}
-	if prog == nil {
-		t.Fatal("expected progress before clear")
-	}
-	if prog.RowsDone != 50000 {
-		t.Errorf("RowsDone = %d, want 50000", prog.RowsDone)
-	}
-
-	// Clear progress
-	err = fs.ClearTransferProgress(taskID)
-	if err != nil {
-		t.Fatalf("ClearTransferProgress: %v", err)
-	}
-
-	// Verify progress is cleared
-	prog, err = fs.GetTransferProgress(taskID)
-	if err != nil {
-		t.Fatalf("GetTransferProgress after clear: %v", err)
-	}
-	if prog != nil {
-		t.Errorf("expected no progress after clear, got: %+v", prog)
-	}
-
-	// Verify task status is reset to pending
-	total, pending, _, _, _, err := fs.GetRunStats("test456")
-	if err != nil {
-		t.Fatalf("GetRunStats: %v", err)
-	}
-	if total != 1 {
-		t.Errorf("total = %d, want 1", total)
-	}
-	if pending != 1 {
-		t.Errorf("pending = %d, want 1", pending)
-	}
-}
-
-func TestFileState_ConfigHash(t *testing.T) {
-	tmpDir := t.TempDir()
-	stateFile := filepath.Join(tmpDir, "state.yaml")
-
-	fs, err := NewFileState(stateFile)
-	if err != nil {
-		t.Fatalf("NewFileState: %v", err)
-	}
-
-	// Create a run with config (hash will be computed)
-	config := map[string]interface{}{
-		"source": map[string]string{"host": "localhost"},
-		"target": map[string]string{"host": "postgres"},
-	}
-	err = fs.CreateRun("hash123", RunKindApply, "dbo", "public", config, "", "/path/to/config.yaml")
-	if err != nil {
-		t.Fatalf("CreateRun: %v", err)
-	}
-
-	// Get the run and verify config hash is set
-	run, err := fs.GetLastIncompleteRun()
-	if err != nil {
-		t.Fatalf("GetLastIncompleteRun: %v", err)
-	}
-	if run == nil {
-		t.Fatal("expected incomplete run")
-	}
-	if run.ConfigHash == "" {
-		t.Error("expected config hash to be set")
-	}
-	t.Logf("Config hash: %s", run.ConfigHash)
-
-	// Verify hash is deterministic (same config = same hash)
-	fs2, _ := NewFileState(filepath.Join(tmpDir, "state2.yaml"))
-	fs2.CreateRun("hash456", RunKindApply, "dbo", "public", config, "", "")
-	run2, _ := fs2.GetLastIncompleteRun()
-	if run.ConfigHash != run2.ConfigHash {
-		t.Errorf("config hashes differ for same config: %s != %s", run.ConfigHash, run2.ConfigHash)
-	}
-
-	// Verify different config = different hash
-	config2 := map[string]interface{}{
-		"source": map[string]string{"host": "other-host"},
-		"target": map[string]string{"host": "postgres"},
-	}
-	fs3, _ := NewFileState(filepath.Join(tmpDir, "state3.yaml"))
-	fs3.CreateRun("hash789", RunKindApply, "dbo", "public", config2, "", "")
-	run3, _ := fs3.GetLastIncompleteRun()
-	if run.ConfigHash == run3.ConfigHash {
-		t.Errorf("config hashes should differ for different configs: %s == %s", run.ConfigHash, run3.ConfigHash)
+	if len(runs) != 1 || runs[0].Status != "success" || runs[0].Phase != "finalizing" {
+		t.Fatalf("GetAllRuns = %+v, want one completed run", runs)
 	}
 }
 
 func TestFileState_LoadExisting(t *testing.T) {
-	// Create temp file with existing state
-	tmpDir := t.TempDir()
-	stateFile := filepath.Join(tmpDir, "state.yaml")
+	stateFile := filepath.Join(t.TempDir(), "state.yaml")
 
-	// Write existing state
-	existingState := `run_id: existing123
+	// A pre-existing file, including a legacy `tables:` block that the v1 reader
+	// ignores (forward-compat).
+	existing := `run_id: existing123
 started_at: 2025-12-20T10:00:00Z
 status: running
+phase: finalizing
 source_schema: dbo
 target_schema: public
+profile_name: p
 tables:
   transfer:dbo.Users:
     status: success
     task_id: 1001
-  transfer:dbo.Posts:
-    status: running
-    last_pk: 5000
-    rows_done: 25000
-    rows_total: 50000
-    task_id: 1002
 `
-	if err := os.WriteFile(stateFile, []byte(existingState), 0600); err != nil {
+	if err := os.WriteFile(stateFile, []byte(existing), 0600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	// Load state
 	fs, err := NewFileState(stateFile)
 	if err != nil {
 		t.Fatalf("NewFileState: %v", err)
 	}
 
-	// Check run
-	run, err := fs.GetLastIncompleteRun()
-	if err != nil {
-		t.Fatalf("GetLastIncompleteRun: %v", err)
+	r, err := fs.GetRunByID("existing123")
+	if err != nil || r == nil {
+		t.Fatalf("GetRunByID: %v %v", r, err)
 	}
-	if run == nil {
-		t.Fatal("expected incomplete run")
-	}
-	if run.ID != "existing123" {
-		t.Errorf("run ID = %q, want %q", run.ID, "existing123")
-	}
-
-	// Check completed tables
-	completed, err := fs.GetCompletedTables("existing123")
-	if err != nil {
-		t.Fatalf("GetCompletedTables: %v", err)
-	}
-	if !completed["transfer:dbo.Users"] {
-		t.Error("expected Users to be completed")
-	}
-	if completed["transfer:dbo.Posts"] {
-		t.Error("expected Posts to NOT be completed")
-	}
-
-	// Check run stats
-	total, pending, running, success, failed, err := fs.GetRunStats("existing123")
-	if err != nil {
-		t.Fatalf("GetRunStats: %v", err)
-	}
-	if total != 2 {
-		t.Errorf("total = %d, want 2", total)
-	}
-	if success != 1 {
-		t.Errorf("success = %d, want 1", success)
-	}
-	if running != 1 {
-		t.Errorf("running = %d, want 1", running)
-	}
-	if pending != 0 {
-		t.Errorf("pending = %d, want 0", pending)
-	}
-	if failed != 0 {
-		t.Errorf("failed = %d, want 0", failed)
+	if r.Status != "running" || r.Phase != "finalizing" || r.ProfileName != "p" {
+		t.Errorf("unexpected run: %+v", r)
 	}
 }

--- a/internal/checkpoint/state.go
+++ b/internal/checkpoint/state.go
@@ -21,20 +21,6 @@ type State struct {
 	db *sql.DB
 }
 
-// Task represents a migration task
-type Task struct {
-	ID           int64
-	RunID        string
-	TaskType     string
-	TaskKey      string
-	Status       string
-	StartedAt    *time.Time
-	CompletedAt  *time.Time
-	RetryCount   int
-	MaxRetries   int
-	ErrorMessage string
-}
-
 // Run represents a migration run
 type Run struct {
 	ID           string
@@ -52,32 +38,6 @@ type Run struct {
 	ProfileName string
 	ConfigPath  string
 	Error       string // Error message if status is "failed"
-}
-
-// TransferProgress tracks chunk-level progress
-type TransferProgress struct {
-	TaskID      int64
-	TableName   string
-	PartitionID *int
-	LastPK      string
-	RowsDone    int64
-	RowsTotal   int64
-	UpdatedAt   time.Time
-}
-
-// TaskWithProgress combines task info with transfer progress
-type TaskWithProgress struct {
-	ID           int64
-	RunID        string
-	TaskType     string
-	TaskKey      string
-	Status       string
-	StartedAt    *time.Time
-	CompletedAt  *time.Time
-	RetryCount   int
-	ErrorMessage string
-	RowsDone     int64
-	RowsTotal    int64
 }
 
 // New creates a new state manager
@@ -137,37 +97,6 @@ func (s *State) migrate() error {
 		config_path TEXT
 	);
 
-	CREATE TABLE IF NOT EXISTS tasks (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		run_id TEXT REFERENCES runs(id),
-		task_type TEXT NOT NULL,
-		task_key TEXT NOT NULL,
-		status TEXT NOT NULL DEFAULT 'pending',
-		started_at TEXT,
-		completed_at TEXT,
-		retry_count INTEGER DEFAULT 0,
-		max_retries INTEGER DEFAULT 3,
-		error_message TEXT,
-		UNIQUE(run_id, task_key)
-	);
-
-	CREATE TABLE IF NOT EXISTS task_outputs (
-		task_id INTEGER REFERENCES tasks(id),
-		key TEXT NOT NULL,
-		value TEXT NOT NULL,
-		PRIMARY KEY (task_id, key)
-	);
-
-	CREATE TABLE IF NOT EXISTS transfer_progress (
-		task_id INTEGER PRIMARY KEY REFERENCES tasks(id),
-		table_name TEXT NOT NULL,
-		partition_id INTEGER,
-		last_pk TEXT,
-		rows_done INTEGER DEFAULT 0,
-		rows_total INTEGER,
-		updated_at TEXT
-	);
-
 	CREATE TABLE IF NOT EXISTS profiles (
 		name TEXT PRIMARY KEY,
 		description TEXT,
@@ -175,19 +104,10 @@ func (s *State) migrate() error {
 		created_at TEXT NOT NULL,
 		updated_at TEXT NOT NULL
 	);
-
-	CREATE TABLE IF NOT EXISTS table_sync_timestamps (
-		source_schema TEXT NOT NULL,
-		table_name TEXT NOT NULL,
-		target_schema TEXT NOT NULL,
-		last_sync_timestamp TEXT NOT NULL,
-		updated_at TEXT NOT NULL,
-		PRIMARY KEY (source_schema, table_name, target_schema)
-	);
-
-	CREATE INDEX IF NOT EXISTS idx_tasks_run_status ON tasks(run_id, status);
-	CREATE INDEX IF NOT EXISTS idx_tasks_type ON tasks(task_type);
 	`
+	// Note (#158): the DMT-era tasks / task_outputs / transfer_progress /
+	// table_sync_timestamps tables are no longer created. Pre-existing state DBs
+	// keep them as harmless empties (no DROP migration — forward-compat option a).
 
 	if _, err := s.db.Exec(schema); err != nil {
 		return err
@@ -295,10 +215,8 @@ func (s *State) ensureProfileColumns() error {
 // validTableNames is a whitelist of allowed table names for schema queries.
 // This prevents SQL injection via the table parameter in tableColumns().
 var validTableNames = map[string]bool{
-	"runs":                  true,
-	"tasks":                 true,
-	"profiles":              true,
-	"table_sync_timestamps": true,
+	"runs":     true,
+	"profiles": true,
 }
 
 func (s *State) tableColumns(table string) ([]string, error) {
@@ -416,29 +334,6 @@ func (s *State) CreateRun(id, kind, sourceSchema, targetSchema string, config an
 	return err
 }
 
-// UpdateRunConfig overwrites the persisted config snapshot for a run.
-// Called after AI tuning so history reflects the values actually used.
-// config_hash is intentionally left unchanged — it's computed against the
-// pre-AI config for resume validation against the user's YAML.
-func (s *State) UpdateRunConfig(id string, config any) error {
-	configJSON, err := json.Marshal(config)
-	if err != nil {
-		return fmt.Errorf("marshal run config: %w", err)
-	}
-	result, err := s.db.Exec(`UPDATE runs SET config = ? WHERE id = ?`, string(configJSON), id)
-	if err != nil {
-		return err
-	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if rows == 0 {
-		return fmt.Errorf("update run config: no run with id %q", id)
-	}
-	return nil
-}
-
 // CompleteRun marks a run as complete
 func (s *State) CompleteRun(id string, status string, errorMsg string) error {
 	_, err := s.db.Exec(`
@@ -448,295 +343,10 @@ func (s *State) CompleteRun(id string, status string, errorMsg string) error {
 	return err
 }
 
-// GetLastIncompleteRun returns the most recent incomplete run
-func (s *State) GetLastIncompleteRun() (*Run, error) {
-	var r Run
-	var startedAtStr string
-	var profileName, configPath, phase, configHash sql.NullString
-	err := s.db.QueryRow(`
-		SELECT id, started_at, status, COALESCE(phase, 'initializing'), source_schema, target_schema, profile_name, config_path, config_hash
-		FROM runs WHERE status = 'running'
-		ORDER BY started_at DESC LIMIT 1
-	`).Scan(&r.ID, &startedAtStr, &r.Status, &phase, &r.SourceSchema, &r.TargetSchema, &profileName, &configPath, &configHash)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	// Parse SQLite datetime string
-	r.StartedAt, _ = time.Parse("2006-01-02 15:04:05", startedAtStr)
-	if profileName.Valid {
-		r.ProfileName = profileName.String
-	}
-	if configPath.Valid {
-		r.ConfigPath = configPath.String
-	}
-	if phase.Valid {
-		r.Phase = phase.String
-	}
-	if configHash.Valid {
-		r.ConfigHash = configHash.String
-	}
-	return &r, nil
-}
-
 // UpdatePhase updates the current phase of a migration run
 func (s *State) UpdatePhase(runID, phase string) error {
 	_, err := s.db.Exec(`UPDATE runs SET phase = ? WHERE id = ?`, phase, runID)
 	return err
-}
-
-// SetRunConfigHash sets the config hash for a run (used for resume validation)
-func (s *State) SetRunConfigHash(runID, configHash string) error {
-	_, err := s.db.Exec(`UPDATE runs SET config_hash = ? WHERE id = ?`, configHash, runID)
-	return err
-}
-
-// HasSuccessfulRunAfter checks if there's a successful run that supersedes the given incomplete run.
-// A run is superseded if a later successful run exists with the same source and target schemas.
-func (s *State) HasSuccessfulRunAfter(run *Run) (bool, error) {
-	if run == nil {
-		return false, nil
-	}
-
-	var count int
-	err := s.db.QueryRow(`
-		SELECT COUNT(*) FROM runs
-		WHERE status = 'success'
-		AND source_schema = ?
-		AND target_schema = ?
-		AND started_at > ?
-	`, run.SourceSchema, run.TargetSchema, run.StartedAt.Format("2006-01-02 15:04:05")).Scan(&count)
-	if err != nil {
-		return false, err
-	}
-	return count > 0, nil
-}
-
-// CreateTask creates a new task or returns existing task ID
-func (s *State) CreateTask(runID, taskType, taskKey string) (int64, error) {
-	// Try to insert new task
-	result, err := s.db.Exec(`
-		INSERT INTO tasks (run_id, task_type, task_key, status)
-		VALUES (?, ?, ?, 'pending')
-		ON CONFLICT(run_id, task_key) DO NOTHING
-	`, runID, taskType, taskKey)
-	if err != nil {
-		return 0, err
-	}
-
-	// Check if we inserted a new row
-	rowsAffected, _ := result.RowsAffected()
-	if rowsAffected > 0 {
-		return result.LastInsertId()
-	}
-
-	// Task already exists - get its ID
-	var taskID int64
-	err = s.db.QueryRow(`
-		SELECT id FROM tasks WHERE run_id = ? AND task_key = ?
-	`, runID, taskKey).Scan(&taskID)
-	return taskID, err
-}
-
-// UpdateTaskStatus updates a task's status
-func (s *State) UpdateTaskStatus(taskID int64, status string, errorMsg string) error {
-	if status == "running" {
-		_, err := s.db.Exec(`
-			UPDATE tasks SET status = ?, started_at = datetime('now')
-			WHERE id = ?
-		`, status, taskID)
-		return err
-	}
-
-	_, err := s.db.Exec(`
-		UPDATE tasks SET status = ?, completed_at = datetime('now'), error_message = ?
-		WHERE id = ?
-	`, status, errorMsg, taskID)
-	return err
-}
-
-// IncrementRetry increments retry count and resets to pending
-func (s *State) IncrementRetry(taskID int64, errorMsg string) error {
-	_, err := s.db.Exec(`
-		UPDATE tasks SET status = 'pending', retry_count = retry_count + 1, error_message = ?
-		WHERE id = ?
-	`, errorMsg, taskID)
-	return err
-}
-
-// GetPendingTasks returns all pending tasks for a run
-func (s *State) GetPendingTasks(runID string) ([]Task, error) {
-	rows, err := s.db.Query(`
-		SELECT id, run_id, task_type, task_key, status, retry_count, max_retries
-		FROM tasks WHERE run_id = ? AND status = 'pending'
-	`, runID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var tasks []Task
-	for rows.Next() {
-		var t Task
-		if err := rows.Scan(&t.ID, &t.RunID, &t.TaskType, &t.TaskKey, &t.Status, &t.RetryCount, &t.MaxRetries); err != nil {
-			return nil, err
-		}
-		tasks = append(tasks, t)
-	}
-	return tasks, nil
-}
-
-// AllTasksComplete returns true if all tasks of a type are complete
-func (s *State) AllTasksComplete(runID, taskType string) (bool, error) {
-	var count int
-	err := s.db.QueryRow(`
-		SELECT COUNT(*) FROM tasks
-		WHERE run_id = ? AND task_type = ? AND status != 'success'
-	`, runID, taskType).Scan(&count)
-	return count == 0, err
-}
-
-// SaveTransferProgress saves chunk-level progress for resume
-func (s *State) SaveTransferProgress(taskID int64, tableName string, partitionID *int, lastPK any, rowsDone, rowsTotal int64) error {
-	lastPKJSON, _ := json.Marshal(lastPK)
-	_, err := s.db.Exec(`
-		INSERT INTO transfer_progress (task_id, table_name, partition_id, last_pk, rows_done, rows_total, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
-		ON CONFLICT(task_id) DO UPDATE SET
-			last_pk = excluded.last_pk,
-			rows_done = excluded.rows_done,
-			updated_at = excluded.updated_at
-	`, taskID, tableName, partitionID, string(lastPKJSON), rowsDone, rowsTotal)
-	return err
-}
-
-// GetTransferProgress returns progress for a task
-func (s *State) GetTransferProgress(taskID int64) (*TransferProgress, error) {
-	var p TransferProgress
-	err := s.db.QueryRow(`
-		SELECT task_id, table_name, partition_id, last_pk, rows_done, rows_total
-		FROM transfer_progress WHERE task_id = ?
-	`, taskID).Scan(&p.TaskID, &p.TableName, &p.PartitionID, &p.LastPK, &p.RowsDone, &p.RowsTotal)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
-	return &p, err
-}
-
-// ClearTransferProgress removes saved progress for a task (for fresh re-transfer)
-func (s *State) ClearTransferProgress(taskID int64) error {
-	_, err := s.db.Exec(`DELETE FROM transfer_progress WHERE task_id = ?`, taskID)
-	return err
-}
-
-// CountPartitionTasks returns the number of existing partition tasks for a table in a run.
-// It counts tasks matching the pattern "transfer:schema.table:p*".
-func (s *State) CountPartitionTasks(runID, taskKeyPrefix string) (int, error) {
-	// Escape LIKE wildcards in the prefix so underscores and percent signs
-	// in table names (e.g., order_items) are treated literally.
-	escaped := strings.ReplaceAll(taskKeyPrefix, `\`, `\\`)
-	escaped = strings.ReplaceAll(escaped, `_`, `\_`)
-	escaped = strings.ReplaceAll(escaped, `%`, `\%`)
-	pattern := escaped + ":p%"
-
-	var count int
-	err := s.db.QueryRow(`
-		SELECT COUNT(*) FROM tasks
-		WHERE run_id = ? AND task_key LIKE ? ESCAPE '\'
-	`, runID, pattern).Scan(&count)
-	return count, err
-}
-
-// GetRunStats returns summary stats for a run
-func (s *State) GetRunStats(runID string) (total, pending, running, success, failed int, err error) {
-	err = s.db.QueryRow(`
-		SELECT
-			COUNT(*),
-			COALESCE(SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0)
-		FROM tasks WHERE run_id = ?
-	`, runID).Scan(&total, &pending, &running, &success, &failed)
-	return
-}
-
-// GetCompletedTables returns table names that completed successfully in a run
-func (s *State) GetCompletedTables(runID string) (map[string]bool, error) {
-	rows, err := s.db.Query(`
-		SELECT task_key FROM tasks
-		WHERE run_id = ? AND task_type = 'transfer' AND status = 'success'
-	`, runID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	completed := make(map[string]bool)
-	for rows.Next() {
-		var key string
-		if err := rows.Scan(&key); err != nil {
-			return nil, err
-		}
-		completed[key] = true
-	}
-	return completed, nil
-}
-
-// MarkRunAsResumed resets running tasks to pending for resume
-func (s *State) MarkRunAsResumed(runID string) error {
-	_, err := s.db.Exec(`
-		UPDATE tasks SET status = 'pending', started_at = NULL
-		WHERE run_id = ? AND status = 'running'
-	`, runID)
-	return err
-}
-
-// MarkTaskComplete marks a task as complete by run_id and task_key
-func (s *State) MarkTaskComplete(runID, taskKey string) error {
-	_, err := s.db.Exec(`
-		INSERT INTO tasks (run_id, task_type, task_key, status, completed_at)
-		VALUES (?, 'transfer', ?, 'success', datetime('now'))
-		ON CONFLICT(run_id, task_key) DO UPDATE SET
-			status = 'success',
-			completed_at = datetime('now')
-	`, runID, taskKey)
-	return err
-}
-
-// ProgressSaver implements transfer.ProgressSaver interface
-type ProgressSaver struct {
-	state StateBackend
-}
-
-// NewProgressSaver creates a progress saver wrapping any state backend
-func NewProgressSaver(s StateBackend) *ProgressSaver {
-	return &ProgressSaver{state: s}
-}
-
-// SaveProgress saves chunk-level progress for resume
-func (p *ProgressSaver) SaveProgress(taskID int64, tableName string, partitionID *int, lastPK any, rowsDone, rowsTotal int64) error {
-	return p.state.SaveTransferProgress(taskID, tableName, partitionID, lastPK, rowsDone, rowsTotal)
-}
-
-// GetProgress retrieves saved progress for a task
-func (p *ProgressSaver) GetProgress(taskID int64) (lastPK any, rowsDone int64, err error) {
-	prog, err := p.state.GetTransferProgress(taskID)
-	if err != nil {
-		return nil, 0, err
-	}
-	if prog == nil {
-		return nil, 0, nil
-	}
-	// Unmarshal lastPK from JSON (stored as string in TransferProgress)
-	if prog.LastPK != "" {
-		if jsonErr := json.Unmarshal([]byte(prog.LastPK), &lastPK); jsonErr != nil {
-			return nil, prog.RowsDone, nil // Ignore unmarshal errors, just return rowsDone
-		}
-	}
-	return lastPK, prog.RowsDone, nil
 }
 
 // GetAllRuns returns all runs for history
@@ -782,92 +392,6 @@ func (s *State) GetAllRuns() ([]Run, error) {
 	return runs, nil
 }
 
-// GetAllTasks returns all tasks for a run with their progress
-func (s *State) GetAllTasks(runID string) ([]Task, error) {
-	rows, err := s.db.Query(`
-		SELECT t.id, t.run_id, t.task_type, t.task_key, t.status,
-		       t.started_at, t.completed_at, t.retry_count, t.max_retries, t.error_message
-		FROM tasks t
-		WHERE t.run_id = ?
-		ORDER BY t.task_type, t.task_key
-	`, runID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var tasks []Task
-	for rows.Next() {
-		var t Task
-		var startedAt, completedAt, errorMsg sql.NullString
-		if err := rows.Scan(&t.ID, &t.RunID, &t.TaskType, &t.TaskKey, &t.Status,
-			&startedAt, &completedAt, &t.RetryCount, &t.MaxRetries, &errorMsg); err != nil {
-			return nil, err
-		}
-		if startedAt.Valid {
-			ts, _ := time.Parse("2006-01-02 15:04:05", startedAt.String)
-			t.StartedAt = &ts
-		}
-		if completedAt.Valid {
-			ts, _ := time.Parse("2006-01-02 15:04:05", completedAt.String)
-			t.CompletedAt = &ts
-		}
-		if errorMsg.Valid {
-			t.ErrorMessage = errorMsg.String
-		}
-		tasks = append(tasks, t)
-	}
-	return tasks, rows.Err()
-}
-
-// GetTasksWithProgress returns all tasks for a run with transfer progress info
-func (s *State) GetTasksWithProgress(runID string) ([]TaskWithProgress, error) {
-	rows, err := s.db.Query(`
-		SELECT t.id, t.run_id, t.task_type, t.task_key, t.status,
-		       t.started_at, t.completed_at, t.retry_count, t.error_message,
-		       tp.rows_done, tp.rows_total
-		FROM tasks t
-		LEFT JOIN transfer_progress tp ON t.id = tp.task_id
-		WHERE t.run_id = ?
-		ORDER BY t.task_type, t.task_key
-	`, runID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var tasks []TaskWithProgress
-	for rows.Next() {
-		var t TaskWithProgress
-		var startedAt, completedAt, errorMsg sql.NullString
-		var rowsDone, rowsTotal sql.NullInt64
-		if err := rows.Scan(&t.ID, &t.RunID, &t.TaskType, &t.TaskKey, &t.Status,
-			&startedAt, &completedAt, &t.RetryCount, &errorMsg,
-			&rowsDone, &rowsTotal); err != nil {
-			return nil, err
-		}
-		if startedAt.Valid {
-			ts, _ := time.Parse("2006-01-02 15:04:05", startedAt.String)
-			t.StartedAt = &ts
-		}
-		if completedAt.Valid {
-			ts, _ := time.Parse("2006-01-02 15:04:05", completedAt.String)
-			t.CompletedAt = &ts
-		}
-		if errorMsg.Valid {
-			t.ErrorMessage = errorMsg.String
-		}
-		if rowsDone.Valid {
-			t.RowsDone = rowsDone.Int64
-		}
-		if rowsTotal.Valid {
-			t.RowsTotal = rowsTotal.Int64
-		}
-		tasks = append(tasks, t)
-	}
-	return tasks, rows.Err()
-}
-
 // GetRunByID returns a specific run by ID
 func (s *State) GetRunByID(runID string) (*Run, error) {
 	var r Run
@@ -906,100 +430,4 @@ func (s *State) GetRunByID(runID string) (*Run, error) {
 		r.Error = errorMsg.String
 	}
 	return &r, nil
-}
-
-// CleanupOldRuns removes completed runs older than retainDays.
-// This prevents unbounded SQLite database growth.
-func (s *State) CleanupOldRuns(retainDays int) (int64, error) {
-	if retainDays <= 0 {
-		return 0, nil
-	}
-
-	cutoff := time.Now().AddDate(0, 0, -retainDays).Format("2006-01-02 15:04:05")
-
-	// Delete old progress records (cascade from tasks)
-	_, err := s.db.Exec(`
-		DELETE FROM transfer_progress WHERE task_id IN (
-			SELECT id FROM tasks WHERE run_id IN (
-				SELECT id FROM runs
-				WHERE completed_at < ? AND status IN ('success', 'failed')
-			)
-		)
-	`, cutoff)
-	if err != nil {
-		return 0, fmt.Errorf("deleting old progress: %w", err)
-	}
-
-	// Delete old task outputs
-	_, err = s.db.Exec(`
-		DELETE FROM task_outputs WHERE task_id IN (
-			SELECT id FROM tasks WHERE run_id IN (
-				SELECT id FROM runs
-				WHERE completed_at < ? AND status IN ('success', 'failed')
-			)
-		)
-	`, cutoff)
-	if err != nil {
-		return 0, fmt.Errorf("deleting old task outputs: %w", err)
-	}
-
-	// Delete old tasks
-	_, err = s.db.Exec(`
-		DELETE FROM tasks WHERE run_id IN (
-			SELECT id FROM runs
-			WHERE completed_at < ? AND status IN ('success', 'failed')
-		)
-	`, cutoff)
-	if err != nil {
-		return 0, fmt.Errorf("deleting old tasks: %w", err)
-	}
-
-	// Delete old runs
-	result, err := s.db.Exec(`
-		DELETE FROM runs
-		WHERE completed_at < ? AND status IN ('success', 'failed')
-	`, cutoff)
-	if err != nil {
-		return 0, fmt.Errorf("deleting old runs: %w", err)
-	}
-
-	rowsDeleted, _ := result.RowsAffected()
-	return rowsDeleted, nil
-}
-
-// GetLastSyncTimestamp returns the last successful sync timestamp for a table.
-// Returns nil if no previous sync exists (first sync should do full load).
-func (s *State) GetLastSyncTimestamp(sourceSchema, tableName, targetSchema string) (*time.Time, error) {
-	var tsStr sql.NullString
-	err := s.db.QueryRow(`
-		SELECT last_sync_timestamp FROM table_sync_timestamps
-		WHERE source_schema = ? AND table_name = ? AND target_schema = ?
-	`, sourceSchema, tableName, targetSchema).Scan(&tsStr)
-
-	if err == sql.ErrNoRows || !tsStr.Valid {
-		return nil, nil // No previous sync
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	ts, err := time.Parse(time.RFC3339, tsStr.String)
-	if err != nil {
-		return nil, nil // Invalid timestamp format, treat as no sync
-	}
-	return &ts, nil
-}
-
-// UpdateSyncTimestamp records the sync timestamp for a table.
-// Should be called at the START of a successful sync (not end), ensuring no data loss
-// if the source is updated during the sync.
-func (s *State) UpdateSyncTimestamp(sourceSchema, tableName, targetSchema string, ts time.Time) error {
-	_, err := s.db.Exec(`
-		INSERT INTO table_sync_timestamps (source_schema, table_name, target_schema, last_sync_timestamp, updated_at)
-		VALUES (?, ?, ?, ?, datetime('now'))
-		ON CONFLICT(source_schema, table_name, target_schema) DO UPDATE SET
-			last_sync_timestamp = excluded.last_sync_timestamp,
-			updated_at = excluded.updated_at
-	`, sourceSchema, tableName, targetSchema, ts.Format(time.RFC3339))
-	return err
 }

--- a/internal/checkpoint/state_test.go
+++ b/internal/checkpoint/state_test.go
@@ -2,89 +2,8 @@ package checkpoint
 
 import (
 	"database/sql"
-	"fmt"
-	"strings"
 	"testing"
-	"time"
 )
-
-func TestCleanupOldRuns(t *testing.T) {
-	state, err := New(t.TempDir())
-	if err != nil {
-		t.Fatalf("New() error: %v", err)
-	}
-	defer state.Close()
-
-	oldSuccess := "old-success"
-	oldFailed := "old-failed"
-	recentSuccess := "recent-success"
-	running := "running"
-
-	for _, runID := range []string{oldSuccess, oldFailed, recentSuccess, running} {
-		if err := state.CreateRun(runID, RunKindApply, "dbo", "public", map[string]string{"run": runID}, "", ""); err != nil {
-			t.Fatalf("CreateRun(%s) error: %v", runID, err)
-		}
-	}
-
-	if err := state.CompleteRun(oldSuccess, "success", ""); err != nil {
-		t.Fatalf("CompleteRun(%s) error: %v", oldSuccess, err)
-	}
-	if err := state.CompleteRun(oldFailed, "failed", "boom"); err != nil {
-		t.Fatalf("CompleteRun(%s) error: %v", oldFailed, err)
-	}
-	if err := state.CompleteRun(recentSuccess, "success", ""); err != nil {
-		t.Fatalf("CompleteRun(%s) error: %v", recentSuccess, err)
-	}
-
-	oldTime := time.Now().AddDate(0, 0, -31).Format("2006-01-02 15:04:05")
-	if _, err := state.db.Exec(`UPDATE runs SET completed_at = ? WHERE id IN (?, ?)`, oldTime, oldSuccess, oldFailed); err != nil {
-		t.Fatalf("update old completed_at error: %v", err)
-	}
-
-	recentTime := time.Now().AddDate(0, 0, -1).Format("2006-01-02 15:04:05")
-	if _, err := state.db.Exec(`UPDATE runs SET completed_at = ? WHERE id = ?`, recentTime, recentSuccess); err != nil {
-		t.Fatalf("update recent completed_at error: %v", err)
-	}
-
-	taskIDs := make(map[string]int64)
-	for _, runID := range []string{oldSuccess, oldFailed, recentSuccess, running} {
-		taskID, err := state.CreateTask(runID, "transfer", "transfer:dbo.Table")
-		if err != nil {
-			t.Fatalf("CreateTask(%s) error: %v", runID, err)
-		}
-		taskIDs[runID] = taskID
-		if err := state.SaveTransferProgress(taskID, "Table", nil, int64(1), 10, 100); err != nil {
-			t.Fatalf("SaveTransferProgress(%s) error: %v", runID, err)
-		}
-		if _, err := state.db.Exec(`INSERT INTO task_outputs (task_id, key, value) VALUES (?, ?, ?)`, taskID, "k", "v"); err != nil {
-			t.Fatalf("insert task_outputs(%s) error: %v", runID, err)
-		}
-	}
-
-	deleted, err := state.CleanupOldRuns(30)
-	if err != nil {
-		t.Fatalf("CleanupOldRuns error: %v", err)
-	}
-	if deleted != 2 {
-		t.Fatalf("deleted runs = %d, want 2", deleted)
-	}
-
-	if got := countRows(t, state.db, `SELECT COUNT(*) FROM runs`); got != 2 {
-		t.Fatalf("runs remaining = %d, want 2", got)
-	}
-	if got := countRows(t, state.db, `SELECT COUNT(*) FROM runs WHERE id = ?`, running); got != 1 {
-		t.Fatalf("running run missing after cleanup")
-	}
-	if got := countRows(t, state.db, `SELECT COUNT(*) FROM tasks`); got != 2 {
-		t.Fatalf("tasks remaining = %d, want 2", got)
-	}
-	if got := countRows(t, state.db, `SELECT COUNT(*) FROM transfer_progress`); got != 2 {
-		t.Fatalf("transfer_progress remaining = %d, want 2", got)
-	}
-	if got := countRows(t, state.db, `SELECT COUNT(*) FROM task_outputs`); got != 2 {
-		t.Fatalf("task_outputs remaining = %d, want 2", got)
-	}
-}
 
 func countRows(t *testing.T, db *sql.DB, query string, args ...any) int {
 	t.Helper()
@@ -95,187 +14,105 @@ func countRows(t *testing.T, db *sql.DB, query string, args ...any) int {
 	return count
 }
 
-func TestSyncTimestamps(t *testing.T) {
+// TestRunLifecycle covers the kept run surface: create, phase, complete, and
+// the two read paths used by history.
+func TestRunLifecycle(t *testing.T) {
 	state, err := New(t.TempDir())
 	if err != nil {
 		t.Fatalf("New() error: %v", err)
 	}
 	defer state.Close()
 
-	sourceSchema := "dbo"
-	tableName := "Orders"
-	targetSchema := "public"
+	const runID = "run-1"
+	if err := state.CreateRun(runID, RunKindApply, "dbo", "public", map[string]string{"k": "v"}, "prof", "/cfg.yaml"); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := state.UpdatePhase(runID, "finalizing"); err != nil {
+		t.Fatalf("UpdatePhase: %v", err)
+	}
+	if err := state.CompleteRun(runID, "success", ""); err != nil {
+		t.Fatalf("CompleteRun: %v", err)
+	}
 
-	// Test: Get timestamp for table with no prior sync
-	ts, err := state.GetLastSyncTimestamp(sourceSchema, tableName, targetSchema)
+	r, err := state.GetRunByID(runID)
+	if err != nil || r == nil {
+		t.Fatalf("GetRunByID: %v %v", r, err)
+	}
+	if r.Status != "success" || r.ProfileName != "prof" {
+		t.Errorf("unexpected run: status=%q profile=%q", r.Status, r.ProfileName)
+	}
+	// GetRunByID does not surface phase; confirm UpdatePhase persisted it.
+	if got := countRows(t, state.db, `SELECT COUNT(*) FROM runs WHERE id=? AND phase='finalizing'`, runID); got != 1 {
+		t.Errorf("phase not persisted as finalizing")
+	}
+
+	runs, err := state.GetAllRuns()
 	if err != nil {
-		t.Fatalf("GetLastSyncTimestamp() error: %v", err)
+		t.Fatalf("GetAllRuns: %v", err)
 	}
-	if ts != nil {
-		t.Errorf("Expected nil timestamp for first sync, got %v", ts)
-	}
-
-	// Test: Update sync timestamp
-	syncTime := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
-	if err := state.UpdateSyncTimestamp(sourceSchema, tableName, targetSchema, syncTime); err != nil {
-		t.Fatalf("UpdateSyncTimestamp() error: %v", err)
-	}
-
-	// Test: Get updated timestamp
-	ts, err = state.GetLastSyncTimestamp(sourceSchema, tableName, targetSchema)
-	if err != nil {
-		t.Fatalf("GetLastSyncTimestamp() error: %v", err)
-	}
-	if ts == nil {
-		t.Fatal("Expected non-nil timestamp after update")
-	}
-	if !ts.Equal(syncTime) {
-		t.Errorf("Timestamp mismatch: got %v, want %v", ts, syncTime)
-	}
-
-	// Test: Update with newer timestamp (upsert)
-	newerTime := time.Date(2024, 6, 16, 12, 0, 0, 0, time.UTC)
-	if err := state.UpdateSyncTimestamp(sourceSchema, tableName, targetSchema, newerTime); err != nil {
-		t.Fatalf("UpdateSyncTimestamp() error: %v", err)
-	}
-
-	ts, err = state.GetLastSyncTimestamp(sourceSchema, tableName, targetSchema)
-	if err != nil {
-		t.Fatalf("GetLastSyncTimestamp() error: %v", err)
-	}
-	if !ts.Equal(newerTime) {
-		t.Errorf("Timestamp not updated: got %v, want %v", ts, newerTime)
-	}
-
-	// Test: Different table should have no timestamp
-	ts, err = state.GetLastSyncTimestamp(sourceSchema, "OtherTable", targetSchema)
-	if err != nil {
-		t.Fatalf("GetLastSyncTimestamp() error: %v", err)
-	}
-	if ts != nil {
-		t.Errorf("Expected nil timestamp for different table, got %v", ts)
-	}
-
-	// Test: Same table, different target schema should have no timestamp
-	ts, err = state.GetLastSyncTimestamp(sourceSchema, tableName, "other_schema")
-	if err != nil {
-		t.Fatalf("GetLastSyncTimestamp() error: %v", err)
-	}
-	if ts != nil {
-		t.Errorf("Expected nil timestamp for different target schema, got %v", ts)
+	if len(runs) != 1 || runs[0].ID != runID {
+		t.Fatalf("GetAllRuns = %+v, want one run %q", runs, runID)
 	}
 }
 
-func TestUpdateRunConfig(t *testing.T) {
+// TestDeadTablesNotCreated asserts the DMT-era tables are gone from fresh DBs
+// while the SMT-active tables remain (#158).
+func TestDeadTablesNotCreated(t *testing.T) {
 	state, err := New(t.TempDir())
 	if err != nil {
 		t.Fatalf("New() error: %v", err)
 	}
 	defer state.Close()
 
-	const runID = "run-update-config"
-	original := map[string]any{"workers": 12, "chunk_size": 113510}
-	if err := state.CreateRun(runID, RunKindApply, "dbo", "public", original, "", ""); err != nil {
-		t.Fatalf("CreateRun error: %v", err)
+	exists := func(name string) bool {
+		return countRows(t, state.db,
+			`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?`, name) > 0
 	}
 
-	updated := map[string]any{"workers": 6, "chunk_size": 100000}
-	if err := state.UpdateRunConfig(runID, updated); err != nil {
-		t.Fatalf("UpdateRunConfig error: %v", err)
+	for _, dead := range []string{"tasks", "task_outputs", "transfer_progress", "table_sync_timestamps"} {
+		if exists(dead) {
+			t.Errorf("dead table %q should not be created", dead)
+		}
 	}
-
-	run, err := state.GetRunByID(runID)
-	if err != nil {
-		t.Fatalf("GetRunByID error: %v", err)
-	}
-	if run == nil {
-		t.Fatalf("run not found after UpdateRunConfig")
-	}
-	if !strings.Contains(run.Config, `"workers":6`) || !strings.Contains(run.Config, `"chunk_size":100000`) {
-		t.Errorf("config not updated, got: %s", run.Config)
-	}
-	if strings.Contains(run.Config, `"workers":12`) {
-		t.Errorf("config still contains pre-update workers=12: %s", run.Config)
-	}
-
-	// Unknown run id should return an error rather than silently succeeding.
-	if err := state.UpdateRunConfig("does-not-exist", updated); err == nil {
-		t.Errorf("expected error for unknown run id, got nil")
+	for _, live := range []string{"runs", "profiles", "schema_snapshots"} {
+		if !exists(live) {
+			t.Errorf("live table %q is missing", live)
+		}
 	}
 }
 
-func TestCountPartitionTasks(t *testing.T) {
-	state, err := New(t.TempDir())
+// TestOpensLegacyDBWithDeadTables is the forward-compat guarantee (option a):
+// an old state DB that still has the dead tables opens cleanly and keeps working.
+func TestOpensLegacyDBWithDeadTables(t *testing.T) {
+	dir := t.TempDir()
+
+	// First open creates the v1 schema.
+	s1, err := New(dir)
 	if err != nil {
 		t.Fatalf("New() error: %v", err)
 	}
-	defer state.Close()
-
-	runID := "test-run"
-	if err := state.CreateRun(runID, RunKindApply, "public", "public", nil, "", ""); err != nil {
-		t.Fatalf("CreateRun() error: %v", err)
+	// Simulate a pre-#158 database by recreating a dead table with a stray row.
+	if _, err := s1.db.Exec(`CREATE TABLE IF NOT EXISTS table_sync_timestamps (
+		source_schema TEXT, table_name TEXT, target_schema TEXT,
+		last_sync_timestamp TEXT, updated_at TEXT,
+		PRIMARY KEY (source_schema, table_name, target_schema))`); err != nil {
+		t.Fatalf("seed dead table: %v", err)
 	}
-
-	// Create partition tasks for a table
-	for i := 1; i <= 6; i++ {
-		key := fmt.Sprintf("transfer:public.votes:p%d", i)
-		if _, err := state.CreateTask(runID, "transfer", key); err != nil {
-			t.Fatalf("CreateTask(%s) error: %v", key, err)
-		}
+	if _, err := s1.db.Exec(`INSERT INTO table_sync_timestamps VALUES ('dbo','t','public','x','y')`); err != nil {
+		t.Fatalf("seed dead row: %v", err)
 	}
+	s1.Close()
 
-	// Create a non-partition task for the same table (should not be counted)
-	if _, err := state.CreateTask(runID, "transfer", "transfer:public.votes"); err != nil {
-		t.Fatalf("CreateTask() error: %v", err)
-	}
-
-	// Create partition tasks for a different table
-	for i := 1; i <= 3; i++ {
-		key := fmt.Sprintf("transfer:public.posts:p%d", i)
-		if _, err := state.CreateTask(runID, "transfer", key); err != nil {
-			t.Fatalf("CreateTask(%s) error: %v", key, err)
-		}
-	}
-
-	// Count votes partitions
-	count, err := state.CountPartitionTasks(runID, "transfer:public.votes")
+	// Re-open: migrate() must not choke on the orphan table, and runs still work.
+	s2, err := New(dir)
 	if err != nil {
-		t.Fatalf("CountPartitionTasks() error: %v", err)
+		t.Fatalf("reopen with orphan dead table: %v", err)
 	}
-	if count != 6 {
-		t.Errorf("expected 6 partition tasks for votes, got %d", count)
+	defer s2.Close()
+	if err := s2.CreateRun("r", RunKindApply, "dbo", "public", nil, "", ""); err != nil {
+		t.Fatalf("CreateRun after reopen: %v", err)
 	}
-
-	// Count posts partitions
-	count, err = state.CountPartitionTasks(runID, "transfer:public.posts")
-	if err != nil {
-		t.Fatalf("CountPartitionTasks() error: %v", err)
-	}
-	if count != 3 {
-		t.Errorf("expected 3 partition tasks for posts, got %d", count)
-	}
-
-	// Table with underscores — underscore must not act as wildcard
-	for i := 1; i <= 2; i++ {
-		key := fmt.Sprintf("transfer:public.order_items:p%d", i)
-		if _, err := state.CreateTask(runID, "transfer", key); err != nil {
-			t.Fatalf("CreateTask(%s) error: %v", key, err)
-		}
-	}
-	count, err = state.CountPartitionTasks(runID, "transfer:public.order_items")
-	if err != nil {
-		t.Fatalf("CountPartitionTasks() error: %v", err)
-	}
-	if count != 2 {
-		t.Errorf("expected 2 partition tasks for order_items, got %d", count)
-	}
-
-	// Non-existent table
-	count, err = state.CountPartitionTasks(runID, "transfer:public.nonexistent")
-	if err != nil {
-		t.Fatalf("CountPartitionTasks() error: %v", err)
-	}
-	if count != 0 {
-		t.Errorf("expected 0 partition tasks for nonexistent table, got %d", count)
+	if r, err := s2.GetRunByID("r"); err != nil || r == nil {
+		t.Fatalf("GetRunByID after reopen: %v %v", r, err)
 	}
 }

--- a/internal/orchestrator/history.go
+++ b/internal/orchestrator/history.go
@@ -53,18 +53,6 @@ func (o *Orchestrator) ShowRunDetails(runID string) error {
 	if r.Error != "" {
 		fmt.Printf("Error:      %s\n", r.Error)
 	}
-
-	tasks, err := o.state.GetTasksWithProgress(r.ID)
-	if err != nil {
-		return err
-	}
-	if len(tasks) == 0 {
-		return nil
-	}
-	fmt.Println("\nTasks:")
-	for _, t := range tasks {
-		fmt.Printf("  %-30s %s\n", t.TaskKey, t.Status)
-	}
 	return nil
 }
 


### PR DESCRIPTION
Closes #158. Part of #144 (v1 readiness). Sibling of #156.

`internal/checkpoint/` created four SQLite tables and a large slice of the
`StateBackend` surface that only ever supported DMT's row-transfer pipeline
(parallel workers, chunk-level resume, date-based incremental sync). SMT runs
DDL synchronously and never wrote them — pure dead weight that would otherwise
become part of the frozen v1 on-disk contract.

**Audit method:** every `StateBackend` method with zero callers outside
`internal/checkpoint` (non-test) is dead-to-SMT. The only borderline caller was
`GetTasksWithProgress`, read by `ShowRunDetails` into an always-empty "Tasks:"
section — removed too.

## Removed

- **Tables** (no longer created by `migrate()`): `tasks`, `task_outputs`,
  `transfer_progress`, `table_sync_timestamps`.
- **Interface** trimmed to the live run surface: `CreateRun`, `CompleteRun`,
  `UpdatePhase`, `GetAllRuns`, `GetRunByID`, `Close` (+ `HistoryBackend` profile
  methods).
- **Methods** (`State` + `FileState`): task tracking, transfer progress
  (`ProgressSaver` included), run-resume (`GetLastIncompleteRun`,
  `HasSuccessfulRunAfter`, `MarkRunAsResumed`, `UpdateRunConfig`,
  `SetRunConfigHash`), sync watermarks, and `CleanupOldRuns` (which deleted from
  the dropped tables).
- **Types**: `Task`, `TransferProgress`, `TaskWithProgress`, and `FileState`'s
  `tableState` / `Tables` map / synthetic task-ID counter.
- Knock-ons: `ShowRunDetails` no longer reads tasks; `validTableNames` drops
  `tasks` / `table_sync_timestamps`.

**Kept untouched:** `runs`, `profiles`, `schema_snapshots` and their live methods.

## Forward-compat (option a, ties into #154)

No DROP migration. A pre-existing `~/.smt` state DB keeps the orphan tables as
harmless empties (never queried); new DBs omit them. A `CHANGELOG` `[Unreleased]`
note documents the 0.x → 1.0 behavior.

## Scope note

`smt history <run>` output is effectively unchanged — the only removed line was a
task section that was always empty for real SMT runs (the `tasks` table was never
populated). The SQLite `GetRunByID`/`GetAllRuns` paths never selected `phase`
either, so that's pre-existing.

## Test plan

- New `internal/checkpoint` tests: kept run lifecycle (create → phase → complete
  → read), dead tables are not created while `runs`/`profiles`/`schema_snapshots`
  are, and a **legacy DB carrying a dead table reopens and works** (forward-compat
  guarantee). `FileState` tests cover create/complete/read and loading an existing
  file with a legacy `tables:` block (ignored).
- `grep` clean: no references to any removed symbol remain in `internal/`/`cmd/`.
- `go build ./...`, `go vet ./...`, `go test ./... -short`, `gofmt` all clean.
- Net ~1270 lines deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)