### PR TITLE
fix: port DMT bug fixes — sanitizer panic, TUI deadlock/tick, PG identifiers (#186–#189)

### DIFF
--- a/cmd/smt/sync.go
+++ b/cmd/smt/sync.go
@@ -265,6 +265,12 @@ func runSyncAgainstTarget(c *cli.Context) error {
 		allSourceNorm[strings.ToLower(norm(t.Name))] = true
 	}
 	desired := filterDesiredScope(currTables, cfg.Migration.IncludeTables, cfg.Migration.ExcludeTables)
+	// Fail closed on identifier collisions before rendering any ALTER (#189):
+	// on a PostgreSQL target two source names that fold to the same identifier
+	// would drift the target silently.
+	if err := driver.CheckIdentifierCollisions(targetDialect, desired); err != nil {
+		return err
+	}
 	desired = schemadiff.NormalizeIdentifiers(desired, norm)
 	desired = schemadiff.RetargetSchema(desired, cfg.Target.Schema)
 
@@ -420,6 +426,10 @@ func buildSnapshotSyncPlan(prev, curr schemadiff.Snapshot, cfg *config.Config) (
 	sourceDialect := driver.Canonicalize(cfg.Source.Type)
 	targetDialect := driver.Canonicalize(cfg.Target.Type)
 	norm := func(name string) string { return driver.NormalizeIdentifier(targetDialect, name) }
+	// Fail closed on identifier collisions before rendering any DDL (#189).
+	if err := driver.CheckIdentifierCollisions(targetDialect, curr.Tables); err != nil {
+		return diff, schemadiff.Plan{}, err
+	}
 	rendered := diff.Normalize(norm).WithTargetSchema(cfg.Target.Schema)
 
 	plan, err := schemadiff.RenderDeterministicWithOptions(rendered, schemadiff.RenderOptions{

--- a/internal/driver/ai_typemapper.go
+++ b/internal/driver/ai_typemapper.go
@@ -526,7 +526,14 @@ func sanitizeErrorResponse(body []byte, maxLen int) string {
 	keyPatterns := []string{"sk-", "api-", "key-", "secret-", "token-"}
 	for _, pattern := range keyPatterns {
 		for {
-			idx := strings.Index(strings.ToLower(s), pattern)
+			// Search a case-folded copy but slice the original, so fold ONLY
+			// ASCII case — asciiLower preserves byte length. strings.ToLower can
+			// change the byte length of some Unicode runes (e.g. İ -> i̇ shifts
+			// every later index), misaligning these slice offsets: worst case an
+			// out-of-range panic on an ordinary API-error path, lesser case wrong
+			// bytes redacted. The key patterns are ASCII, so ASCII folding still
+			// matches them (#186).
+			idx := strings.Index(asciiLower(s), pattern)
 			if idx == -1 {
 				break
 			}
@@ -539,6 +546,26 @@ func sanitizeErrorResponse(body []byte, maxLen int) string {
 	}
 
 	return s
+}
+
+// asciiLower lowercases only ASCII A-Z, leaving every other byte unchanged so
+// the result has exactly the same byte length as the input — a prerequisite
+// for using its match offsets to slice the original string (#186).
+func asciiLower(s string) string {
+	var b []byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			if b == nil {
+				b = []byte(s)
+			}
+			b[i] = c + ('a' - 'A')
+		}
+	}
+	if b == nil {
+		return s
+	}
+	return string(b)
 }
 
 // isRetryableError determines if an error is transient and should be retried.

--- a/internal/driver/ai_typemapper_test.go
+++ b/internal/driver/ai_typemapper_test.go
@@ -696,6 +696,30 @@ func TestSanitizeErrorResponse(t *testing.T) {
 	}
 }
 
+// TestSanitizeErrorResponse_NonASCII guards #186: the redactor must fold case
+// on a byte-length-preserving copy. A rune whose Unicode lowercase form has a
+// different byte length (İ U+0130 → i̇, 2 bytes → 3) before an embedded key
+// used to shift the match offset past the original string and panic (or redact
+// the wrong bytes).
+func TestSanitizeErrorResponse_NonASCII(t *testing.T) {
+	inputs := []string{
+		"İİİ error: sk-ant-api03-secret",        // length-changing runes before the key
+		"prefix İ İ İ sk-ant-api03-leak suffix", // interleaved
+		"Ⱥ Ⱥ Ⱥ token-abcdefghijklmnop",          // U+023A, another length-changer
+	}
+	for _, in := range inputs {
+		// Must not panic, and must still redact the key.
+		result := sanitizeErrorResponse([]byte(in), 200)
+		if strings.Contains(result, "sk-ant-api03") || strings.Contains(result, "api03") {
+			t.Errorf("sanitizeErrorResponse(%q) = %q, key not redacted", in, result)
+		}
+	}
+	// Case-insensitive match still works after ASCII-only folding.
+	if !strings.Contains(sanitizeErrorResponse([]byte("SK-ANT-API03-SECRET"), 200), "[REDACTED]") {
+		t.Error("uppercase key pattern should still be redacted")
+	}
+}
+
 func TestAITypeMapper_BuildPromptExcludesSampleValues(t *testing.T) {
 	// Sample values are no longer included in prompts (privacy improvement).
 	// This test verifies that even when SampleValues are provided,

--- a/internal/driver/identifiers.go
+++ b/internal/driver/identifiers.go
@@ -18,26 +18,50 @@ package driver
 // Adding a new dialect: extend the switch below.
 
 import (
+	"fmt"
+	"hash/crc32"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
+// pgMaxIdentifierBytes is PostgreSQL's NAMEDATALEN-1: identifiers longer than
+// this are silently truncated by the server, so a name SMT thinks it created
+// would differ from what's on disk. We truncate deterministically instead.
+const pgMaxIdentifierBytes = 63
+
 // NormalizeIdentifier returns the on-disk identifier name for the given
-// target dialect. dbType is the canonical driver name (postgres, mssql,
-// mysql); aliases (pg, sqlserver, mariadb) are normalized via the registry
-// before this is called by callers that already hold a canonical name.
+// target dialect. dbType may be a canonical driver name (postgres, mssql,
+// mysql) or an alias (pg, postgresql, sqlserver, mariadb) — it is canonicalized
+// here so an alias can't bypass PostgreSQL folding (#189).
 func NormalizeIdentifier(dbType, name string) string {
-	switch dbType {
-	case "postgres":
+	if isPostgresDialect(dbType) {
 		return normalizePostgresIdentifier(name)
-	default:
-		return name
 	}
+	return name
 }
 
-// normalizePostgresIdentifier mirrors the historical sanitizePGIdentifier
-// in internal/driver/postgres/writer.go — kept identical so the create
-// and sync paths produce the same names. If you change one, change both.
+// isPostgresDialect reports whether dbType names PostgreSQL — by canonical
+// name or alias. It consults the driver registry first (authoritative, picks
+// up any alias a driver declares) and falls back to the literal alias set so
+// identifier folding is correct even when the registry isn't populated yet
+// (e.g. unit tests of this package, which can't blank-import the engines
+// without an import cycle). Without the fallback an alias like "pg" would
+// silently skip folding (#189).
+func isPostgresDialect(dbType string) bool {
+	if Canonicalize(dbType) == "postgres" {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(dbType)) {
+	case "postgres", "postgresql", "pg":
+		return true
+	}
+	return false
+}
+
+// normalizePostgresIdentifier is the single implementation of PostgreSQL
+// identifier folding; the postgres writer's sanitizePGIdentifier delegates
+// here, so create and sync always produce the same names.
 func normalizePostgresIdentifier(ident string) string {
 	if ident == "" {
 		return "col_"
@@ -58,5 +82,60 @@ func normalizePostgresIdentifier(ident string) string {
 	if s == "" {
 		return "col_"
 	}
+	if len(s) > pgMaxIdentifierBytes {
+		s = truncatePGIdentifier(s)
+	}
 	return s
+}
+
+// truncatePGIdentifier shortens an over-long normalized identifier to fit
+// PostgreSQL's 63-byte limit, appending a hash of the full name so two names
+// sharing a 63-byte prefix don't silently fold onto the same identifier. The
+// hash is over the normalized string, so it's stable across runs. (True
+// distinct-source collisions are caught separately by CheckIdentifierCollisions.)
+func truncatePGIdentifier(s string) string {
+	suffix := fmt.Sprintf("_%08x", crc32.ChecksumIEEE([]byte(s)))
+	keep := pgMaxIdentifierBytes - len(suffix)
+	// Back up to a rune boundary at or below keep bytes so we never split a
+	// multi-byte rune (identifiers may contain Unicode letters).
+	cut := keep
+	if cut > len(s) {
+		cut = len(s)
+	}
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + suffix
+}
+
+// CheckIdentifierCollisions verifies that normalizing the given tables' and
+// their columns' identifiers for the target dialect maps no two distinct
+// source names onto the same on-disk name. Only PostgreSQL folds identifiers,
+// so this is a no-op for mssql/mysql. On collision it returns an error naming
+// both source identifiers so the operator can rename one before create/sync
+// emits DDL that would fail late (duplicate column) or silently land two
+// source objects on one target object (#189). Tables are assumed to be within
+// a single schema.
+func CheckIdentifierCollisions(dbType string, tables []Table) error {
+	if !isPostgresDialect(dbType) {
+		return nil
+	}
+	seenTable := make(map[string]string, len(tables))
+	for _, t := range tables {
+		norm := NormalizeIdentifier(dbType, t.Name)
+		if prev, ok := seenTable[norm]; ok && prev != t.Name {
+			return fmt.Errorf("identifier collision on postgres target: tables %q and %q both normalize to %q — rename one", prev, t.Name, norm)
+		}
+		seenTable[norm] = t.Name
+
+		seenCol := make(map[string]string, len(t.Columns))
+		for _, c := range t.Columns {
+			cn := NormalizeIdentifier(dbType, c.Name)
+			if prev, ok := seenCol[cn]; ok && prev != c.Name {
+				return fmt.Errorf("identifier collision on postgres target: columns %q and %q in table %q both normalize to %q — rename one", prev, c.Name, t.Name, cn)
+			}
+			seenCol[cn] = c.Name
+		}
+	}
+	return nil
 }

--- a/internal/driver/identifiers_collision_test.go
+++ b/internal/driver/identifiers_collision_test.go
@@ -1,0 +1,108 @@
+package driver
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNormalizeIdentifier_AliasNotBypassed guards the #189 alias fix: pg /
+// postgresql must fold exactly like the canonical postgres name, so an alias
+// in config can't skip normalization.
+func TestNormalizeIdentifier_AliasNotBypassed(t *testing.T) {
+	const name = "Order Details"
+	want := NormalizeIdentifier("postgres", name)
+	if want != "order_details" {
+		t.Fatalf("canonical postgres normalize = %q, want order_details", want)
+	}
+	for _, alias := range []string{"pg", "postgresql", "POSTGRES"} {
+		if got := NormalizeIdentifier(alias, name); got != want {
+			t.Errorf("NormalizeIdentifier(%q, %q) = %q, want %q", alias, name, got, want)
+		}
+	}
+}
+
+// TestNormalizePostgresIdentifier_Truncation guards the 63-byte limit (#189):
+// over-long names are truncated to fit, and two names sharing a 63-byte prefix
+// stay distinct via the hash suffix.
+func TestNormalizePostgresIdentifier_Truncation(t *testing.T) {
+	long := "a_very_long_" + strings.Repeat("x", 80) // > 63 bytes after folding
+	got := NormalizeIdentifier("postgres", long)
+	if len(got) > pgMaxIdentifierBytes {
+		t.Fatalf("normalized len = %d, want <= %d", len(got), pgMaxIdentifierBytes)
+	}
+
+	// Two names identical for the first 70 chars but differing after byte 63
+	// must not collapse to the same identifier.
+	a := strings.Repeat("c", 70) + "_alpha"
+	b := strings.Repeat("c", 70) + "_beta"
+	na := NormalizeIdentifier("postgres", a)
+	nb := NormalizeIdentifier("postgres", b)
+	if na == nb {
+		t.Fatalf("distinct long names both normalized to %q — hash suffix missing", na)
+	}
+	if len(na) > pgMaxIdentifierBytes || len(nb) > pgMaxIdentifierBytes {
+		t.Fatalf("truncated names exceed limit: %d / %d", len(na), len(nb))
+	}
+	// Stable across calls.
+	if NormalizeIdentifier("postgres", a) != na {
+		t.Error("truncation is not deterministic")
+	}
+}
+
+func TestCheckIdentifierCollisions(t *testing.T) {
+	tbl := func(name string, cols ...string) Table {
+		t := Table{Name: name}
+		for _, c := range cols {
+			t.Columns = append(t.Columns, Column{Name: c})
+		}
+		return t
+	}
+
+	t.Run("table collision on postgres errors", func(t *testing.T) {
+		err := CheckIdentifierCollisions("postgres", []Table{
+			tbl("Order Details"),
+			tbl("Order-Details"),
+		})
+		if err == nil {
+			t.Fatal("expected collision error")
+		}
+		if !strings.Contains(err.Error(), "Order Details") || !strings.Contains(err.Error(), "Order-Details") {
+			t.Errorf("error should name both source identifiers: %v", err)
+		}
+	})
+
+	t.Run("column collision within a table errors", func(t *testing.T) {
+		err := CheckIdentifierCollisions("postgres", []Table{
+			tbl("users", "User Name", "User-Name"),
+		})
+		if err == nil {
+			t.Fatal("expected column collision error")
+		}
+		if !strings.Contains(err.Error(), "users") {
+			t.Errorf("error should name the table: %v", err)
+		}
+	})
+
+	t.Run("no collision passes", func(t *testing.T) {
+		if err := CheckIdentifierCollisions("postgres", []Table{
+			tbl("orders", "id", "status"),
+			tbl("customers", "id", "name"),
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("alias also gated", func(t *testing.T) {
+		if err := CheckIdentifierCollisions("pg", []Table{tbl("A B"), tbl("A-B")}); err == nil {
+			t.Fatal("alias pg should be gated like postgres")
+		}
+	})
+
+	t.Run("non-folding targets are a no-op", func(t *testing.T) {
+		for _, dbType := range []string{"mssql", "mysql", "sqlserver"} {
+			if err := CheckIdentifierCollisions(dbType, []Table{tbl("A B"), tbl("A-B")}); err != nil {
+				t.Errorf("%s should not gate (case-preserving): %v", dbType, err)
+			}
+		}
+	})
+}

--- a/internal/orchestrator/ddl_plan.go
+++ b/internal/orchestrator/ddl_plan.go
@@ -73,6 +73,14 @@ func (o *Orchestrator) renderDDLPlan(ctx context.Context, runID string) (schemad
 		return schemadiff.Plan{}, err
 	}
 
+	// Fail closed on identifier collisions before emitting any DDL: on a
+	// PostgreSQL target, two source names that fold to the same identifier
+	// would otherwise fail late (duplicate column) or silently land two
+	// source objects on one target object (#189).
+	if err := driver.CheckIdentifierCollisions(renderer.targetType, o.tables); err != nil {
+		return schemadiff.Plan{}, err
+	}
+
 	plan := schemadiff.Plan{}
 	if ddl, err := renderer.ddlRenderer.CreateSchemaDDL(); err != nil {
 		return schemadiff.Plan{}, err

--- a/internal/tui/capture.go
+++ b/internal/tui/capture.go
@@ -77,6 +77,9 @@ func CaptureToString(fn func() error) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("creating pipe: %w", err)
 	}
+	// Close the read end on every exit path, including an fn panic that
+	// unwinds before the explicit drain below — otherwise r's fd leaks.
+	defer r.Close()
 
 	origStdout := os.Stdout
 	os.Stdout = w
@@ -105,7 +108,6 @@ func CaptureToString(fn func() error) (string, error) {
 	}()
 
 	res := <-done
-	r.Close()
 	if res.err != nil && fnErr == nil {
 		fnErr = fmt.Errorf("reading captured output: %w", res.err)
 	}

--- a/internal/tui/capture.go
+++ b/internal/tui/capture.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"time"
@@ -80,26 +81,33 @@ func CaptureToString(fn func() error) (string, error) {
 	origStdout := os.Stdout
 	os.Stdout = w
 
-	// Run the function
-	fnErr := fn()
-
-	// Restore stdout and close writer
-	w.Close()
-	os.Stdout = origStdout
-
-	// Read captured output
-	var buf []byte
-	readBuf := make([]byte, 1024)
-	for {
-		n, readErr := r.Read(readBuf)
-		if n > 0 {
-			buf = append(buf, readBuf[:n]...)
-		}
-		if readErr != nil {
-			break
-		}
+	// Drain the pipe concurrently so fn's writes never block on a full pipe
+	// buffer (~64KB on Linux). The old code ran fn to completion with nobody
+	// reading, so any output larger than the buffer wedged fn forever (#187).
+	type readResult struct {
+		data []byte
+		err  error
 	}
-	r.Close()
+	done := make(chan readResult, 1)
+	go func() {
+		data, readErr := io.ReadAll(r)
+		done <- readResult{data: data, err: readErr}
+	}()
 
-	return string(buf), fnErr
+	// Restore stdout and close the writer however fn returns — including a
+	// panic — so the reader always sees EOF and the os.Stdout swap can't leak.
+	fnErr := func() (err error) {
+		defer func() {
+			w.Close()
+			os.Stdout = origStdout
+		}()
+		return fn()
+	}()
+
+	res := <-done
+	r.Close()
+	if res.err != nil && fnErr == nil {
+		fnErr = fmt.Errorf("reading captured output: %w", res.err)
+	}
+	return string(res.data), fnErr
 }

--- a/internal/tui/capture_test.go
+++ b/internal/tui/capture_test.go
@@ -1,0 +1,65 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCaptureToString_LargeOutput guards #187: without a concurrent reader,
+// output larger than the OS pipe buffer (~64KB) blocks fn's write forever.
+// The capture must complete and return the full output.
+func TestCaptureToString_LargeOutput(t *testing.T) {
+	const lines = 20000 // ~ >64KB of output, well past the pipe buffer
+	done := make(chan struct {
+		out string
+		err error
+	}, 1)
+
+	go func() {
+		out, err := CaptureToString(func() error {
+			for i := 0; i < lines; i++ {
+				fmt.Printf("line %06d filler filler filler\n", i)
+			}
+			return nil
+		})
+		done <- struct {
+			out string
+			err error
+		}{out, err}
+	}()
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("CaptureToString returned error: %v", res.err)
+		}
+		if got := strings.Count(res.out, "\n"); got != lines {
+			t.Fatalf("captured %d lines, want %d (output truncated or wedged)", got, lines)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("CaptureToString deadlocked on large output (#187)")
+	}
+}
+
+// TestCaptureToString_PropagatesError confirms fn's error still surfaces and
+// stdout is restored.
+func TestCaptureToString_PropagatesError(t *testing.T) {
+	orig := os.Stdout
+	sentinel := fmt.Errorf("boom")
+	out, err := CaptureToString(func() error {
+		fmt.Println("some output")
+		return sentinel
+	})
+	if err != sentinel {
+		t.Fatalf("err = %v, want sentinel", err)
+	}
+	if !strings.Contains(out, "some output") {
+		t.Fatalf("out = %q, want captured output", out)
+	}
+	if os.Stdout != orig {
+		t.Fatal("os.Stdout was not restored")
+	}
+}

--- a/internal/tui/gitinfo_test.go
+++ b/internal/tui/gitinfo_test.go
@@ -1,0 +1,51 @@
+package tui
+
+import (
+	"testing"
+	"time"
+)
+
+// TestUpdate_TickDoesNotProbeGitSynchronously guards #188: a TickMsg must not
+// call GetGitInfo inline (it shells out to git and would block the event
+// loop). Instead it schedules an async probe and marks it in flight.
+func TestUpdate_TickSchedulesAsyncGitProbe(t *testing.T) {
+	m := InitialModel()
+	m.gitInfoInFlight = false
+
+	updated, cmd := m.Update(TickMsg(time.Now()))
+	if cmd == nil {
+		t.Fatal("TickMsg should return a batch command (tick + git probe)")
+	}
+	if !updated.(Model).gitInfoInFlight {
+		t.Fatal("TickMsg should mark a git probe in flight")
+	}
+}
+
+// TestUpdate_TickSkipsGitProbeWhenInFlight confirms the in-flight guard: a
+// slow probe must not pile up across ticks.
+func TestUpdate_TickSkipsGitProbeWhenInFlight(t *testing.T) {
+	m := InitialModel()
+	m.gitInfoInFlight = true
+
+	updated, _ := m.Update(TickMsg(time.Now()))
+	if !updated.(Model).gitInfoInFlight {
+		t.Fatal("in-flight flag should stay set (no second probe spawned)")
+	}
+}
+
+// TestUpdate_GitInfoMsgStoresResult confirms the async result lands and clears
+// the in-flight flag.
+func TestUpdate_GitInfoMsgStoresResult(t *testing.T) {
+	m := InitialModel()
+	m.gitInfoInFlight = true
+
+	want := GitInfo{Branch: "feature-x", Status: "Dirty"}
+	updated, _ := m.Update(gitInfoMsg(want))
+	got := updated.(Model)
+	if got.gitInfo != want {
+		t.Fatalf("gitInfo = %+v, want %+v", got.gitInfo, want)
+	}
+	if got.gitInfoInFlight {
+		t.Fatal("gitInfoMsg should clear the in-flight flag")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -62,8 +62,9 @@ type Model struct {
 	height    int
 
 	// Git integration
-	gitInfo GitInfo
-	cwd     string
+	gitInfo         GitInfo
+	gitInfoInFlight bool // a gitInfoCmd probe is running; don't spawn another
+	cwd             string
 
 	// Single content buffer with memory management
 	content      *strings.Builder
@@ -146,6 +147,16 @@ func tickCmd() tea.Cmd {
 	return tea.Tick(time.Second*5, func(t time.Time) tea.Msg {
 		return TickMsg(t)
 	})
+}
+
+// gitInfoMsg carries an async git-probe result back into Update (#188).
+type gitInfoMsg GitInfo
+
+// gitInfoCmd runs GetGitInfo (which shells out to git) off the event loop.
+func gitInfoCmd() tea.Cmd {
+	return func() tea.Msg {
+		return gitInfoMsg(GetGitInfo())
+	}
 }
 
 // InitialModel returns the initial model state
@@ -464,8 +475,21 @@ func (m Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		}
 
 	case TickMsg:
-		m.gitInfo = GetGitInfo()
-		return m, tickCmd()
+		// GetGitInfo shells out to git; never run it inside Update() — a slow
+		// `git status` (large repo, WSL /mnt) would block the whole event loop
+		// every tick. Probe asynchronously via a tea.Cmd, at most one in flight
+		// so slow probes can't pile up (#188).
+		cmds := []tea.Cmd{tickCmd()}
+		if !m.gitInfoInFlight {
+			m.gitInfoInFlight = true
+			cmds = append(cmds, gitInfoCmd())
+		}
+		return m, tea.Batch(cmds...)
+
+	case gitInfoMsg:
+		m.gitInfo = GitInfo(msg)
+		m.gitInfoInFlight = false
+		return m, nil
 	}
 
 	m.textInput, tiCmd = m.textInput.Update(msg)


### PR DESCRIPTION
Ports the four DMT code-review fixes whose bug class SMT still carried in verbatim-copied code. Four scoped commits, one per issue.

- **#186** (`fix(ai)`, dmt#562) — `sanitizeErrorResponse` searched a `strings.ToLower` copy but sliced the original; a rune whose lowercase form changes byte length (İ → i̇) shifted every later index → out-of-range panic on an ordinary API-error path. Fold ASCII case only (length-preserving).
- **#187** (`fix(tui)`, dmt#556) — `CaptureToString` ran `fn` with no concurrent reader, so output past the ~64KB pipe buffer wedged `fn` forever. Drain the pipe in a goroutine before `fn`; restore stdout via `defer`.
- **#188** (`fix(tui)`, dmt#559) — `Update()` called `GetGitInfo()` (two git subprocesses) inline every 5s tick, freezing the event loop. Moved to an async `tea.Cmd` with an in-flight guard.
- **#189** (`fix(identifiers)`, dmt#553) — `NormalizeIdentifier` had no PG 63-byte truncation (server-side silent truncation → recorded name ≠ on-disk name), no collision detection (two source names folding to one identifier landed silently), and an alias bypass (`pg` skipped folding). Adds hash-suffixed truncation, a fail-closed `CheckIdentifierCollisions` gate on both create and sync plans, and registry-first alias resolution.

Each fix has a fail-before/pass-after regression test (non-ASCII sanitize, large-output capture, async git wiring, truncation + collision + alias). Local build / vet / gofmt / `go test ./... -short` all green. #189 touches the deterministic identifier path, so the CRM matrix is the gate.

Closes #186, closes #187, closes #188, closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)