### PR TITLE
Fix TUI Esc quitting mid-run without cancelling

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -282,6 +282,19 @@ func (m Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 			return m, tea.Quit
 
 		case tea.KeyEsc:
+			// Mirror Ctrl+C: never quit out from under a running schema
+			// operation. Cancelling it via the migration context lets the
+			// orchestrator unwind (close connections, mark the run) instead
+			// of the process dying mid-DDL. Only quit when idle.
+			if m.migrationStatus == "running" {
+				if m.migrationCancel != nil {
+					m.migrationCancel()
+					m.appendOutput(styleSystemOutput.Render("Cancelling migration... please wait") + "\n")
+				} else {
+					m.appendOutput(styleSystemOutput.Render("Schema operation is starting; cancel will be available shortly.") + "\n")
+				}
+				return m, nil
+			}
 			return m, tea.Quit
 
 		case tea.KeyEnter:

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"strings"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestHandleCommand_SchemaOperationMarksRunningSynchronously(t *testing.T) {
@@ -35,5 +37,35 @@ func TestHandleCommand_BlocksSecondSchemaOperationWhileStarting(t *testing.T) {
 	}
 	if !strings.Contains(string(output), "already running") {
 		t.Fatalf("output = %q, want already running message", output)
+	}
+}
+
+// Esc during a running schema operation must cancel it (like Ctrl+C), not
+// quit the process out from under the orchestrator. Regression for the
+// DMT #558 pattern (Esc quit mid-run without cancel/cleanup).
+func TestUpdate_EscCancelsRunningOperationInsteadOfQuitting(t *testing.T) {
+	m := InitialModel()
+	cancelled := false
+	m.migrationStatus = "running"
+	m.migrationCancel = func() { cancelled = true }
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if !cancelled {
+		t.Fatal("Esc during a running operation did not invoke migrationCancel")
+	}
+	if cmd != nil {
+		t.Fatal("Esc during a running operation returned a command (expected nil, not tea.Quit)")
+	}
+}
+
+// Esc while idle should still quit the TUI.
+func TestUpdate_EscQuitsWhenIdle(t *testing.T) {
+	m := InitialModel()
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if cmd == nil {
+		t.Fatal("Esc while idle should return a quit command")
 	}
 }


### PR DESCRIPTION
Fixes a TUI bug surfaced by the DMT code-review handoff sweep (#190, item dmt#558): **Esc quit the TUI instantly during a running schema operation** without cancelling it.

`tea.KeyEsc` unconditionally returned `tea.Quit`, so pressing Esc mid-run killed the process mid-DDL — connections weren't closed and the run wasn't marked in state. Ctrl+C already guarded on `migrationStatus == "running"` and cancelled the migration context; Esc now mirrors that, quitting only when idle.

Regression tests cover both paths (cancel-while-running, quit-while-idle).

Part of #190 (dmt#558).

## Verification
`go test ./internal/tui/`, `gofmt -l` — pass/clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
