### PR TITLE
ci: run full CRM fixture matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,45 @@ jobs:
 
       - name: Build ./cmd/smt
         run: go build -trimpath -o "${RUNNER_TEMP}/smt" ./cmd/smt
+
+  crm-matrix:
+    name: CRM Fixture Matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Start database containers
+        run: |
+          make test-dbs-up
+          make mysql-test-up
+
+      - name: Wait for databases
+        run: make test-dbs-wait
+
+      - name: Load CRM fixtures
+        run: make test-crm-fixtures-load
+
+      - name: Run all-pairs CRM fixture matrix
+        run: make test-crm-acceptance
+
+      - name: Upload CRM matrix report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crm-acceptance-matrix
+          path: .acceptance-artifacts/crm/
+          if-no-files-found: ignore
+
+      - name: Stop database containers
+        if: always()
+        run: |
+          make test-dbs-down
+          make mysql-test-down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Documented the published v1.0.0 release status, artifact list, CI status,
   release-blocker closure, and validation artifacts.
+- Added a CI CRM fixture matrix that runs every supported source-to-target
+  permutation across SQL Server, PostgreSQL, and MySQL.
 
 ## [1.0.0] - 2026-06-22
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean test test-short test-coverage test-so2010 test-crm-acceptance test-live-ai release-artifacts release-checksums run install check setup-hooks fmt lint
+.PHONY: build clean test test-short test-coverage test-so2010 test-crm-acceptance test-crm-fixtures-load test-crm-ci test-dbs-wait test-live-ai release-artifacts release-checksums run install check setup-hooks fmt lint
 
 # Build variables
 BINARY_NAME=smt
@@ -61,14 +61,24 @@ test-so2010:
 	SMT_E2E_SO2010=1 SO2010_REPORT_DIR=$(CURDIR)/.acceptance-artifacts/so2010 $(GOTEST) -count=1 -v -run TestSO2010 ./internal/orchestrator/
 	@echo "Verification report: $(CURDIR)/.acceptance-artifacts/so2010/so2010_verification.json"
 
-# No-AI CRM live acceptance matrix. The three cases cover every supported
-# engine at least once as a source and once as a target:
-#   mssql -> postgres, postgres -> mysql, mysql -> mssql.
+# No-AI CRM live acceptance matrix. Covers every supported source -> target
+# permutation across SQL Server, PostgreSQL, and MySQL.
 # Requires the CRM fixture databases from testdata/crm to be loaded first.
 test-crm-acceptance:
 	mkdir -p .acceptance-artifacts/crm
 	SMT_E2E_CRM=1 CRM_REPORT_DIR=$(CURDIR)/.acceptance-artifacts/crm $(GOTEST) -count=1 -v -run TestCRM_DeterministicAcceptanceMatrix ./internal/orchestrator/
 	@echo "CRM report: $(CURDIR)/.acceptance-artifacts/crm/crm_acceptance_matrix.json"
+
+test-crm-fixtures-load:
+	docker cp testdata/crm/crm_mssql.sql mssql-test:/tmp/
+	docker exec mssql-test /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'TestPass2024' -C -Q "IF DB_ID(N'CRM_MSSQL') IS NOT NULL BEGIN ALTER DATABASE CRM_MSSQL SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE CRM_MSSQL; END; CREATE DATABASE CRM_MSSQL;"
+	docker exec mssql-test /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'TestPass2024' -C -d CRM_MSSQL -i /tmp/crm_mssql.sql
+	docker cp testdata/crm/crm_postgres.sql pg-test:/tmp/
+	docker exec pg-test sh -c "PGPASSWORD=TestPass2024 dropdb --if-exists -U postgres crm_pg && PGPASSWORD=TestPass2024 createdb -U postgres crm_pg && PGPASSWORD=TestPass2024 psql -U postgres -d crm_pg -v ON_ERROR_STOP=1 -f /tmp/crm_postgres.sql"
+	docker cp testdata/crm/crm_mysql.sql mysql-test:/tmp/
+	docker exec mysql-test sh -c "mysql -uroot -pTestPass2024 -e 'DROP DATABASE IF EXISTS crm_mysql; CREATE DATABASE crm_mysql;' && mysql -uroot -pTestPass2024 crm_mysql < /tmp/crm_mysql.sql"
+
+test-crm-ci: test-dbs-up mysql-test-up test-dbs-wait test-crm-fixtures-load test-crm-acceptance
 
 # Optional live AI smoke. Explicitly opt in so default unit tests remain
 # hermetic and never load host AI secrets.
