### PR TITLE
docs: record v1.0.0 release status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Documented the published v1.0.0 release status, artifact list, CI status,
+  release-blocker closure, and validation artifacts.
+
 ## [1.0.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ SMT extracts the schema of a source database and builds matching target-dialect 
 
 SMT is the schema-only counterpart to [DMT](https://github.com/johndauphine/dmt) (the data migration tool): same pluggable driver model, same TUI scaffolding, same encrypted profile storage. It does not move rows.
 
+## Release Status
+
+SMT v1.0.0 is published as a stable GitHub Release:
+[SMT v1.0.0](https://github.com/johndauphine/smt/releases/tag/v1.0.0).
+The release tag points at commit
+`b08be2c1fcf22ced8e38e7137420e5d81b8e8ec0`, and downloadable Linux, macOS,
+and Windows artifacts are available with SHA-256 checksums. See
+[docs/release-checklist.md](docs/release-checklist.md#current-release-status)
+for the current release status, validation gates, and asset list.
+
 ## Supported databases
 
 PostgreSQL, SQL Server, MySQL — both as source and target. New engines are added by dropping a package under `internal/driver/foo/` that implements `driver.Driver`/`Reader`/`Writer` and registers itself in `init()`.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,5 +1,20 @@
 # SMT v1.0.0 Release Checklist
 
+## Current Release Status
+
+SMT v1.0.0 is published as a stable GitHub Release:
+[SMT v1.0.0](https://github.com/johndauphine/smt/releases/tag/v1.0.0).
+
+| Item | Status |
+|------|--------|
+| Release | Published on 2026-06-23 at 02:10 UTC; not a draft or prerelease |
+| Tag | Annotated tag `v1.0.0`, targeting `b08be2c1fcf22ced8e38e7137420e5d81b8e8ec0` |
+| CI | Passing on `main` for Unit Tests, Race Tests, Lint, and Build CLI at the release commit |
+| Release blockers | No open `v1` or `release-blocker` issues; release readiness tracker [#144](https://github.com/johndauphine/smt/issues/144) is closed |
+| Assets | `smt-linux-amd64`, `smt-darwin-arm64`, `smt-windows-amd64.exe`, `checksums.txt` |
+| Checksums | Local release checksums passed before upload; the published `checksums.txt` matches the local file |
+| Acceptance artifacts | `so2010_verification.json`, `crm_acceptance_matrix.json`, and `live_ai_smoke.json` were generated under `.acceptance-artifacts/` during release validation |
+
 ## Supported Artifacts
 
 `make release-artifacts` builds:


### PR DESCRIPTION
## Summary

- Record that SMT v1.0.0 is published as a stable GitHub Release.
- Add the release URL, tag/commit, assets, CI status, release-blocker status, and validation artifacts to the release checklist.
- Add a README release-status pointer and changelog entry for the docs update.

## Validation

- `git diff --check`
- `git diff --cached --check`