### PR TITLE
Add `smt snapshot list` subcommand — closes #159

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`smt snapshot list`** ([#159]) — list stored source-schema snapshots (id,
+  source type, schema, table count, captured-at), newest first, with `--limit`
+  (default 50). Surfaces the existing `schema_snapshots` baselines that `smt
+  snapshot` writes and `smt sync` consumes; read-only.
+
 ### Removed
 
 - **Dead DMT-era state-DB tables and checkpoint APIs** ([#158]). The SQLite
@@ -132,6 +139,7 @@ history since v0.9.0:
 [#134]: https://github.com/johndauphine/smt/issues/134
 [#156]: https://github.com/johndauphine/smt/issues/156
 [#158]: https://github.com/johndauphine/smt/issues/158
+[#159]: https://github.com/johndauphine/smt/issues/159
 [#46]: https://github.com/johndauphine/smt/issues/46
 [#57]: https://github.com/johndauphine/smt/issues/57
 [#58]: https://github.com/johndauphine/smt/issues/58

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Run `./smt` with no arguments to launch the TUI. See `./smt --help` for the full
 | `smt create` | extract source schema and emit CREATE TABLE / CREATE INDEX / etc to `schema.sql` |
 | `smt create --apply` | also execute the generated DDL against the configured target |
 | `smt snapshot` | save the current source schema as a baseline for future diffing |
+| `smt snapshot list` | list stored snapshots (id, source, schema, table count, captured-at); `--limit N` |
 | `smt sync` | diff source against last snapshot; generate target-dialect SQL; emit to `migration.sql` for review |
 | `smt sync --apply` | also execute the generated SQL against the target |
 | `smt sync --apply --allow-data-loss` | permit column/table drops |

--- a/cmd/smt/snapshot_list_test.go
+++ b/cmd/smt/snapshot_list_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"smt/internal/checkpoint"
+	"smt/internal/driver"
+	"smt/internal/schemadiff"
+)
+
+// saveSnap stores a schemadiff.Snapshot with tableCount empty tables.
+func saveSnap(t *testing.T, state *checkpoint.State, src, schema string, capturedAt time.Time, tableCount int) {
+	t.Helper()
+	snap := schemadiff.Snapshot{
+		Version:    schemadiff.CurrentSnapshotVersion,
+		Schema:     schema,
+		SourceType: src,
+		CapturedAt: capturedAt,
+		Tables:     make([]driver.Table, tableCount),
+	}
+	payload, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := state.SaveSnapshot(src, schema, capturedAt, payload); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+}
+
+// TestSnapshotList covers the data + decode path behind `smt snapshot list`:
+// newest-first ordering, the --limit cap, the default cap, and the payload
+// table-count decode that the command renders.
+func TestSnapshotList(t *testing.T) {
+	state, err := checkpoint.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer state.Close()
+
+	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	saveSnap(t, state, "mssql", "dbo", base, 3)
+	saveSnap(t, state, "postgres", "public", base.Add(1*time.Hour), 14)
+	saveSnap(t, state, "mysql", "app", base.Add(2*time.Hour), 7)
+
+	// --limit caps the result and returns newest first.
+	snaps, err := state.ListSnapshots(2)
+	if err != nil {
+		t.Fatalf("ListSnapshots: %v", err)
+	}
+	if len(snaps) != 2 {
+		t.Fatalf("limit=2 returned %d snapshots", len(snaps))
+	}
+	if snaps[0].SourceType != "mysql" || snaps[1].SourceType != "postgres" {
+		t.Errorf("not newest-first: got %s, %s", snaps[0].SourceType, snaps[1].SourceType)
+	}
+
+	// The payload decodes to the table count the command prints.
+	var snap schemadiff.Snapshot
+	if err := json.Unmarshal(snaps[0].Payload, &snap); err != nil {
+		t.Fatalf("payload decode: %v", err)
+	}
+	if len(snap.Tables) != 7 {
+		t.Errorf("newest snapshot table count = %d, want 7", len(snap.Tables))
+	}
+
+	// limit <= 0 falls back to the default cap and returns everything stored.
+	all, err := state.ListSnapshots(0)
+	if err != nil {
+		t.Fatalf("ListSnapshots(0): %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("default limit returned %d, want all 3", len(all))
+	}
+}

--- a/cmd/smt/sync.go
+++ b/cmd/smt/sync.go
@@ -14,12 +14,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/urfave/cli/v2"
 
 	"smt/internal/checkpoint"
+	"smt/internal/config"
 	"smt/internal/driver"
 	"smt/internal/logging"
 	"smt/internal/orchestrator"
@@ -35,7 +37,62 @@ func snapshotCommand() *cli.Command {
 			&cli.StringFlag{Name: "out", Aliases: []string{"o"}, Usage: "Also write the snapshot JSON to this file"},
 		},
 		Action: runSnapshot,
+		Subcommands: []*cli.Command{
+			{
+				Name:    "list",
+				Aliases: []string{"ls"},
+				Usage:   "List stored source-schema snapshots (newest first)",
+				Flags: []cli.Flag{
+					&cli.IntFlag{Name: "limit", Aliases: []string{"n"}, Value: 50, Usage: "Maximum snapshots to show"},
+				},
+				Action: runSnapshotList,
+			},
+		},
 	}
+}
+
+func runSnapshotList(c *cli.Context) error {
+	if c.String("state-file") != "" {
+		return fmt.Errorf("snapshot list requires the SQLite state backend; it is not available with --state-file")
+	}
+	cfg, _, _, err := loadConfig(c)
+	if err != nil {
+		return err
+	}
+
+	dataDir := cfg.Migration.DataDir
+	if dataDir == "" {
+		dataDir, err = config.DefaultDataDir()
+		if err != nil {
+			return err
+		}
+	}
+	state, err := checkpoint.New(dataDir)
+	if err != nil {
+		return err
+	}
+	defer state.Close()
+
+	snaps, err := state.ListSnapshots(c.Int("limit"))
+	if err != nil {
+		return err
+	}
+	if len(snaps) == 0 {
+		fmt.Println("No snapshots found. Run `smt snapshot` to capture one.")
+		return nil
+	}
+
+	fmt.Printf("%-5s  %-10s  %-20s  %-6s  %s\n", "ID", "SOURCE", "SCHEMA", "TABLES", "CAPTURED")
+	for _, s := range snaps {
+		tables := "?"
+		var snap schemadiff.Snapshot
+		if json.Unmarshal(s.Payload, &snap) == nil {
+			tables = strconv.Itoa(len(snap.Tables))
+		}
+		fmt.Printf("%-5d  %-10s  %-20s  %-6s  %s\n",
+			s.ID, s.SourceType, s.Schema, tables, s.CapturedAt.Format(time.RFC3339))
+	}
+	return nil
 }
 
 func runSnapshot(c *cli.Context) error {


### PR DESCRIPTION
Closes #159.

`State.ListSnapshots` was a complete, working accessor over the live
`schema_snapshots` table with **zero callers** — users could capture baselines
(`smt snapshot`) and `sync` consumed the latest, but nothing surfaced what
baselines existed. This wires it up (Option A, the issue's preferred path)
instead of removing it.

## What's here

- **`smt snapshot list`** (alias `ls`) — prints stored snapshots newest-first:
  id, source type, schema, table count (decoded from the snapshot payload),
  captured-at. `--limit N` (default 50, matching the accessor). Read-only.
- Added as a **subcommand of `snapshot`**; bare `smt snapshot` still captures.
- Opens the same SQLite state DB `smt snapshot` writes to — `data_dir`
  resolution mirrors the orchestrator (`cfg.Migration.DataDir` else
  `config.DefaultDataDir()`). Errors clearly under `--state-file` (the file
  backend has no snapshot storage).
- Empty case prints a helpful hint instead of nothing.

## Test plan

- New `cmd/smt/snapshot_list_test.go` covers the data + decode path behind the
  command: newest-first ordering, the `--limit` cap, the default cap (limit ≤ 0
  → 50), and the payload → table-count decode the command renders.
  (`schema_snapshots` had no test before this.)
- Smoke-verified routing: `smt snapshot --help` lists the subcommand;
  `smt snapshot list` / `ls --limit 5` print the empty-state hint and exit 0;
  bare `smt snapshot` still routes to capture.
- `go build ./...`, `go vet ./...`, `go test ./... -short`, `gofmt` all clean.

## Notes

- README command table + CHANGELOG (`[Unreleased]` → Added) updated.
- Pure addition (+66 lines tracked, plus the new test file); no behavior change
  to existing commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)