@@ -99,6 +109,7 @@ test-dbs-up:
 		--user root \
 		-e 'ACCEPT_EULA=Y' \
 		-e 'SA_PASSWORD=TestPass2024' \
+		-e 'MSSQL_SA_PASSWORD=TestPass2024' \
 		-v mssql-test-data:/var/opt/mssql \
 		-p 1433:1433 \
 		mcr.microsoft.com/mssql/server:2022-latest
@@ -117,6 +128,14 @@ mysql-test-up:
 		-v mysql-test-data:/var/lib/mysql \
 		-p 3306:3306 \
 		mysql:8.0
+
+test-dbs-wait:
+	@echo "Waiting for PostgreSQL..."
+	@i=0; while [ $$i -lt 90 ]; do docker exec pg-test pg_isready -U postgres >/dev/null 2>&1 && exit 0; i=$$((i + 1)); sleep 2; done; docker logs pg-test; exit 1
+	@echo "Waiting for SQL Server..."
+	@i=0; while [ $$i -lt 90 ]; do docker exec mssql-test /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'TestPass2024' -C -Q "SELECT 1" >/dev/null 2>&1 && exit 0; i=$$((i + 1)); sleep 2; done; docker logs mssql-test; exit 1
+	@echo "Waiting for MySQL..."
+	@i=0; while [ $$i -lt 90 ]; do docker exec mysql-test mysqladmin ping -uroot -pTestPass2024 --silent >/dev/null 2>&1 && exit 0; i=$$((i + 1)); sleep 2; done; docker logs mysql-test; exit 1
 
 mysql-test-down:
 	docker rm -f mysql-test 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ test-dbs-wait:
 	@echo "Waiting for SQL Server..."
 	@i=0; while [ $$i -lt 90 ]; do docker exec mssql-test /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'TestPass2024' -C -Q "SELECT 1" >/dev/null 2>&1 && exit 0; i=$$((i + 1)); sleep 2; done; docker logs mssql-test; exit 1
 	@echo "Waiting for MySQL..."
-	@i=0; while [ $$i -lt 90 ]; do docker exec mysql-test mysqladmin ping -uroot -pTestPass2024 --silent >/dev/null 2>&1 && exit 0; i=$$((i + 1)); sleep 2; done; docker logs mysql-test; exit 1
+	@i=0; while [ $$i -lt 90 ]; do docker exec mysql-test mysql -uroot -pTestPass2024 -e "SELECT 1" >/dev/null 2>&1 && exit 0; i=$$((i + 1)); sleep 2; done; docker logs mysql-test; exit 1
 
 mysql-test-down:
 	docker rm -f mysql-test 2>/dev/null || true

--- a/docs/live-acceptance.md
+++ b/docs/live-acceptance.md
@@ -45,14 +45,19 @@ Artifact:
 
 ## CRM Matrix Gate
 
-This gate exercises each supported engine at least once as a source and once as
-a target:
+This gate exercises every supported source-to-target permutation:
 
 | Case | Source | Target |
 |------|--------|--------|
+| `mssql-to-mssql` | SQL Server | SQL Server |
 | `mssql-to-postgres` | SQL Server | PostgreSQL |
+| `mssql-to-mysql` | SQL Server | MySQL |
+| `postgres-to-mssql` | PostgreSQL | SQL Server |
+| `postgres-to-postgres` | PostgreSQL | PostgreSQL |
 | `postgres-to-mysql` | PostgreSQL | MySQL |
 | `mysql-to-mssql` | MySQL | SQL Server |
