### PR TITLE
Refactor TUI capture path to injected io.Writer

### DIFF
--- a/cmd/smt/run.go
+++ b/cmd/smt/run.go
@@ -149,9 +149,9 @@ func runHistory(c *cli.Context) error {
 	defer orch.Close()
 
 	if id := c.String("run"); id != "" {
-		return orch.ShowRunDetails(id)
+		return orch.ShowRunDetails(os.Stdout, id)
 	}
-	return orch.ShowHistory()
+	return orch.ShowHistory(os.Stdout)
 }
 
 // withSignalCancel returns a derived context that is cancelled when the

--- a/internal/orchestrator/history.go
+++ b/internal/orchestrator/history.go
@@ -5,52 +5,53 @@ package orchestrator
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
 	"smt/internal/checkpoint"
 )
 
-// ShowHistory prints all known runs (most recent first) in a small
+// ShowHistory writes all known runs (most recent first) to w in a small
 // fixed-width table.
-func (o *Orchestrator) ShowHistory() error {
+func (o *Orchestrator) ShowHistory(w io.Writer) error {
 	runs, err := o.state.GetAllRuns()
 	if err != nil {
 		return err
 	}
 	if len(runs) == 0 {
-		fmt.Println("No runs recorded yet.")
+		fmt.Fprintln(w, "No runs recorded yet.")
 		return nil
 	}
 
-	fmt.Printf("%-36s %-10s %-19s %-19s %s\n", "RUN ID", "STATUS", "STARTED", "ENDED", "PHASE")
-	fmt.Println(strings.Repeat("-", 105))
+	fmt.Fprintf(w, "%-36s %-10s %-19s %-19s %s\n", "RUN ID", "STATUS", "STARTED", "ENDED", "PHASE")
+	fmt.Fprintln(w, strings.Repeat("-", 105))
 	for _, r := range runs {
-		fmt.Printf("%-36s %-10s %-19s %-19s %s\n",
+		fmt.Fprintf(w, "%-36s %-10s %-19s %-19s %s\n",
 			r.ID, r.Status, fmtTime(&r.StartedAt), fmtTime(r.CompletedAt), r.Phase)
 	}
 	return nil
 }
 
-// ShowRunDetails prints one run's record plus its task list.
-func (o *Orchestrator) ShowRunDetails(runID string) error {
+// ShowRunDetails writes one run's record plus its task list to w.
+func (o *Orchestrator) ShowRunDetails(w io.Writer, runID string) error {
 	r, err := o.state.GetRunByID(runID)
 	if err != nil {
 		return err
 	}
 	if r == nil {
-		fmt.Printf("No run with id %s\n", runID)
+		fmt.Fprintf(w, "No run with id %s\n", runID)
 		return nil
 	}
-	fmt.Printf("Run:        %s\n", r.ID)
-	fmt.Printf("Status:     %s\n", r.Status)
-	fmt.Printf("Phase:      %s\n", r.Phase)
-	fmt.Printf("Source:     %s\n", r.SourceSchema)
-	fmt.Printf("Target:     %s\n", r.TargetSchema)
-	fmt.Printf("Started:    %s\n", fmtTime(&r.StartedAt))
-	fmt.Printf("Ended:      %s\n", fmtTime(r.CompletedAt))
+	fmt.Fprintf(w, "Run:        %s\n", r.ID)
+	fmt.Fprintf(w, "Status:     %s\n", r.Status)
+	fmt.Fprintf(w, "Phase:      %s\n", r.Phase)
+	fmt.Fprintf(w, "Source:     %s\n", r.SourceSchema)
+	fmt.Fprintf(w, "Target:     %s\n", r.TargetSchema)
+	fmt.Fprintf(w, "Started:    %s\n", fmtTime(&r.StartedAt))
+	fmt.Fprintf(w, "Ended:      %s\n", fmtTime(r.CompletedAt))
 	if r.Error != "" {
-		fmt.Printf("Error:      %s\n", r.Error)
+		fmt.Fprintf(w, "Error:      %s\n", r.Error)
 	}
 
 	tasks, err := o.state.GetTasksWithProgress(r.ID)
@@ -60,9 +61,9 @@ func (o *Orchestrator) ShowRunDetails(runID string) error {
 	if len(tasks) == 0 {
 		return nil
 	}
-	fmt.Println("\nTasks:")
+	fmt.Fprintln(w, "\nTasks:")
 	for _, t := range tasks {
-		fmt.Printf("  %-30s %s\n", t.TaskKey, t.Status)
+		fmt.Fprintf(w, "  %-30s %s\n", t.TaskKey, t.Status)
 	}
 	return nil
 }

--- a/internal/tui/capture.go
+++ b/internal/tui/capture.go
@@ -82,38 +82,3 @@ func SetProgramRef(p *tea.Program) {
 func GetProgramRef() *tea.Program {
 	return programRef
 }
-
-// CaptureToString captures stdout from a function and returns it as a string.
-// Used for commands like /history that print to stdout.
-func CaptureToString(fn func() error) (string, error) {
-	r, w, err := os.Pipe()
-	if err != nil {
-		return "", fmt.Errorf("creating pipe: %w", err)
-	}
-
-	origStdout := os.Stdout
-	os.Stdout = w
-
-	// Run the function
-	fnErr := fn()
-
-	// Restore stdout and close writer
-	w.Close()
-	os.Stdout = origStdout
-
-	// Read captured output
-	var buf []byte
-	readBuf := make([]byte, 1024)
-	for {
-		n, readErr := r.Read(readBuf)
-		if n > 0 {
-			buf = append(buf, readBuf[:n]...)
-		}
-		if readErr != nil {
-			break
-		}
-	}
-	r.Close()
-
-	return string(buf), fnErr
-}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -921,17 +922,17 @@ func (m Model) runHistoryCmd(configFile, profileName, runID string) tea.Cmd {
 			}
 			defer orch.Close()
 
-			var output string
+			var buf bytes.Buffer
 			if runID != "" {
-				output, err = CaptureToString(func() error { return orch.ShowRunDetails(runID) })
+				err = orch.ShowRunDetails(&buf, runID)
 			} else {
-				output, err = CaptureToString(orch.ShowHistory)
+				err = orch.ShowHistory(&buf)
 			}
 			if err != nil {
 				p.Send(OutputMsg(fmt.Sprintf("Error showing history: %v\n", err)))
 				return
 			}
-			p.Send(BoxedOutputMsg(output))
+			p.Send(BoxedOutputMsg(buf.String()))
 		}()
 
 		return nil


### PR DESCRIPTION
Threads an explicit `io.Writer` through the history-rendering commands instead of hijacking the process-global `os.Stdout`, removing the race described in #228.

## Problem
`CaptureToString` swapped `os.Stdout` to a pipe to capture `/history` output, while the TUI's whole-program capture also owns `os.Stdout` and `/history` runs in a goroutine — the two swaps raced and could route unrelated output into the captured buffer.

## Change
- `orchestrator.ShowHistory(w io.Writer)` and `ShowRunDetails(w io.Writer, runID string)` now render via `fmt.Fprint*`.
- CLI `history` command passes `os.Stdout` (output unchanged).
- TUI `runHistoryCmd` renders into a `bytes.Buffer` it owns → `BoxedOutputMsg` — no global touched.
- Racy `CaptureToString` removed (no remaining callers).

Rendered text is byte-identical. Scope kept to the `/history` capture path per the issue; the single synchronized program-wide capture seam is unchanged.

## Verification
`go build ./...`, `make test-short`, `gofmt -l` — all clean/pass.

Closes #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
