### PR TITLE
Release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to SMT are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.12.1] - 2026-06-21
 
 ### Fixed
 
@@ -171,7 +171,7 @@ Releases before 0.10.0 are listed on the
 history since v0.9.0:
 [`v0.9.0...v0.10.0`](https://github.com/johndauphine/smt/compare/v0.9.0...v0.10.0).
 
-[Unreleased]: https://github.com/johndauphine/smt/compare/v0.12.0...HEAD
+[0.12.1]: https://github.com/johndauphine/smt/releases/tag/v0.12.1
 [0.12.0]: https://github.com/johndauphine/smt/releases/tag/v0.12.0
 [0.11.0]: https://github.com/johndauphine/smt/releases/tag/v0.11.0
 [#141]: https://github.com/johndauphine/smt/issues/141

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version is the current version of smt.
 // Can be overridden at build time with -ldflags "-X ...version.Version=..."
-var Version = "0.12.0"
+var Version = "0.12.1"
 
 // Name is the application name.
 const Name = "smt"


### PR DESCRIPTION
Patch release cutting **v0.12.1** with the three fixes from the local-model test session (all already on `main`):

- **#169** — TZ-aware timestamp (`timestamptz` / `datetimeoffset`) → MySQL `TIMESTAMP` instead of naive `DATETIME`; `RendererVersion` 3 → 4.
- **#168** — AI-review parser contract emits `datetime_precision`.
- **#170** — AI-review parser contract emits `is_unsigned`, `display_width`, `enum_values`.

Bumps `version.Version` 0.12.0 → 0.12.1 and promotes CHANGELOG `[Unreleased]` → `[0.12.1] - 2026-06-21`. Tag + binaries follow once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)