+| `mysql-to-postgres` | MySQL | PostgreSQL |
+| `mysql-to-mysql` | MySQL | MySQL |
 
 Start local disposable services:
 
@@ -61,11 +66,15 @@ make test-dbs-up
 make mysql-test-up
 ```
 
-Load the CRM fixtures from `testdata/crm/README.md`, then run:
+Load the CRM fixtures, then run:
 
 ```bash
+make test-dbs-wait
+make test-crm-fixtures-load
 make test-crm-acceptance
 ```
+
+`make test-crm-ci` runs the same sequence from a clean Docker environment.
 
 The Go acceptance harness verifies table presence plus columns, max length,
 precision/scale, nullability, identity, timezone class, default-expression
@@ -75,7 +84,7 @@ review. Computed-column expression and storage-class equivalence is not a v1
 release claim; the legacy shell helper remains a smoke tool for the SQL Server
 to PostgreSQL path.
 
-Manual CLI configs for the same three paths live in `testdata/crm/configs/`.
+Manual CLI configs for representative paths live in `testdata/crm/configs/`.
 
 Artifact:
 

--- a/internal/driver/verify_compare.go
+++ b/internal/driver/verify_compare.go
@@ -479,7 +479,7 @@ func cmpDefaultClass(src, tgt Column, srcDialect, tgtDialect string) *ColumnDelt
 	}
 	srcClass := defaultExpressionClassForColumn(src.DefaultExpression, src, srcDialect)
 	tgtClass := defaultExpressionClassForColumn(tgt.DefaultExpression, tgt, tgtDialect)
-	if srcClass == tgtClass {
+	if srcClass == tgtClass || structuredEmptyDefaultEquivalent(srcClass, tgtClass, src, tgt, srcDialect, tgtDialect) {
 		return nil
 	}
 	return &ColumnDelta{
@@ -506,6 +506,38 @@ func defaultExpressionClassForColumn(expr string, col Column, dialect string) st
 		return "empty_array"
 	}
 	return defaultExpressionClass(expr)
+}
+
+func structuredEmptyDefaultEquivalent(srcClass, tgtClass string, src, tgt Column, srcDialect, tgtDialect string) bool {
+	if !isMSSQLDialect(tgtDialect) || !isTextStorageType(tgt.DataType) {
+		return false
+	}
+	switch srcClass {
+	case "empty_json_object":
+		return dataTypeClass(srcDialect, src) == "json" && tgtClass == "constant'{}'"
+	case "empty_array":
+		return isArrayType(src.DataType) && (tgtClass == "constant'{}'" || tgtClass == "constant'[]'")
+	default:
+		return false
+	}
+}
+
+func isMSSQLDialect(dialect string) bool {
+	switch strings.ToLower(strings.TrimSpace(dialect)) {
+	case "mssql", "sqlserver", "sql_server":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTextStorageType(dt string) bool {
+	switch strings.ToLower(strings.TrimSpace(dt)) {
+	case "char", "nchar", "varchar", "nvarchar", "text", "ntext", "xml":
+		return true
+	default:
+		return false
+	}
 }
 
 func normalizedDefaultLiteral(expr string) string {

--- a/internal/driver/verify_compare_test.go
+++ b/internal/driver/verify_compare_test.go
@@ -305,6 +305,20 @@ func TestCompareColumns_DefaultClassColumnAware(t *testing.T) {
 			srcDialect: "postgres",
 			tgtDialect: "mysql",
 		},
+		{
+			name:       "postgres empty json object default serializes to mssql text storage",
+			src:        Column{Name: "settings", DataType: "jsonb", DefaultExpression: "'{}'::jsonb"},
+			tgt:        Column{Name: "settings", DataType: "nvarchar", MaxLength: -1, DefaultExpression: "('{}')"},
+			srcDialect: "postgres",
+			tgtDialect: "mssql",
+		},
+		{
+			name:       "postgres empty array default serializes to mssql text storage",
+			src:        Column{Name: "skills", DataType: "text[]", DefaultExpression: "'{}'::text[]"},
+			tgt:        Column{Name: "skills", DataType: "nvarchar", MaxLength: -1, DefaultExpression: "('{}')"},
+			srcDialect: "postgres",
+			tgtDialect: "mssql",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/orchestrator/crm_acceptance_test.go
+++ b/internal/orchestrator/crm_acceptance_test.go
@@ -106,81 +106,110 @@ func TestCRM_DeterministicAcceptanceMatrix(t *testing.T) {
 
 func crmAcceptanceCases(t *testing.T) []crmAcceptanceCase {
 	t.Helper()
-	return []crmAcceptanceCase{
-		{
-			Name: "mssql-to-postgres",
-			Source: config.SourceConfig{
-				Type:            "mssql",
-				Host:            env("CRM_MSSQL_HOST", "localhost"),
-				Port:            envInt(t, "CRM_MSSQL_PORT", 1433),
-				Database:        env("CRM_MSSQL_DB", "CRM_MSSQL"),
-				User:            env("CRM_MSSQL_USER", "sa"),
-				Password:        env("CRM_MSSQL_PASS", "TestPass2024"),
-				Schema:          env("CRM_MSSQL_SCHEMA", "dbo"),
-				TrustServerCert: true,
-			},
-			Target: config.TargetConfig{
-				Type:     "postgres",
-				Host:     env("CRM_PG_HOST", "localhost"),
-				Port:     envInt(t, "CRM_PG_PORT", 5432),
-				Database: env("CRM_PG_TARGET_DB", "postgres"),
-				User:     env("CRM_PG_USER", "postgres"),
-				Password: env("CRM_PG_PASS", "TestPass2024"),
-				Schema:   env("CRM_PG_TARGET_SCHEMA", "crm_accept_mssql_to_postgres"),
-				SSLMode:  "disable",
-			},
-			SourceType: "mssql",
-			TargetType: "postgres",
-		},
-		{
-			Name: "postgres-to-mysql",
-			Source: config.SourceConfig{
-				Type:     "postgres",
-				Host:     env("CRM_PG_HOST", "localhost"),
-				Port:     envInt(t, "CRM_PG_PORT", 5432),
-				Database: env("CRM_PG_DB", "crm_pg"),
-				User:     env("CRM_PG_USER", "postgres"),
-				Password: env("CRM_PG_PASS", "TestPass2024"),
-				Schema:   env("CRM_PG_SCHEMA", "public"),
-				SSLMode:  "disable",
-			},
-			Target: config.TargetConfig{
-				Type:     "mysql",
-				Host:     env("CRM_MYSQL_HOST", "localhost"),
-				Port:     envInt(t, "CRM_MYSQL_PORT", 3306),
-				Database: env("CRM_MYSQL_ADMIN_DB", "mysql"),
-				User:     env("CRM_MYSQL_USER", "root"),
-				Password: env("CRM_MYSQL_PASS", "TestPass2024"),
-				Schema:   env("CRM_MYSQL_TARGET_SCHEMA", "crm_accept_postgres_to_mysql"),
-			},
-			SourceType: "postgres",
-			TargetType: "mysql",
-		},
-		{
-			Name: "mysql-to-mssql",
-			Source: config.SourceConfig{
-				Type:     "mysql",
-				Host:     env("CRM_MYSQL_HOST", "localhost"),
-				Port:     envInt(t, "CRM_MYSQL_PORT", 3306),
-				Database: env("CRM_MYSQL_DB", "crm_mysql"),
-				User:     env("CRM_MYSQL_USER", "root"),
-				Password: env("CRM_MYSQL_PASS", "TestPass2024"),
-				Schema:   env("CRM_MYSQL_SCHEMA", "crm_mysql"),
-			},
-			Target: config.TargetConfig{
-				Type:            "mssql",
-				Host:            env("CRM_MSSQL_HOST", "localhost"),
-				Port:            envInt(t, "CRM_MSSQL_PORT", 1433),
-				Database:        env("CRM_MSSQL_TARGET_DB", "tempdb"),
-				User:            env("CRM_MSSQL_USER", "sa"),
-				Password:        env("CRM_MSSQL_PASS", "TestPass2024"),
-				Schema:          env("CRM_MSSQL_TARGET_SCHEMA", "crm_accept_mysql_to_mssql"),
-				TrustServerCert: true,
-			},
-			SourceType: "mysql",
-			TargetType: "mssql",
-		},
+
+	dialects := []string{"mssql", "postgres", "mysql"}
+	cases := make([]crmAcceptanceCase, 0, len(dialects)*len(dialects))
+	for _, sourceType := range dialects {
+		for _, targetType := range dialects {
+			name := sourceType + "-to-" + targetType
+			cases = append(cases, crmAcceptanceCase{
+				Name:       name,
+				Source:     crmSourceConfig(t, sourceType),
+				Target:     crmTargetConfig(t, targetType, name),
+				SourceType: sourceType,
+				TargetType: targetType,
+			})
+		}
 	}
+	return cases
+}
+
+func crmSourceConfig(t *testing.T, dialect string) config.SourceConfig {
+	t.Helper()
+	switch dialect {
+	case "mssql":
+		return config.SourceConfig{
+			Type:            "mssql",
+			Host:            env("CRM_MSSQL_HOST", "localhost"),
+			Port:            envInt(t, "CRM_MSSQL_PORT", 1433),
+			Database:        env("CRM_MSSQL_DB", "CRM_MSSQL"),
+			User:            env("CRM_MSSQL_USER", "sa"),
+			Password:        env("CRM_MSSQL_PASS", "TestPass2024"),
+			Schema:          env("CRM_MSSQL_SCHEMA", "dbo"),
+			TrustServerCert: true,
+		}
+	case "postgres":
+		return config.SourceConfig{
+			Type:     "postgres",
+			Host:     env("CRM_PG_HOST", "localhost"),
+			Port:     envInt(t, "CRM_PG_PORT", 5432),
+			Database: env("CRM_PG_DB", "crm_pg"),
+			User:     env("CRM_PG_USER", "postgres"),
+			Password: env("CRM_PG_PASS", "TestPass2024"),
+			Schema:   env("CRM_PG_SCHEMA", "public"),
+			SSLMode:  "disable",
+		}
+	case "mysql":
+		return config.SourceConfig{
+			Type:     "mysql",
+			Host:     env("CRM_MYSQL_HOST", "localhost"),
+			Port:     envInt(t, "CRM_MYSQL_PORT", 3306),
+			Database: env("CRM_MYSQL_DB", "crm_mysql"),
+			User:     env("CRM_MYSQL_USER", "root"),
+			Password: env("CRM_MYSQL_PASS", "TestPass2024"),
+			Schema:   env("CRM_MYSQL_SCHEMA", "crm_mysql"),
+		}
+	default:
+		t.Fatalf("unsupported CRM source dialect %q", dialect)
+		return config.SourceConfig{}
+	}
+}
+
+func crmTargetConfig(t *testing.T, dialect, caseName string) config.TargetConfig {
+	t.Helper()
+	schema := crmTargetSchema(caseName)
+	switch dialect {
+	case "mssql":
+		return config.TargetConfig{
+			Type:            "mssql",
+			Host:            env("CRM_MSSQL_HOST", "localhost"),
+			Port:            envInt(t, "CRM_MSSQL_PORT", 1433),
+			Database:        env("CRM_MSSQL_TARGET_DB", "tempdb"),
+			User:            env("CRM_MSSQL_USER", "sa"),
+			Password:        env("CRM_MSSQL_PASS", "TestPass2024"),
+			Schema:          schema,
+			TrustServerCert: true,
+		}
+	case "postgres":
+		return config.TargetConfig{
+			Type:     "postgres",
+			Host:     env("CRM_PG_HOST", "localhost"),
+			Port:     envInt(t, "CRM_PG_PORT", 5432),
+			Database: env("CRM_PG_TARGET_DB", "postgres"),
+			User:     env("CRM_PG_USER", "postgres"),
+			Password: env("CRM_PG_PASS", "TestPass2024"),
+			Schema:   schema,
+			SSLMode:  "disable",
+		}
+	case "mysql":
+		return config.TargetConfig{
+			Type:     "mysql",
+			Host:     env("CRM_MYSQL_HOST", "localhost"),
+			Port:     envInt(t, "CRM_MYSQL_PORT", 3306),
+			Database: env("CRM_MYSQL_ADMIN_DB", "mysql"),
+			User:     env("CRM_MYSQL_USER", "root"),
+			Password: env("CRM_MYSQL_PASS", "TestPass2024"),
+			Schema:   schema,
+		}
+	default:
+		t.Fatalf("unsupported CRM target dialect %q", dialect)
+		return config.TargetConfig{}
+	}
+}
+
+func crmTargetSchema(caseName string) string {
+	envName := "CRM_" + strings.ToUpper(strings.ReplaceAll(caseName, "-", "_")) + "_TARGET_SCHEMA"
+	return env(envName, "crm_accept_"+strings.ReplaceAll(caseName, "-", "_"))
 }
 
 func cleanCRMTarget(t *testing.T, ctx context.Context, cfg *config.Config) {

--- a/testdata/crm/README.md
+++ b/testdata/crm/README.md
@@ -73,16 +73,33 @@ docker exec mysql-test sh -c "mysql -uroot -pTestPass2024 crm_mysql < /tmp/crm_m
 The integration-test docker containers are started by `make test-dbs-up` (postgres + mssql)
 and `make mysql-test-up` (mysql).
 
-## Migration permutation matrix
+## Migration Permutation Matrix
 
-The v1 release gate uses three representative paths so every supported engine is
-exercised at least once as a source and once as a target:
+The CRM acceptance gate runs all nine supported source-to-target permutations:
+
+| Case | Source | Target |
+|------|--------|--------|
+| `mssql-to-mssql` | SQL Server | SQL Server |
+| `mssql-to-postgres` | SQL Server | PostgreSQL |
+| `mssql-to-mysql` | SQL Server | MySQL |
+| `postgres-to-mssql` | PostgreSQL | SQL Server |
+| `postgres-to-postgres` | PostgreSQL | PostgreSQL |
+| `postgres-to-mysql` | PostgreSQL | MySQL |
+| `mysql-to-mssql` | MySQL | SQL Server |
+| `mysql-to-postgres` | MySQL | PostgreSQL |
+| `mysql-to-mysql` | MySQL | MySQL |
 
 ```bash
