### PR TITLE
Wire up snapshot-to-snapshot diff as sync --against snapshot (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - **Snapshot-mode sync** ([#167]) — `smt sync --against snapshot` diffs the
-  current source schema against the latest stored snapshot (the pre-#143
-  offline workflow, now an explicit mode) and renders deterministic ALTERs
-  with the same risk gating as the default live-target mode. Planning opens
-  no target connection; `--apply` does. `--against target` remains the
-  default and is unchanged.
+  current source schema against the latest stored snapshot (the offline
+  question the pre-#143 sync answered, now an explicit mode with scope
+  filtering, create_* object-kind gating, plan summary, and
+  unsupported-change refusal) and renders deterministic ALTERs with the same
+  risk gating as the default live-target mode. Planning opens no target
+  connection; `--apply` does. `--against target` remains the default and is
+  unchanged. Fixed in passing: `Diff.Normalize` / `Diff.WithTargetSchema`
+  mutated table data shared with the caller's snapshot through slice backing
+  arrays — both now deep-copy, so `--apply --save-snapshot` persists a clean
+  baseline.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Snapshot-mode sync** ([#167]) — `smt sync --against snapshot` diffs the
+  current source schema against the latest stored snapshot (the pre-#143
+  offline workflow, now an explicit mode) and renders deterministic ALTERs
+  with the same risk gating as the default live-target mode. Planning opens
+  no target connection; `--apply` does. `--against target` remains the
+  default and is unchanged.
+
 ### Changed
 
 - Documented the published v1.0.0 release status, artifact list, CI status,
@@ -240,6 +249,7 @@ history since v0.9.0:
 [0.12.1]: https://github.com/johndauphine/smt/releases/tag/v0.12.1
 [0.12.0]: https://github.com/johndauphine/smt/releases/tag/v0.12.0
 [0.11.0]: https://github.com/johndauphine/smt/releases/tag/v0.11.0
+[#167]: https://github.com/johndauphine/smt/issues/167
 [#141]: https://github.com/johndauphine/smt/issues/141
 [#160]: https://github.com/johndauphine/smt/issues/160
 [#121]: https://github.com/johndauphine/smt/issues/121

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ make build
 ./smt create --apply                # execute DDL against the configured target
 ./smt snapshot                      # capture source schema as a baseline
 # ...time passes, source schema evolves...
-./smt sync                          # diff vs snapshot, render ALTERs to migration.sql
+./smt sync                          # diff source vs live target, render ALTERs to migration.sql
+./smt sync --against snapshot       # diff source vs last snapshot instead (offline planning)
 ./smt sync --apply                  # execute the ALTERs against the target
 ```
 
@@ -44,7 +45,8 @@ Run `./smt` with no arguments to launch the TUI. See `./smt --help` for command 
 | `smt create --apply` | also execute the generated DDL against the configured target |
 | `smt snapshot` | save the current source schema as a baseline for future diffing |
 | `smt snapshot list` | list stored snapshots (id, source, schema, table count, captured-at); `--limit N` |
-| `smt sync` | diff source against last snapshot; generate target-dialect SQL; emit to `migration.sql` for review |
+| `smt sync` | diff source against the live target schema; generate target-dialect SQL; emit to `migration.sql` for review |
+| `smt sync --against snapshot` | diff source against the latest stored snapshot instead — planning is fully offline (no target connection) |
 | `smt sync --apply` | also execute the generated SQL against the target |
 | `smt sync --apply --allow-data-loss` | permit column/table drops |
 | `smt sync --apply --save-snapshot` | save the new schema as the next baseline after success |
@@ -115,10 +117,17 @@ SMT's core schema path is deterministic: introspect schemas, map types, compute 
 
 ## How `sync` works
 
+`smt sync` extracts the current source schema and diffs it against a baseline selected with `--against`:
+
+- `--against target` (default): introspect the live target schema and diff desired-vs-existing — "how does my target differ from what the source says it should be?" Requires a target connection.
+- `--against snapshot`: load the latest stored snapshot (captured with `smt snapshot`) and diff current-vs-baseline — "what changed in my source since the last baseline?" Planning is fully offline; a target connection is only opened for `--apply`.
+
+Either way:
+
 1. `smt snapshot` extracts the current source schema (tables + columns + indexes + FKs + check constraints) and stores the JSON in the SQLite state DB at `~/.smt/state.db`.
-2. `smt sync` extracts the current source schema again, loads the latest snapshot, and computes a structural diff (added / removed / changed tables and per-table column/index/FK/check deltas).
+2. `smt sync` computes a structural diff (added / removed / changed tables and per-table column/index/FK/check deltas) against the chosen baseline.
 3. SMT renders a target-dialect plan locally using deterministic rules.
-4. By default the SQL is written to `migration.sql` for review and no target connection is opened. With `--apply` the statements are executed against the target in order. `data-loss-risk` statements (column drops, table drops) are refused unless `--allow-data-loss` is also passed.
+4. By default the SQL is written to `migration.sql` for review. With `--apply` the statements are executed against the target in order. `data-loss-risk` statements (column drops, table drops) are refused unless `--allow-data-loss` is also passed.
 
 The stable v1 sync support and refusal behavior is documented in [docs/sync-contract.md](docs/sync-contract.md).
 Apply failure and rerun behavior for `create --apply` and `sync --apply` is

--- a/cmd/smt/sync.go
+++ b/cmd/smt/sync.go
@@ -297,6 +297,9 @@ func runSyncAgainstTarget(c *cli.Context) error {
 // as deterministic target-dialect ALTERs. The target connection is opened
 // only when --apply is set.
 func runSyncAgainstSnapshot(c *cli.Context) error {
+	if c.String("state-file") != "" {
+		return fmt.Errorf("sync --against snapshot requires the SQLite state backend; it is not available with --state-file")
+	}
 	cfg, profileName, configPath, err := loadConfig(c)
 	if err != nil {
 		return err
@@ -344,6 +347,11 @@ func runSyncAgainstSnapshot(c *cli.Context) error {
 
 	diff, plan, err := buildSnapshotSyncPlan(prevSnap, currSnap, cfg)
 	if err != nil {
+		// Surface what changed even when rendering fails, so the operator
+		// knows which delta the renderer could not express.
+		if !diff.IsEmpty() {
+			fmt.Printf("Diff since snapshot (%s): %s\n", prevSnap.CapturedAt.Format(time.RFC3339), diff.Summary())
+		}
 		return err
 	}
 	if diff.IsEmpty() {
@@ -361,17 +369,25 @@ func runSyncAgainstSnapshot(c *cli.Context) error {
 
 // buildSnapshotSyncPlan computes the offline snapshot-to-snapshot diff and
 // renders it as a deterministic target-dialect ALTER plan. The migration
-// include/exclude scope applies to both snapshots; the diff runs on
+// include/exclude scope applies to both snapshots and unmanaged object kinds
+// (create_indexes / create_foreign_keys / create_check_constraints) are
+// dropped, matching the live-target mode's gating; the diff runs on
 // source-side names, then identifiers and schema references are rewritten
 // to the target convention before rendering (same order Normalize's and
-// WithTargetSchema's contracts require). Pure — no database or state I/O —
-// which is what keeps snapshot-mode planning offline.
+// WithTargetSchema's contracts require). Pure — no database or state I/O,
+// no mutation of either snapshot — which is what keeps snapshot-mode
+// planning offline and the caller's snapshot safe to persist as the next
+// baseline.
 func buildSnapshotSyncPlan(prev, curr schemadiff.Snapshot, cfg *config.Config) (schemadiff.Diff, schemadiff.Plan, error) {
 	include, exclude := cfg.Migration.IncludeTables, cfg.Migration.ExcludeTables
 	prev.Tables = filterDesiredScope(prev.Tables, include, exclude)
 	curr.Tables = filterDesiredScope(curr.Tables, include, exclude)
 
-	diff := schemadiff.Compute(prev, curr)
+	diff := schemadiff.Compute(prev, curr).FilterManagedKinds(
+		cfg.Migration.CreateIndexes,
+		cfg.Migration.CreateForeignKeys,
+		cfg.Migration.CreateCheckConstraints,
+	)
 	if diff.IsEmpty() {
 		return diff, schemadiff.Plan{}, nil
 	}

--- a/cmd/smt/sync.go
+++ b/cmd/smt/sync.go
@@ -5,9 +5,16 @@ package main
 // snapshot: extract the current source schema and store it in the SMT state DB
 //   as a source-schema baseline/history artifact.
 //
-// sync: extract the current source schema, introspect the live target schema,
-//   render the structural diff as ALTER statements, and either write the SQL
-//   to a file (default) or apply it against the target (--apply).
+// sync: extract the current source schema, diff it against a baseline, render
+//   the structural diff as ALTER statements, and either write the SQL to a
+//   file (default) or apply it against the target (--apply). The baseline is
+//   selected with --against:
+//     --against target   (default) introspect the live target schema and diff
+//                        desired-vs-existing (needs a target connection).
+//     --against snapshot diff against the latest stored source snapshot —
+//                        "what changed in my source since the last baseline?"
+//                        Fully offline for planning; a target connection is
+//                        only opened for --apply.
 
 import (
 	"context"
@@ -158,8 +165,9 @@ func runSnapshot(c *cli.Context) error {
 func syncCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "sync",
-		Usage: "Diff source schema against the live target and (optionally) apply ALTERs",
+		Usage: "Diff source schema against the live target (or the latest snapshot) and (optionally) apply ALTERs",
 		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "against", Value: "target", Usage: "Baseline to diff against: 'target' (introspect the live target) or 'snapshot' (latest stored snapshot; offline planning)"},
 			&cli.BoolFlag{Name: "apply", Usage: "Execute ALTERs against the target (default: emit SQL for review)"},
 			&cli.StringFlag{Name: "out", Aliases: []string{"o"}, Value: "migration.sql", Usage: "Output file when not applying"},
 			&cli.BoolFlag{Name: "allow-data-loss", Usage: "Permit data-loss-risk statements (column drops, table drops) when applying"},
@@ -170,6 +178,17 @@ func syncCommand() *cli.Command {
 }
 
 func runSync(c *cli.Context) error {
+	switch strings.ToLower(strings.TrimSpace(c.String("against"))) {
+	case "", "target":
+		return runSyncAgainstTarget(c)
+	case "snapshot":
+		return runSyncAgainstSnapshot(c)
+	default:
+		return fmt.Errorf("invalid --against value %q (expected 'target' or 'snapshot')", c.String("against"))
+	}
+}
+
+func runSyncAgainstTarget(c *cli.Context) error {
 	cfg, profileName, configPath, err := loadConfig(c)
 	if err != nil {
 		return err
@@ -270,6 +289,114 @@ func runSync(c *cli.Context) error {
 		fmt.Println("Renderer returned no statements; nothing to apply.")
 		return nil
 	}
+	return finishSyncPlan(c, ctx, orch, plan, state, currSnap)
+}
+
+// runSyncAgainstSnapshot diffs the current source schema against the latest
+// stored snapshot (offline — no target introspection) and renders the delta
+// as deterministic target-dialect ALTERs. The target connection is opened
+// only when --apply is set.
+func runSyncAgainstSnapshot(c *cli.Context) error {
+	cfg, profileName, configPath, err := loadConfig(c)
+	if err != nil {
+		return err
+	}
+
+	apply := c.Bool("apply")
+	orch, err := orchestrator.NewWithOptions(cfg, orchestrator.Options{
+		StateFile:  c.String("state-file"),
+		SourceOnly: !apply,
+	})
+	if err != nil {
+		return err
+	}
+	defer orch.Close()
+	orch.SetRunContext(profileName, configPath)
+
+	state, ok := orch.State().(*checkpoint.State)
+	if !ok {
+		return fmt.Errorf("sync --against snapshot requires the SQLite state backend; it is not available with --state-file")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	prevSnap, err := loadPreviousSnapshot(state, cfg.Source.Type, cfg.Source.Schema)
+	if err != nil {
+		return err
+	}
+
+	logging.Info("extracting current source schema")
+	currTables, err := orch.Source().ExtractSchema(ctx, cfg.Source.Schema)
+	if err != nil {
+		return fmt.Errorf("extracting current schema: %w", err)
+	}
+	if err := loadAllConstraints(ctx, orch.Source(), currTables); err != nil {
+		return err
+	}
+	currSnap := schemadiff.Snapshot{
+		Version:    schemadiff.CurrentSnapshotVersion,
+		Schema:     cfg.Source.Schema,
+		SourceType: cfg.Source.Type,
+		CapturedAt: time.Now().UTC(),
+		Tables:     currTables,
+	}
+
+	diff, plan, err := buildSnapshotSyncPlan(prevSnap, currSnap, cfg)
+	if err != nil {
+		return err
+	}
+	if diff.IsEmpty() {
+		fmt.Printf("No schema changes since the last snapshot (captured %s).\n",
+			prevSnap.CapturedAt.Format(time.RFC3339))
+		return nil
+	}
+	fmt.Printf("Diff since snapshot (%s): %s\n", prevSnap.CapturedAt.Format(time.RFC3339), diff.Summary())
+	if plan.IsEmpty() {
+		fmt.Println("Renderer returned no statements; nothing to apply.")
+		return nil
+	}
+	return finishSyncPlan(c, ctx, orch, plan, state, currSnap)
+}
+
+// buildSnapshotSyncPlan computes the offline snapshot-to-snapshot diff and
+// renders it as a deterministic target-dialect ALTER plan. The migration
+// include/exclude scope applies to both snapshots; the diff runs on
+// source-side names, then identifiers and schema references are rewritten
+// to the target convention before rendering (same order Normalize's and
+// WithTargetSchema's contracts require). Pure — no database or state I/O —
+// which is what keeps snapshot-mode planning offline.
+func buildSnapshotSyncPlan(prev, curr schemadiff.Snapshot, cfg *config.Config) (schemadiff.Diff, schemadiff.Plan, error) {
+	include, exclude := cfg.Migration.IncludeTables, cfg.Migration.ExcludeTables
+	prev.Tables = filterDesiredScope(prev.Tables, include, exclude)
+	curr.Tables = filterDesiredScope(curr.Tables, include, exclude)
+
+	diff := schemadiff.Compute(prev, curr)
+	if diff.IsEmpty() {
+		return diff, schemadiff.Plan{}, nil
+	}
+
+	sourceDialect := driver.Canonicalize(cfg.Source.Type)
+	targetDialect := driver.Canonicalize(cfg.Target.Type)
+	norm := func(name string) string { return driver.NormalizeIdentifier(targetDialect, name) }
+	rendered := diff.Normalize(norm).WithTargetSchema(cfg.Target.Schema)
+
+	plan, err := schemadiff.RenderDeterministicWithOptions(rendered, schemadiff.RenderOptions{
+		TargetSchema:      cfg.Target.Schema,
+		TargetDialect:     targetDialect,
+		SourceDialect:     sourceDialect,
+		UnknownTypePolicy: cfg.SchemaGeneration.UnknownTypePolicy,
+	})
+	if err != nil {
+		return diff, schemadiff.Plan{}, err
+	}
+	return diff, plan, nil
+}
+
+// finishSyncPlan is the shared tail of both sync modes: write the plan to
+// --out for review, or gate (unsupported changes, data-loss risk) and apply
+// it against the target, optionally saving the new baseline snapshot.
+func finishSyncPlan(c *cli.Context, ctx context.Context, orch *orchestrator.Orchestrator, plan schemadiff.Plan, state *checkpoint.State, currSnap schemadiff.Snapshot) error {
 	printPlanSummary(plan)
 
 	if !c.Bool("apply") {
@@ -287,13 +414,8 @@ func runSync(c *cli.Context) error {
 		return fmt.Errorf("refusing to apply plan with unsupported change(s)")
 	}
 
-	if !c.Bool("allow-data-loss") {
-		filtered := plan.FilterByRisk(schemadiff.RiskRebuildNeeded)
-		if len(filtered.Statements) < len(plan.Statements) {
-			fmt.Printf("Refusing to apply %d data-loss-risk statement(s) without --allow-data-loss.\n",
-				len(plan.Statements)-len(filtered.Statements))
-			return fmt.Errorf("aborted")
-		}
+	if err := gatePlanForApply(plan, c.Bool("allow-data-loss")); err != nil {
+		return err
 	}
 
 	if err := applyPlan(ctx, orch.Target(), plan); err != nil {
@@ -312,9 +434,24 @@ func runSync(c *cli.Context) error {
 	return nil
 }
 
+// gatePlanForApply refuses to apply a plan containing data-loss-risk
+// statements unless the operator passed --allow-data-loss.
+func gatePlanForApply(plan schemadiff.Plan, allowDataLoss bool) error {
+	if allowDataLoss {
+		return nil
+	}
+	filtered := plan.FilterByRisk(schemadiff.RiskRebuildNeeded)
+	if len(filtered.Statements) < len(plan.Statements) {
+		fmt.Printf("Refusing to apply %d data-loss-risk statement(s) without --allow-data-loss.\n",
+			len(plan.Statements)-len(filtered.Statements))
+		return fmt.Errorf("aborted")
+	}
+	return nil
+}
+
 // loadPreviousSnapshot returns the most recent stored snapshot for this
-// (sourceType, schema). Kept for snapshot-history callers and tests; live
-// target sync planning does not require a previous snapshot.
+// (sourceType, schema). It is the baseline loader for `sync --against
+// snapshot`; live target sync planning does not require a previous snapshot.
 func loadPreviousSnapshot(state *checkpoint.State, sourceType, schema string) (schemadiff.Snapshot, error) {
 	snapRow, err := state.GetLatestSnapshot(sourceType, schema)
 	if err != nil {

--- a/cmd/smt/sync_test.go
+++ b/cmd/smt/sync_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"smt/internal/checkpoint"
+	"smt/internal/config"
 	"smt/internal/driver"
 	"smt/internal/schemadiff"
 )
@@ -230,6 +231,140 @@ func TestLoadPreviousSnapshot_RoundTrip(t *testing.T) {
 	}
 	if len(got.Tables) != 1 || got.Tables[0].Name != "Users" {
 		t.Errorf("table list not preserved: got %+v", got.Tables)
+	}
+}
+
+// snapshotSyncCfg builds the minimal config buildSnapshotSyncPlan needs:
+// mssql source, postgres target, no scope filters unless set by the test.
+func snapshotSyncCfg() *config.Config {
+	cfg := &config.Config{}
+	cfg.Source.Type = "mssql"
+	cfg.Source.Schema = "dbo"
+	cfg.Target.Type = "postgres"
+	cfg.Target.Schema = "public"
+	cfg.SchemaGeneration.UnknownTypePolicy = "fail"
+	return cfg
+}
+
+func snapshotWith(tables ...driver.Table) schemadiff.Snapshot {
+	return schemadiff.Snapshot{
+		Version:    schemadiff.CurrentSnapshotVersion,
+		Schema:     "dbo",
+		SourceType: "mssql",
+		CapturedAt: time.Now().UTC(),
+		Tables:     tables,
+	}
+}
+
+func TestBuildSnapshotSyncPlan_AddedColumn(t *testing.T) {
+	prev := snapshotWith(driver.Table{
+		Schema:  "dbo",
+		Name:    "Users",
+		Columns: []driver.Column{{Name: "ID", DataType: "int", IsNullable: false}},
+	})
+	curr := snapshotWith(driver.Table{
+		Schema: "dbo",
+		Name:   "Users",
+		Columns: []driver.Column{
+			{Name: "ID", DataType: "int", IsNullable: false},
+			{Name: "Age", DataType: "int", IsNullable: true},
+		},
+	})
+
+	diff, plan, err := buildSnapshotSyncPlan(prev, curr, snapshotSyncCfg())
+	if err != nil {
+		t.Fatalf("expected no err, got %v", err)
+	}
+	if diff.IsEmpty() {
+		t.Fatal("expected a non-empty diff for an added column")
+	}
+	if len(plan.Statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d: %+v", len(plan.Statements), plan.Statements)
+	}
+	sql := plan.Statements[0].SQL
+	// Identifiers must be normalized to the postgres convention and the
+	// schema retargeted, so the ALTER hits the table that exists there.
+	if !strings.Contains(sql, "users") || !strings.Contains(sql, "age") {
+		t.Errorf("statement should reference normalized identifiers, got: %s", sql)
+	}
+	if !strings.Contains(sql, "public") {
+		t.Errorf("statement should be qualified with the target schema, got: %s", sql)
+	}
+	if strings.Contains(sql, "dbo") {
+		t.Errorf("statement must not reference the source schema, got: %s", sql)
+	}
+	if plan.Statements[0].Risk != schemadiff.RiskSafe {
+		t.Errorf("adding a nullable column should be RiskSafe, got %s", plan.Statements[0].Risk)
+	}
+}
+
+func TestBuildSnapshotSyncPlan_NoChanges(t *testing.T) {
+	table := driver.Table{
+		Schema:  "dbo",
+		Name:    "Users",
+		Columns: []driver.Column{{Name: "ID", DataType: "int", IsNullable: false}},
+	}
+	diff, plan, err := buildSnapshotSyncPlan(snapshotWith(table), snapshotWith(table), snapshotSyncCfg())
+	if err != nil {
+		t.Fatalf("expected no err, got %v", err)
+	}
+	if !diff.IsEmpty() {
+		t.Errorf("identical snapshots should diff empty, got: %s", diff.Summary())
+	}
+	if !plan.IsEmpty() {
+		t.Errorf("identical snapshots should render no statements, got %d", len(plan.Statements))
+	}
+}
+
+func TestBuildSnapshotSyncPlan_ExcludedTableIgnored(t *testing.T) {
+	prev := snapshotWith(driver.Table{
+		Schema:  "dbo",
+		Name:    "Audit",
+		Columns: []driver.Column{{Name: "ID", DataType: "int"}},
+	})
+	curr := snapshotWith(driver.Table{
+		Schema: "dbo",
+		Name:   "Audit",
+		Columns: []driver.Column{
+			{Name: "ID", DataType: "int"},
+			{Name: "Extra", DataType: "int", IsNullable: true},
+		},
+	})
+
+	cfg := snapshotSyncCfg()
+	cfg.Migration.ExcludeTables = []string{"Audit"}
+	diff, plan, err := buildSnapshotSyncPlan(prev, curr, cfg)
+	if err != nil {
+		t.Fatalf("expected no err, got %v", err)
+	}
+	if !diff.IsEmpty() {
+		t.Errorf("change in an excluded table should not appear in the diff, got: %s", diff.Summary())
+	}
+	if !plan.IsEmpty() {
+		t.Errorf("excluded table produced statements: %+v", plan.Statements)
+	}
+}
+
+func TestGatePlanForApply_RefusesDataLossWithoutFlag(t *testing.T) {
+	plan := schemadiff.Plan{Statements: []schemadiff.Statement{
+		{SQL: "ALTER TABLE public.users ADD COLUMN age integer", Risk: schemadiff.RiskSafe},
+		{SQL: "DROP TABLE public.audit", Risk: schemadiff.RiskDataLoss},
+	}}
+
+	if err := gatePlanForApply(plan, false); err == nil {
+		t.Fatal("expected data-loss plan to be refused without --allow-data-loss")
+	}
+	if err := gatePlanForApply(plan, true); err != nil {
+		t.Fatalf("expected data-loss plan to pass with --allow-data-loss, got %v", err)
+	}
+}
+
+func TestGatePlanForApply_SafePlanPasses(t *testing.T) {
+	plan := schemadiff.Plan{Statements: []schemadiff.Statement{
+		{SQL: "ALTER TABLE public.users ADD COLUMN age integer", Risk: schemadiff.RiskSafe},
+	}}
+	if err := gatePlanForApply(plan, false); err != nil {
+		t.Fatalf("safe plan should pass the gate, got %v", err)
 	}
 }
 

--- a/cmd/smt/sync_test.go
+++ b/cmd/smt/sync_test.go
@@ -235,7 +235,8 @@ func TestLoadPreviousSnapshot_RoundTrip(t *testing.T) {
 }
 
 // snapshotSyncCfg builds the minimal config buildSnapshotSyncPlan needs:
-// mssql source, postgres target, no scope filters unless set by the test.
+// mssql source, postgres target, all object kinds managed (the loaded-config
+// default), no scope filters unless set by the test.
 func snapshotSyncCfg() *config.Config {
 	cfg := &config.Config{}
 	cfg.Source.Type = "mssql"
@@ -243,6 +244,9 @@ func snapshotSyncCfg() *config.Config {
 	cfg.Target.Type = "postgres"
 	cfg.Target.Schema = "public"
 	cfg.SchemaGeneration.UnknownTypePolicy = "fail"
+	cfg.Migration.CreateIndexes = true
+	cfg.Migration.CreateForeignKeys = true
+	cfg.Migration.CreateCheckConstraints = true
 	return cfg
 }
 
@@ -342,6 +346,75 @@ func TestBuildSnapshotSyncPlan_ExcludedTableIgnored(t *testing.T) {
 	}
 	if !plan.IsEmpty() {
 		t.Errorf("excluded table produced statements: %+v", plan.Statements)
+	}
+}
+
+// buildSnapshotSyncPlan must never mutate its input snapshots: the caller
+// persists currSnap as the next baseline (--apply --save-snapshot), and the
+// diff's tables share slice backing arrays with it. A regression here means
+// the saved baseline carries target-normalized names and the next sync
+// proposes drop+re-add of every column.
+func TestBuildSnapshotSyncPlan_DoesNotMutateInputSnapshots(t *testing.T) {
+	mkSnap := func() schemadiff.Snapshot {
+		return snapshotWith(
+			driver.Table{
+				Schema:     "dbo",
+				Name:       "Users",
+				PrimaryKey: []string{"ID"},
+				Columns:    []driver.Column{{Name: "ID", DataType: "int", IsNullable: false}},
+				Indexes:    []driver.Index{{Name: "IX_Users_ID", Columns: []string{"ID"}}},
+				ForeignKeys: []driver.ForeignKey{{
+					Name: "FK_Users_Orgs", Columns: []string{"OrgID"},
+					RefSchema: "dbo", RefTable: "Orgs", RefColumns: []string{"ID"},
+				}},
+			},
+		)
+	}
+	prev := snapshotWith() // empty baseline: Users becomes an added table
+	curr := mkSnap()
+	want := mkSnap()
+
+	if _, _, err := buildSnapshotSyncPlan(prev, curr, snapshotSyncCfg()); err != nil {
+		t.Fatalf("buildSnapshotSyncPlan: %v", err)
+	}
+
+	// Compare Tables only: CapturedAt differs between the two constructions.
+	got, wantJSON := mustJSON(t, curr.Tables), mustJSON(t, want.Tables)
+	if got != wantJSON {
+		t.Errorf("input snapshot mutated by plan build:\ngot:  %s\nwant: %s", got, wantJSON)
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+// Unmanaged object kinds must not produce statements: create_indexes etc.
+// gate snapshot-mode deltas exactly like the live-target mode.
+func TestBuildSnapshotSyncPlan_UnmanagedKindsGated(t *testing.T) {
+	base := driver.Table{
+		Schema:  "dbo",
+		Name:    "Users",
+		Columns: []driver.Column{{Name: "ID", DataType: "int", IsNullable: false}},
+	}
+	withIndex := base
+	withIndex.Indexes = []driver.Index{{Name: "IX_Users_ID", Columns: []string{"ID"}}}
+
+	cfg := snapshotSyncCfg()
+	cfg.Migration.CreateIndexes = false
+
+	diff, plan, err := buildSnapshotSyncPlan(snapshotWith(base), snapshotWith(withIndex), cfg)
+	if err != nil {
+		t.Fatalf("buildSnapshotSyncPlan: %v", err)
+	}
+	if !diff.IsEmpty() || !plan.IsEmpty() {
+		t.Errorf("index-only change with create_indexes=false should gate to empty; diff=%s statements=%d",
+			diff.Summary(), len(plan.Statements))
 	}
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -97,6 +97,7 @@ change in any 1.x release.
 
 | flag | status | description |
 |---|---|---|
+| `--against` | stable | Baseline to diff against: `target` (default; introspect the live target) or `snapshot` (latest stored snapshot; offline planning, target connection only for `--apply`). |
 | `--apply` | stable | Execute ALTERs against the target. |
 | `--out`, `-o` | stable | Output file when not applying; default `migration.sql`. |
 | `--allow-data-loss` | stable | Permit data-loss-risk statements while applying. |

--- a/docs/sync-contract.md
+++ b/docs/sync-contract.md
@@ -4,6 +4,18 @@
 and the live target schema. The default mode writes `migration.sql` for review.
 `smt sync --apply` executes the plan statement by statement.
 
+This contract describes the default `--against target` mode (live-target
+introspection). `smt sync --against snapshot` diffs the source against the
+latest stored snapshot instead — same renderer, risk labels, and apply
+gating — with these deltas from the target-mode contract:
+
+- the baseline is the stored snapshot, so drift introduced directly on the
+  target is invisible to it (use `--against target` or `smt drift` for that);
+- primary-key and identity changes between snapshots are not detected (the
+  snapshot diff compares columns, indexes, FKs, and checks by name);
+- a computed-column change between snapshots fails the render with an error
+  instead of an `-- [unsupported]` plan entry.
+
 ## Supported Changes
 
 SMT v1 can render these sync changes:

--- a/internal/schemadiff/diff.go
+++ b/internal/schemadiff/diff.go
@@ -156,40 +156,99 @@ func (d Diff) WithTargetSchema(targetSchema string) Diff {
 		Unsupported:    append([]UnsupportedChange(nil), d.Unsupported...),
 	}
 	for _, t := range d.AddedTables {
-		retargetTable(&t, targetSchema)
-		out.AddedTables = append(out.AddedTables, t)
+		out.AddedTables = append(out.AddedTables, retargetTable(t, targetSchema))
 	}
 	for _, t := range d.RemovedTables {
-		retargetTable(&t, targetSchema)
-		out.RemovedTables = append(out.RemovedTables, t)
+		out.RemovedTables = append(out.RemovedTables, retargetTable(t, targetSchema))
 	}
 	for _, td := range d.ChangedTables {
 		td.Schema = targetSchema
-		retargetTable(&td.Curr, targetSchema)
-		retargetForeignKeys(td.AddedForeignKeys, targetSchema)
-		retargetForeignKeys(td.RemovedForeignKeys, targetSchema)
+		td.Curr = retargetTable(td.Curr, targetSchema)
+		td.AddedForeignKeys = retargetForeignKeys(td.AddedForeignKeys, targetSchema)
+		td.RemovedForeignKeys = retargetForeignKeys(td.RemovedForeignKeys, targetSchema)
 		out.ChangedTables = append(out.ChangedTables, td)
 	}
 	return out
 }
 
-// retargetTable rewrites the table's own Schema and the RefSchema on
-// every inline foreign key. Operates in place on the supplied pointer.
-func retargetTable(t *driver.Table, targetSchema string) {
-	t.Schema = targetSchema
-	retargetForeignKeys(t.ForeignKeys, targetSchema)
+// FilterManagedKinds drops index / foreign-key / check deltas — and the
+// corresponding side objects on added tables — for object kinds the
+// migration does not manage, mirroring the create_* gating that `create` and
+// the live-target sync apply. Returns copies; inputs are not mutated.
+func (d Diff) FilterManagedKinds(indexes, fks, checks bool) Diff {
+	if indexes && fks && checks {
+		return d
+	}
+	out := Diff{
+		PrevCapturedAt: d.PrevCapturedAt,
+		CurrCapturedAt: d.CurrCapturedAt,
+		Unsupported:    append([]UnsupportedChange(nil), d.Unsupported...),
+	}
+	strip := func(t driver.Table) driver.Table {
+		if !indexes {
+			t.Indexes = nil
+		}
+		if !fks {
+			t.ForeignKeys = nil
+		}
+		if !checks {
+			t.CheckConstraints = nil
+		}
+		return t
+	}
+	for _, t := range d.AddedTables {
+		out.AddedTables = append(out.AddedTables, strip(t))
+	}
+	for _, t := range d.RemovedTables {
+		out.RemovedTables = append(out.RemovedTables, strip(t))
+	}
+	for _, td := range d.ChangedTables {
+		td.Curr = strip(td.Curr)
+		if !indexes {
+			td.AddedIndexes, td.RemovedIndexes = nil, nil
+		}
+		if !fks {
+			td.AddedForeignKeys, td.RemovedForeignKeys = nil, nil
+		}
+		if !checks {
+			td.AddedChecks, td.RemovedChecks = nil, nil
+		}
+		if !td.IsEmpty() {
+			out.ChangedTables = append(out.ChangedTables, td)
+		}
+	}
+	return out
 }
 
-// retargetForeignKeys rewrites RefSchema on every entry in the supplied
-// slice. Slice elements are mutated directly (FKs are values, not
-// pointers, so a `for _, fk := range` loop would not stick).
-func retargetForeignKeys(fks []driver.ForeignKey, targetSchema string) {
-	for i := range fks {
-		fks[i].RefSchema = targetSchema
+// retargetTable returns a deep copy of the table with its own Schema and the
+// RefSchema of every inline foreign key rewritten. A copy, not in-place: the
+// table's slices share backing arrays with the snapshot the diff came from,
+// which callers persist as the next baseline.
+func retargetTable(t driver.Table, targetSchema string) driver.Table {
+	t = deepCopyTable(t)
+	t.Schema = targetSchema
+	for i := range t.ForeignKeys {
+		t.ForeignKeys[i].RefSchema = targetSchema
 	}
+	return t
+}
+
+// retargetForeignKeys returns a copy of the slice with RefSchema rewritten on
+// every entry (copy for the same aliasing reason as retargetTable).
+func retargetForeignKeys(fks []driver.ForeignKey, targetSchema string) []driver.ForeignKey {
+	out := append([]driver.ForeignKey(nil), fks...)
+	for i := range out {
+		out[i].RefSchema = targetSchema
+	}
+	return out
 }
 
 func normalizeTable(t driver.Table, norm func(string) string) driver.Table {
+	// The in-place rewrites below would otherwise reach through the slice
+	// backing arrays into the caller's tables — Compute's diff shares them
+	// with the snapshot it was built from, and callers persist that snapshot
+	// as the next baseline (sync --save-snapshot).
+	t = deepCopyTable(t)
 	t.Name = norm(t.Name)
 	for i := range t.Columns {
 		t.Columns[i].Name = norm(t.Columns[i].Name)
@@ -244,6 +303,7 @@ func normalizeTableDiff(td TableDiff, norm func(string) string) TableDiff {
 	}
 	for _, idx := range td.AddedIndexes {
 		idx.Name = norm(idx.Name)
+		idx.Columns = append([]string(nil), idx.Columns...)
 		for j := range idx.Columns {
 			idx.Columns[j] = norm(idx.Columns[j])
 		}
@@ -256,9 +316,11 @@ func normalizeTableDiff(td TableDiff, norm func(string) string) TableDiff {
 	for _, fk := range td.AddedForeignKeys {
 		fk.Name = norm(fk.Name)
 		fk.RefTable = norm(fk.RefTable)
+		fk.Columns = append([]string(nil), fk.Columns...)
 		for j := range fk.Columns {
 			fk.Columns[j] = norm(fk.Columns[j])
 		}
+		fk.RefColumns = append([]string(nil), fk.RefColumns...)
 		for j := range fk.RefColumns {
 			fk.RefColumns[j] = norm(fk.RefColumns[j])
 		}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -96,7 +96,7 @@ type commandInfo struct {
 var availableCommands = []commandInfo{
 	{"/init", "Create a config.yaml with a guided wizard"},
 	{"/create", "Generate target DDL from the source"},
-	{"/sync", "Diff source vs snapshot and emit/apply ALTERs"},
+	{"/sync", "Diff source vs target (or snapshot) and emit/apply ALTERs"},
 	{"/snapshot", "Capture current source schema for future diffing"},
 	{"/config", "Show configuration details"},
 	{"/history", "Show migration history"},
@@ -698,7 +698,7 @@ func (m *Model) handleCommand(cmdStr string) tea.Cmd {
   /create --apply         Execute generated DDL against the target
   /create --profile NAME  Generate using a saved profile
   /snapshot [@config]     Capture current source schema for future diffing
-  /sync [@config]         Diff source vs snapshot, emit/apply ALTERs
+  /sync [@config]         Diff source vs target (or --against snapshot), emit/apply ALTERs
   /config [config_file]   Show configuration details
   /history                Show schema-run history
   /profile save NAME      Save an encrypted profile


### PR DESCRIPTION
## Summary

Resolves #167 by exposing the tested-but-unreachable snapshot-to-snapshot diff path as an explicit sync mode.

- **`smt sync --against snapshot`** — diffs the current source schema against the latest stored snapshot (`smt snapshot` baseline) and renders deterministic target-dialect ALTERs. Planning is fully offline: the orchestrator is opened `SourceOnly` unless `--apply` is set, so no target connection is required to produce `migration.sql`.
- **`--against target`** (the #143 live-target diff) remains the default and is byte-for-byte unchanged.
- Both modes share one delivery tail (`finishSyncPlan`): plan summary, `--out` write, unsupported-change refusal, data-loss risk gating (`gatePlanForApply` / `--allow-data-loss`), apply, and `--save-snapshot`.
- The snapshot diff runs on source-side names, then `Diff.Normalize` + `WithTargetSchema` rewrite identifiers/schema references to the target convention before rendering — the exact order those methods' contracts document.
- README's sync docs were stale (still described the pre-#143 snapshot workflow as the only behavior); now documents both modes. CHANGELOG entry added.

## Acceptance criteria from #167

- ✅ A documented CLI path reaches `schemadiff.Compute` + `RenderDeterministicWithOptions` (and `loadPreviousSnapshot` regains a production caller).
- ✅ Snapshot-mode sync produces a deterministic ALTER plan offline and respects risk gating / `--allow-data-loss`.
- ✅ The live-target mode is unchanged and remains the default.
- ✅ Golden tests for the snapshot path stay green (full `-short` suite passes).

## Testing

- New unit tests: `buildSnapshotSyncPlan` (added column renders normalized+retargeted ALTER; identical snapshots are empty; excluded tables are ignored) and `gatePlanForApply` (data-loss refusal without the flag, pass with it, safe plans pass).
- End-to-end against a live postgres source with an **unreachable target host**: baseline snapshot → no-change sync → `ALTER TABLE` + new FK'd table on the source → 3-statement mysql-dialect plan written offline with correct risk labels (safe/blocking) and target-schema qualification.
- `go test ./... -short` clean; `gofmt` clean; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)