+make test-dbs-wait
+make test-crm-fixtures-load
 make test-crm-acceptance
 ```
 
-The committed manual configs live under `testdata/crm/configs/`:
+From a clean Docker environment, `make test-crm-ci` starts the containers,
+waits for readiness, loads the fixtures, and runs the same matrix.
+
+The committed manual configs for representative paths live under
+`testdata/crm/configs/`:
 
 - `mssql-to-postgres.yaml`
 - `postgres-to-mysql.yaml`


### PR DESCRIPTION
## Summary

- Expand the CRM deterministic acceptance test from three representative paths to all nine supported source-to-target permutations across SQL Server, PostgreSQL, and MySQL.
- Add reusable make targets to wait for test DBs, load the CRM fixtures, and run the CRM matrix in CI.
- Add a GitHub Actions CRM Fixture Matrix job that starts the three database containers, loads fixtures, runs the matrix, and uploads the JSON report.
- Tighten the default comparator for PostgreSQL empty JSON/array defaults serialized into MSSQL text storage.
- Update CRM acceptance documentation and the changelog.

## Validation

- `git diff --check`
- `go test ./... -count=1`
- `make lint`
- `go test ./internal/driver ./internal/orchestrator -count=1`
- Full local nine-pair CRM matrix against temporary Docker containers on alternate ports: `CRM_MSSQL_PORT=11433 CRM_PG_PORT=15432 CRM_MYSQL_PORT=13306 make test-crm-acceptance`

Note: local `actionlint` is not installed, so workflow validation is deferred to GitHub Actions.