### PR TITLE
feat(schema): add ClickHouse canonical mapper

### DIFF
--- a/schema/canonical/canonical_public_test.go
+++ b/schema/canonical/canonical_public_test.go
@@ -20,3 +20,18 @@ func TestPublicPackageSupportsTypeMapping(t *testing.T) {
 		t.Fatalf("rendered type = %q, want TIMESTAMP(6)", got)
 	}
 }
+
+func TestPublicPackageSupportsClickHouseMapping(t *testing.T) {
+	ct := canonical.ToCanonical(
+		"LowCardinality(Nullable(Array(UInt32)))",
+		canonical.TypeMeta{},
+		"clickhouse",
+	)
+	got, err := canonical.FromCanonical(ct, "clickhouse", canonical.RenderOpts{})
+	if err != nil {
+		t.Fatalf("FromCanonical: %v", err)
+	}
+	if got != "Array(UInt32)" {
+		t.Fatalf("rendered type = %q, want Array(UInt32)", got)
+	}
+}

--- a/schema/canonical/clickhouse.go
+++ b/schema/canonical/clickhouse.go
@@ -1,0 +1,601 @@
+package canonical
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ClickHouse has a strict but distinct type system. Nullable(T) is a type
+// wrapper rather than a column constraint, and LowCardinality(T) is a storage
+// optimization. The public canonical API deliberately models neither: SMT's
+// column IR owns nullability and has no storage-layout knobs. Therefore source
+// wrappers are stripped before normalization, matching DMT's catalog mapper.
+//
+// The target policy keeps values in native ClickHouse types when canonical
+// semantics suffice. It intentionally does not emit Nullable or
+// LowCardinality because RenderOpts contains no column-nullability or storage
+// policy; that composition remains a future DDL-renderer milestone.
+func clickhouseToCanonical(typeName string, _ TypeMeta) CanonicalType {
+	typ := strings.TrimSpace(typeName)
+	for {
+		next, ok := unwrapClickHouseWrapper(typ, "Nullable")
+		if !ok {
+			next, ok = unwrapClickHouseWrapper(typ, "LowCardinality")
+		}
+		if !ok {
+			break
+		}
+		typ = next
+	}
+
+	name, args, ok := clickhouseTypeCall(typ)
+	if !ok || name == "" {
+		return CanonicalType{Kind: Raw, Raw: typ}
+	}
+	upper := strings.ToUpper(name)
+
+	switch upper {
+	case "FIXEDSTRING":
+		if len(args) != 1 {
+			return CanonicalType{Kind: Raw, Raw: typ}
+		}
+		length, ok := clickhousePositiveInt(args[0])
+		if !ok {
+			return CanonicalType{Kind: Raw, Raw: typ}
+		}
+		return CanonicalType{Kind: Char, Length: length}
+	case "DECIMAL":
+		precision, scale, ok := clickhouseDecimalParameters(args, 0)
+		if !ok {
+			return CanonicalType{Kind: Raw, Raw: typ}
+		}
+		return CanonicalType{Kind: Decimal, Precision: precision, Scale: scale}
+	case "DECIMAL32":
+		precision, scale, ok := clickhouseDecimalParameters(args, 9)
+		if !ok {
+			return CanonicalType{Kind: Raw, Raw: typ}
+		}
+		return CanonicalType{Kind: Decimal, Precision: precision, Scale: scale}
+	case "DECIMAL64":
+		precision, scale, ok := clickhouseDecimalParameters(args, 18)
+		if !ok {
+			return CanonicalType{Kind: Raw, Raw: typ}
+		}
+		return CanonicalType{Kind: Decimal, Precision: precision, Scale: scale}
+	case "DECIMAL128":
+		precision, scale, ok := clickhouseDecimalParameters(args, 38)
+		if !ok {
+			return CanonicalType{Kind: Raw, Raw: typ}
+		}
+		return CanonicalType{Kind: Decimal, Precision: precision, Scale: scale}
+	case "DECIMAL256":
+		precision, scale, ok := clickhouseDecimalParameters(args, 76)
+		if !ok {
+			return CanonicalType{Kind: Raw, Raw: typ}
+		}
+		return CanonicalType{Kind: Decimal, Precision: precision, Scale: scale}
+	case "DATETIME", "DATETIME64":
+		fsp, withTZ, ok := clickhouseTimestampParameters(upper, args)
+		if !ok {
+			return CanonicalType{Kind: Raw, Raw: typ}
+		}
+		return CanonicalType{Kind: Timestamp, Fsp: fsp, WithTZ: withTZ}
+	case "ENUM8", "ENUM16":
+		values, ok := clickhouseEnumValues(args)
+		if !ok {
+			return CanonicalType{Kind: Raw, Raw: typ}
+		}
+		return CanonicalType{Kind: Enum, EnumValues: values}
+	case "ARRAY":
+		if len(args) != 1 || strings.TrimSpace(args[0]) == "" {
+			return CanonicalType{Kind: Raw, Raw: typ}
+		}
+		element := clickhouseToCanonical(args[0], TypeMeta{})
+		return CanonicalType{Kind: Array, Element: &element}
+	}
+
+	if len(args) != 0 {
+		if upper == "OBJECT" && len(args) == 1 && strings.EqualFold(clickhouseUnquote(args[0]), "json") {
+			return CanonicalType{Kind: Json}
+		}
+		return CanonicalType{Kind: Raw, Raw: typ}
+	}
+
+	switch upper {
+	case "BOOL", "BOOLEAN":
+		return CanonicalType{Kind: Boolean}
+	case "INT8":
+		return CanonicalType{Kind: TinyInt}
+	case "UINT8":
+		return CanonicalType{Kind: TinyInt, Unsigned: true}
+	case "INT16":
+		return CanonicalType{Kind: SmallInt}
+	case "UINT16":
+		return CanonicalType{Kind: SmallInt, Unsigned: true}
+	case "INT32":
+		return CanonicalType{Kind: Integer}
+	case "UINT32":
+		return CanonicalType{Kind: Integer, Unsigned: true}
+	case "INT64":
+		return CanonicalType{Kind: BigInt}
+	case "UINT64":
+		return CanonicalType{Kind: BigInt, Unsigned: true}
+	case "FLOAT32":
+		return CanonicalType{Kind: Real}
+	case "FLOAT64":
+		return CanonicalType{Kind: Double}
+	case "STRING", "IPV4", "IPV6":
+		return CanonicalType{Kind: Text}
+	case "DATE", "DATE32":
+		return CanonicalType{Kind: Date}
+	case "UUID":
+		return CanonicalType{Kind: Uuid}
+	case "JSON":
+		return CanonicalType{Kind: Json}
+	default:
+		// UInt128/UInt256, AggregateFunction, Map, Tuple, Variant, and
+		// experimental/vendor types have no lossless home in the public IR.
+		return CanonicalType{Kind: Raw, Raw: typ}
+	}
+}
+
+func isClickHouse(dialect string) bool {
+	return strings.EqualFold(strings.TrimSpace(dialect), "clickhouse")
+}
+
+func unwrapClickHouseWrapper(typ, wrapper string) (string, bool) {
+	name, args, ok := clickhouseTypeCall(typ)
+	if !ok || !strings.EqualFold(name, wrapper) || len(args) != 1 {
+		return typ, false
+	}
+	return strings.TrimSpace(args[0]), true
+}
+
+// clickhouseTypeCall splits a complete ClickHouse Type(args...) expression.
+// It is quote- and nested-parentheses-aware so Array(Nullable(String)) and
+// Enum8('a,b' = 1) do not lose their inner structure.
+func clickhouseTypeCall(typ string) (string, []string, bool) {
+	typ = strings.TrimSpace(typ)
+	if typ == "" {
+		return "", nil, false
+	}
+	open := strings.IndexByte(typ, '(')
+	if open < 0 {
+		return typ, nil, true
+	}
+	name := strings.TrimSpace(typ[:open])
+	if name == "" {
+		return "", nil, false
+	}
+	close, ok := clickhouseMatchingParen(typ, open)
+	if !ok || strings.TrimSpace(typ[close+1:]) != "" {
+		return "", nil, false
+	}
+	args, ok := clickhouseSplitArgs(typ[open+1 : close])
+	if !ok {
+		return "", nil, false
+	}
+	return name, args, true
+}
+
+func clickhouseMatchingParen(s string, open int) (int, bool) {
+	depth := 0
+	inQuote := false
+	for i := open; i < len(s); i++ {
+		c := s[i]
+		if inQuote {
+			if c == '\\' && i+1 < len(s) {
+				i++
+				continue
+			}
+			if c == '\'' {
+				if i+1 < len(s) && s[i+1] == '\'' {
+					i++
+					continue
+				}
+				inQuote = false
+			}
+			continue
+		}
+		switch c {
+		case '\'':
+			inQuote = true
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i, true
+			}
+			if depth < 0 {
+				return 0, false
+			}
+		}
+	}
+	return 0, false
+}
+
+func clickhouseSplitArgs(s string) ([]string, bool) {
+	if strings.TrimSpace(s) == "" {
+		return nil, true
+	}
+	var args []string
+	start, depth := 0, 0
+	inQuote := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inQuote {
+			if c == '\\' && i+1 < len(s) {
+				i++
+				continue
+			}
+			if c == '\'' {
+				if i+1 < len(s) && s[i+1] == '\'' {
+					i++
+					continue
+				}
+				inQuote = false
+			}
+			continue
+		}
+		switch c {
+		case '\'':
+			inQuote = true
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth < 0 {
+				return nil, false
+			}
+		case ',':
+			if depth == 0 {
+				arg := strings.TrimSpace(s[start:i])
+				if arg == "" {
+					return nil, false
+				}
+				args = append(args, arg)
+				start = i + 1
+			}
+		}
+	}
+	if inQuote || depth != 0 {
+		return nil, false
+	}
+	arg := strings.TrimSpace(s[start:])
+	if arg == "" {
+		return nil, false
+	}
+	return append(args, arg), true
+}
+
+func clickhousePositiveInt(s string) (int, bool) {
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	return n, err == nil && n > 0
+}
+
+func clickhouseNonNegativeInt(s string) (int, bool) {
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	return n, err == nil && n >= 0
+}
+
+func clickhouseDecimalParameters(args []string, impliedPrecision int) (int, int, bool) {
+	if impliedPrecision > 0 {
+		if len(args) != 1 {
+			return 0, 0, false
+		}
+		scale, ok := clickhouseNonNegativeInt(args[0])
+		if !ok || scale > impliedPrecision {
+			return 0, 0, false
+		}
+		return impliedPrecision, scale, true
+	}
+	if len(args) != 2 {
+		return 0, 0, false
+	}
+	precision, ok := clickhousePositiveInt(args[0])
+	if !ok || precision > 76 {
+		return 0, 0, false
+	}
+	scale, ok := clickhouseNonNegativeInt(args[1])
+	if !ok || scale > precision {
+		return 0, 0, false
+	}
+	return precision, scale, true
+}
+
+func clickhouseTimestampParameters(name string, args []string) (*int, bool, bool) {
+	if name == "DATETIME" {
+		if len(args) > 1 {
+			return nil, false, false
+		}
+		fsp := 0
+		return &fsp, len(args) == 1 && strings.TrimSpace(args[0]) != "", true
+	}
+	if len(args) < 1 || len(args) > 2 {
+		return nil, false, false
+	}
+	fsp, ok := clickhouseNonNegativeInt(args[0])
+	if !ok || fsp > 9 {
+		return nil, false, false
+	}
+	return &fsp, len(args) == 2 && strings.TrimSpace(args[1]) != "", true
+}
+
+func clickhouseEnumValues(args []string) ([]string, bool) {
+	if len(args) == 0 {
+		return nil, false
+	}
+	values := make([]string, 0, len(args))
+	for _, arg := range args {
+		eq := clickhouseEnumEquals(arg)
+		if eq < 0 {
+			return nil, false
+		}
+		label := strings.TrimSpace(arg[:eq])
+		code := strings.TrimSpace(arg[eq+1:])
+		if len(label) < 2 || label[0] != '\'' || label[len(label)-1] != '\'' {
+			return nil, false
+		}
+		if _, err := strconv.Atoi(code); err != nil {
+			return nil, false
+		}
+		values = append(values, clickhouseUnquote(label))
+	}
+	return values, true
+}
+
+func clickhouseEnumEquals(s string) int {
+	inQuote := false
+	for i := 0; i < len(s); i++ {
+		if inQuote {
+			if s[i] == '\\' && i+1 < len(s) {
+				i++
+				continue
+			}
+			if s[i] == '\'' {
+				if i+1 < len(s) && s[i+1] == '\'' {
+					i++
+					continue
+				}
+				inQuote = false
+			}
+			continue
+		}
+		if s[i] == '\'' {
+			inQuote = true
+		} else if s[i] == '=' {
+			return i
+		}
+	}
+	return -1
+}
+
+func clickhouseUnquote(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) < 2 || s[0] != '\'' || s[len(s)-1] != '\'' {
+		return s
+	}
+	s = s[1 : len(s)-1]
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			i++
+			b.WriteByte(s[i])
+			continue
+		}
+		if s[i] == '\'' && i+1 < len(s) && s[i+1] == '\'' {
+			i++
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+func fromCanonicalClickHouse(ct CanonicalType, opts RenderOpts) (string, error) {
+	integer := func(signed, unsigned string) string {
+		if ct.Unsigned {
+			return unsigned
+		}
+		return signed
+	}
+
+	switch ct.Kind {
+	case Boolean:
+		return "Bool", nil
+	case TinyInt:
+		return integer("Int8", "UInt8"), nil
+	case SmallInt:
+		return integer("Int16", "UInt16"), nil
+	case MediumInt:
+		return integer("Int32", "UInt32"), nil
+	case Integer:
+		return integer("Int32", "UInt32"), nil
+	case BigInt:
+		return integer("Int64", "UInt64"), nil
+	case Decimal:
+		return clickhouseDecimalDDL(ct)
+	case Real:
+		return "Float32", nil
+	case Double:
+		return "Float64", nil
+	case Varchar, Text:
+		return "String", nil
+	case Char:
+		if ct.Length > 0 {
+			return fmt.Sprintf("FixedString(%d)", ct.Length), nil
+		}
+		return "String", nil
+	case Binary:
+		if ct.Length > 0 {
+			return fmt.Sprintf("FixedString(%d)", ct.Length), nil
+		}
+		return "String", nil
+	case VarBinary, Blob:
+		return "String", nil
+	case RowVersion:
+		return "FixedString(8)", nil
+	case Date:
+		return "Date32", nil
+	case Time:
+		// Time/Time64 is experimental on the ClickHouse versions DMT supports.
+		return "String", nil
+	case Timestamp:
+		return clickhouseTimestampDDL(ct), nil
+	case Uuid:
+		return "UUID", nil
+	case Json, Xml, Set, Spatial:
+		return "String", nil
+	case Enum:
+		return clickhouseEnumDDL(ct), nil
+	case Array:
+		element := CanonicalType{Kind: Text}
+		if ct.Element != nil {
+			element = *ct.Element
+		}
+		typ, err := fromCanonicalClickHouse(element, opts)
+		if err != nil {
+			return "", err
+		}
+		return "Array(" + typ + ")", nil
+	case Raw:
+		return "", fmt.Errorf("%w: %s", ErrUnknownType, ct.Raw)
+	default:
+		return "", fmt.Errorf("%w", ErrUnknownType)
+	}
+}
+
+func clickhouseDecimalDDL(ct CanonicalType) (string, error) {
+	if ct.Precision <= 0 {
+		return "Decimal(38, 9)", nil
+	}
+	if ct.Precision > 76 || ct.Scale < 0 || ct.Scale > ct.Precision {
+		return "", fmt.Errorf("%w: ClickHouse Decimal(%d,%d) is outside its supported precision/scale range", ErrUnknownType, ct.Precision, ct.Scale)
+	}
+	return fmt.Sprintf("Decimal(%d, %d)", ct.Precision, ct.Scale), nil
+}
+
+func clickhouseTimestampDDL(ct CanonicalType) string {
+	fsp := 3 // conservative, DMT-compatible default for unspecified precision
+	if value, ok := ct.Fspv(); ok && value >= 0 {
+		fsp = value
+	}
+	if fsp > 9 {
+		fsp = 9
+	}
+	if fsp == 0 {
+		if ct.WithTZ {
+			return "DateTime('UTC')"
+		}
+		return "DateTime"
+	}
+	if ct.WithTZ {
+		return fmt.Sprintf("DateTime64(%d, 'UTC')", fsp)
+	}
+	return fmt.Sprintf("DateTime64(%d)", fsp)
+}
+
+func clickhouseEnumDDL(ct CanonicalType) string {
+	if len(ct.EnumValues) == 0 || len(ct.EnumValues) > 32767 {
+		return "String"
+	}
+	name := "Enum8"
+	if len(ct.EnumValues) > 127 {
+		name = "Enum16"
+	}
+	values := make([]string, len(ct.EnumValues))
+	for i, value := range ct.EnumValues {
+		values[i] = fmt.Sprintf("%s = %d", clickhouseQuote(value), i+1)
+	}
+	return name + "(" + strings.Join(values, ", ") + ")"
+}
+
+func clickhouseQuote(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `'`, `\'`)
+	return "'" + s + "'"
+}
+
+func clickhouseMappingWarnings(ct CanonicalType, rendered string) []MappingWarning {
+	var out []MappingWarning
+	add := func(kind Kind, reason string) {
+		out = append(out, MappingWarning{
+			Kind:          kindName(kind),
+			TargetDialect: "clickhouse",
+			Reason:        reason,
+		})
+	}
+
+	switch ct.Kind {
+	case MediumInt:
+		add(ct.Kind, "ClickHouse has no 24-bit integer; widened to "+rendered)
+	case Varchar:
+		if ct.Length > 0 {
+			add(ct.Kind, "ClickHouse String does not enforce the declared maximum length; rendered as "+rendered)
+		}
+		if ct.National {
+			add(ct.Kind, "ClickHouse has no separate national character type; rendered as "+rendered)
+		}
+	case Char:
+		if ct.Length <= 0 {
+			add(ct.Kind, "fixed character length was unspecified, so ClickHouse FixedString cannot be used; rendered as "+rendered)
+		} else {
+			add(ct.Kind, "ClickHouse FixedString is byte-sized; character width and padding semantics may differ; rendered as "+rendered)
+		}
+		if ct.National {
+			add(ct.Kind, "ClickHouse has no separate national character type; rendered as "+rendered)
+		}
+	case Binary:
+		if ct.Length <= 0 {
+			add(ct.Kind, "fixed binary length was unspecified, so ClickHouse FixedString cannot be used; rendered as "+rendered)
+		}
+	case VarBinary:
+		if ct.Length > 0 {
+			add(ct.Kind, "ClickHouse String does not enforce the declared maximum byte length; rendered as "+rendered)
+		}
+	case Decimal:
+		if ct.Precision <= 0 {
+			add(ct.Kind, "source decimal had no declared precision; rendered with conservative Decimal(38, 9) default")
+		}
+	case Date:
+		add(ct.Kind, "ClickHouse Date32 supports 1900-2299; values outside that range cannot be preserved")
+	case Time:
+		add(ct.Kind, "ClickHouse Time/Time64 is experimental for the supported target baseline; stored as String")
+	case Timestamp:
+		if _, ok := ct.Fspv(); !ok {
+			add(ct.Kind, "source timestamp had no declared fractional-seconds precision; rendered with DateTime64(3) default")
+		}
+		if ct.WithTZ {
+			add(ct.Kind, "canonical time-zone awareness has no named-zone identity; rendered with UTC time zone")
+		}
+	case RowVersion:
+		add(ct.Kind, "ClickHouse has no rowversion token semantics; rendered as opaque FixedString(8)")
+	case Json:
+		add(ct.Kind, "ClickHouse native JSON availability varies by server version; stored as String")
+	case Xml:
+		add(ct.Kind, "ClickHouse has no native XML type; stored as String")
+	case Enum:
+		switch {
+		case len(ct.EnumValues) == 0:
+			add(ct.Kind, "enum values are unavailable, so the value set cannot be preserved; rendered as String")
+		case len(ct.EnumValues) > 32767:
+			add(ct.Kind, "enum has more than 32767 values, exceeding ClickHouse Enum16; rendered as String")
+		default:
+			add(ct.Kind, "ClickHouse enum integer codes are assigned sequentially; original codes are not represented in the canonical type")
+		}
+	case Set:
+		add(ct.Kind, "ClickHouse has no MySQL-style multi-value SET type; stored as String")
+	case Array:
+		if ct.Element == nil {
+			add(ct.Kind, "array element type is unavailable; rendered as Array(String)")
+			break
+		}
+		if elementRendered, err := fromCanonicalClickHouse(*ct.Element, RenderOpts{}); err == nil {
+			out = append(out, clickhouseMappingWarnings(*ct.Element, elementRendered)...)
+		}
+	case Spatial:
+		add(ct.Kind, "ClickHouse has no portable geometry/geography column type; stored as String")
+	}
+	return out
+}

--- a/schema/canonical/clickhouse_golden_test.go
+++ b/schema/canonical/clickhouse_golden_test.go
@@ -1,0 +1,223 @@
+package canonical
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestClickHouseToCanonical_Golden(t *testing.T) {
+	intp := func(v int) *int { return &v }
+	cases := []struct {
+		name     string
+		typeName string
+		want     CanonicalType
+	}{
+		{
+			name: "nullable and low cardinality wrappers are stripped", typeName: "Nullable(LowCardinality(String))",
+			want: CanonicalType{Kind: Text},
+		},
+		{
+			name: "wrappers nest in either order", typeName: "LowCardinality(Nullable(FixedString(16)))",
+			want: CanonicalType{Kind: Char, Length: 16},
+		},
+		{
+			name: "signed integer widths", typeName: "Int8",
+			want: CanonicalType{Kind: TinyInt},
+		},
+		{
+			name: "unsigned integer widths", typeName: "UInt32",
+			want: CanonicalType{Kind: Integer, Unsigned: true},
+		},
+		{
+			name: "sixteen bit integer", typeName: "Int16",
+			want: CanonicalType{Kind: SmallInt},
+		},
+		{
+			name: "unsigned sixty four bit integer", typeName: "UInt64",
+			want: CanonicalType{Kind: BigInt, Unsigned: true},
+		},
+		{
+			name: "decimal precision and scale", typeName: "Decimal(30, 12)",
+			want: CanonicalType{Kind: Decimal, Precision: 30, Scale: 12},
+		},
+		{
+			name: "decimal alias", typeName: "Decimal256(20)",
+			want: CanonicalType{Kind: Decimal, Precision: 76, Scale: 20},
+		},
+		{
+			name: "datetime seconds", typeName: "DateTime",
+			want: CanonicalType{Kind: Timestamp, Fsp: intp(0)},
+		},
+		{
+			name: "datetime64 precision and zone", typeName: "DateTime64(9, 'UTC')",
+			want: CanonicalType{Kind: Timestamp, Fsp: intp(9), WithTZ: true},
+		},
+		{
+			name: "array recursively maps element", typeName: "Array(Nullable(UInt16))",
+			want: CanonicalType{Kind: Array, Element: &CanonicalType{Kind: SmallInt, Unsigned: true}},
+		},
+		{
+			name: "enum names are retained", typeName: "Enum8('a,b' = -1, 'it\\'s' = 2)",
+			want: CanonicalType{Kind: Enum, EnumValues: []string{"a,b", "it's"}},
+		},
+		{
+			name: "unrepresentable wide integer remains raw", typeName: "UInt128",
+			want: CanonicalType{Kind: Raw, Raw: "UInt128"},
+		},
+		{
+			name: "unsupported aggregate remains raw after wrapper stripping", typeName: "Nullable(AggregateFunction(sum, UInt64))",
+			want: CanonicalType{Kind: Raw, Raw: "AggregateFunction(sum, UInt64)"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ToCanonical(tc.typeName, TypeMeta{}, "clickhouse"); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("ToCanonical(%q, clickhouse) = %#v, want %#v", tc.typeName, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFromCanonicalClickHouse_Golden(t *testing.T) {
+	intp := func(v int) *int { return &v }
+	cases := []struct {
+		name           string
+		ct             CanonicalType
+		want           string
+		warningSubstrs []string
+	}{
+		{
+			name: "integer widths and sign", ct: CanonicalType{Kind: TinyInt, Unsigned: true},
+			want: "UInt8",
+		},
+		{
+			name: "sixteen bit unsigned integer", ct: CanonicalType{Kind: SmallInt, Unsigned: true},
+			want: "UInt16",
+		},
+		{
+			name: "thirty two bit signed integer", ct: CanonicalType{Kind: Integer},
+			want: "Int32",
+		},
+		{
+			name: "sixty four bit unsigned integer", ct: CanonicalType{Kind: BigInt, Unsigned: true},
+			want: "UInt64",
+		},
+		{
+			name: "medium integer widens", ct: CanonicalType{Kind: MediumInt, Unsigned: true},
+			want: "UInt32", warningSubstrs: []string{"no 24-bit integer"},
+		},
+		{
+			name: "fixed string", ct: CanonicalType{Kind: Char, Length: 16},
+			want: "FixedString(16)", warningSubstrs: []string{"byte-sized"},
+		},
+		{
+			name: "bounded varchar becomes string", ct: CanonicalType{Kind: Varchar, Length: 255},
+			want: "String", warningSubstrs: []string{"does not enforce"},
+		},
+		{
+			name: "decimal precision and scale", ct: CanonicalType{Kind: Decimal, Precision: 30, Scale: 12},
+			want: "Decimal(30, 12)",
+		},
+		{
+			name: "decimal default is explicit", ct: CanonicalType{Kind: Decimal},
+			want: "Decimal(38, 9)", warningSubstrs: []string{"no declared precision"},
+		},
+		{
+			name: "date uses wider ClickHouse date", ct: CanonicalType{Kind: Date},
+			want: "Date32", warningSubstrs: []string{"1900-2299"},
+		},
+		{
+			name: "datetime seconds", ct: CanonicalType{Kind: Timestamp, Fsp: intp(0)},
+			want: "DateTime",
+		},
+		{
+			name: "datetime64 precision and zone", ct: CanonicalType{Kind: Timestamp, Fsp: intp(9), WithTZ: true},
+			want: "DateTime64(9, 'UTC')", warningSubstrs: []string{"named-zone identity"},
+		},
+		{
+			name: "unspecified timestamp precision has DMT compatible default", ct: CanonicalType{Kind: Timestamp},
+			want: "DateTime64(3)", warningSubstrs: []string{"DateTime64(3) default"},
+		},
+		{
+			name: "array maps supported elements", ct: CanonicalType{Kind: Array, Element: &CanonicalType{Kind: Integer, Unsigned: true}},
+			want: "Array(UInt32)",
+		},
+		{
+			name: "array without element is explicit fallback", ct: CanonicalType{Kind: Array},
+			want: "Array(String)", warningSubstrs: []string{"element type is unavailable"},
+		},
+		{
+			name: "enum preserves values with deterministic codes", ct: CanonicalType{Kind: Enum, EnumValues: []string{"active", "pending"}},
+			want: "Enum8('active' = 1, 'pending' = 2)", warningSubstrs: []string{"assigned sequentially"},
+		},
+		{
+			name: "enum without values degrades explicitly", ct: CanonicalType{Kind: Enum},
+			want: "String", warningSubstrs: []string{"values are unavailable"},
+		},
+		{
+			name: "json is version safe string", ct: CanonicalType{Kind: Json},
+			want: "String", warningSubstrs: []string{"availability varies"},
+		},
+		{
+			name: "time avoids experimental ClickHouse type", ct: CanonicalType{Kind: Time},
+			want: "String", warningSubstrs: []string{"experimental"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, warnings, err := FromCanonicalWithWarnings(tc.ct, "clickhouse", RenderOpts{})
+			if err != nil {
+				t.Fatalf("FromCanonicalWithWarnings: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("rendered type = %q, want %q", got, tc.want)
+			}
+			for _, want := range tc.warningSubstrs {
+				if !hasClickHouseWarning(warnings, want) {
+					t.Errorf("warnings = %+v, missing %q", warnings, want)
+				}
+			}
+			if len(tc.warningSubstrs) == 0 && len(warnings) != 0 {
+				t.Errorf("warnings = %+v, want none", warnings)
+			}
+		})
+	}
+}
+
+func TestFromCanonicalClickHouse_UnsupportedAndRawRemainExplicit(t *testing.T) {
+	cases := []CanonicalType{
+		{Kind: Raw, Raw: "AggregateFunction(sum, UInt64)"},
+		{Kind: Decimal, Precision: 77, Scale: 2},
+		{Kind: Array, Element: &CanonicalType{Kind: Raw, Raw: "Map(String, UInt64)"}},
+	}
+	for _, ct := range cases {
+		_, err := FromCanonical(ct, "clickhouse", RenderOpts{})
+		if !errors.Is(err, ErrUnknownType) {
+			t.Errorf("FromCanonical(%#v, clickhouse) error = %v, want ErrUnknownType", ct, err)
+		}
+	}
+}
+
+func TestFromCanonicalClickHouse_AcceptsCaseAndPublicEntryPoint(t *testing.T) {
+	ct := ToCanonical("LowCardinality(Nullable(DateTime64(6)))", TypeMeta{}, "CLICKHOUSE")
+	got, err := FromCanonical(ct, "ClickHouse", RenderOpts{})
+	if err != nil {
+		t.Fatalf("FromCanonical: %v", err)
+	}
+	if got != "DateTime64(6)" {
+		t.Fatalf("rendered type = %q, want DateTime64(6)", got)
+	}
+}
+
+func hasClickHouseWarning(warnings []MappingWarning, want string) bool {
+	for _, warning := range warnings {
+		if warning.TargetDialect == "clickhouse" && strings.Contains(warning.Reason, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/schema/canonical/from_canonical.go
+++ b/schema/canonical/from_canonical.go
@@ -60,6 +60,8 @@ func FromCanonicalWithWarnings(ct CanonicalType, dialect string, opts RenderOpts
 		typ, err = fromCanonicalMySQL(ct, opts)
 	case "sqlite":
 		typ, err = fromCanonicalSQLite(ct, opts)
+	case "clickhouse":
+		typ, err = fromCanonicalClickHouse(ct, opts)
 	default:
 		return "", nil, fmt.Errorf("FromCanonical: unsupported target dialect %q", dialect)
 	}
@@ -686,6 +688,9 @@ func mappingWarnings(ct CanonicalType, target, rendered string, opts RenderOpts)
 	if target == "sqlite" {
 		out = append(out, sqliteMappingWarnings(ct, rendered)...)
 	}
+	if target == "clickhouse" {
+		out = append(out, clickhouseMappingWarnings(ct, rendered)...)
+	}
 	add := func(reason string) {
 		out = append(out, MappingWarning{
 			Kind:          kindName(ct.Kind),
@@ -700,15 +705,15 @@ func mappingWarnings(ct CanonicalType, target, rendered string, opts RenderOpts)
 			add("target has no 8-bit integer; rendered as " + rendered)
 		}
 	case MediumInt:
-		if target != "mysql" && target != "sqlite" {
+		if target != "mysql" && target != "sqlite" && target != "clickhouse" {
 			add("target has no 24-bit integer; rendered as " + rendered)
 		}
 	case SmallInt, Integer:
-		if ct.Unsigned && target != "mysql" && target != "sqlite" {
+		if ct.Unsigned && target != "mysql" && target != "sqlite" && target != "clickhouse" {
 			add("target has no unsigned integer flag; widened to " + rendered)
 		}
 	case BigInt:
-		if ct.Unsigned && target != "mysql" && target != "sqlite" && !opts.IsIdentity {
+		if ct.Unsigned && target != "mysql" && target != "sqlite" && target != "clickhouse" && !opts.IsIdentity {
 			add("target has no unsigned 64-bit integer; rendered as " + rendered)
 		}
 	case Decimal:
@@ -789,6 +794,12 @@ func mappingWarnings(ct CanonicalType, target, rendered string, opts RenderOpts)
 			add("MySQL has no native geography type; rendered as " + rendered)
 		}
 	case Array:
+		// ClickHouse has a native Array(T) type. Its mapper already emits
+		// element-level ClickHouse capability warnings above, so avoid the
+		// generic non-array fallback (and duplicate element warnings) here.
+		if target == "clickhouse" {
+			break
+		}
 		if target != "postgres" {
 			add("target has no native array type; rendered as " + rendered)
 			break
@@ -810,6 +821,8 @@ func temporalFSPMax(target string) int {
 		return 6
 	case "mssql":
 		return 7
+	case "clickhouse":
+		return 9
 	default:
 		return -1
 	}

--- a/schema/canonical/source_canonical_golden_test.go
+++ b/schema/canonical/source_canonical_golden_test.go
@@ -1,7 +1,6 @@
 package canonical
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 )
@@ -154,20 +153,5 @@ func TestToCanonical_SourceGolden(t *testing.T) {
 				t.Fatalf("ToCanonical(%q, %#v, %q) = %#v, want %#v", tc.typeName, tc.meta, tc.source, got, tc.want)
 			}
 		})
-	}
-}
-
-// ClickHouse remains intentionally unsupported. ToCanonical is permissive for
-// shared type spellings and is not a supported-dialect registry; FromCanonical
-// is the target capability boundary. Add a dedicated dialect mapper and change
-// this expectation with its own golden suite when ClickHouse becomes supported.
-func TestFromCanonical_UnsupportedClickHouseTarget(t *testing.T) {
-	_, err := FromCanonical(CanonicalType{Kind: Integer}, "clickhouse", RenderOpts{})
-	if err == nil {
-		t.Fatal("FromCanonical unexpectedly supports ClickHouse")
-	}
-	want := fmt.Sprintf("FromCanonical: unsupported target dialect %q", "clickhouse")
-	if err.Error() != want {
-		t.Fatalf("FromCanonical error = %q, want %q", err, want)
 	}
 }

--- a/schema/canonical/to_canonical.go
+++ b/schema/canonical/to_canonical.go
@@ -15,12 +15,15 @@ const (
 
 // ToCanonical normalizes a source column's dialect-specific type into the
 // dialect-neutral CanonicalType. dialect is the canonical source driver name
-// ("postgres", "mysql", "mariadb", "mssql", "sqlite"); unknown dialects are
+// ("postgres", "mysql", "mariadb", "mssql", "sqlite", "clickhouse"); unknown dialects are
 // treated permissively. An unrecognized type name becomes Kind: Raw carrying
 // the original name, so the caller's unknown-type policy decides what to do.
 func ToCanonical(typeName string, m TypeMeta, dialect string) CanonicalType {
 	if isSQLite(dialect) {
 		return sqliteToCanonical(typeName, m)
+	}
+	if isClickHouse(dialect) {
+		return clickhouseToCanonical(typeName, m)
 	}
 
 	dt := strings.ToLower(strings.TrimSpace(typeName))


### PR DESCRIPTION
## Summary
Adds the ClickHouse implementation of SMT's public canonical type mapper.

- Normalizes ClickHouse primitives, Decimal variants, dates/timestamps, UUID, JSON, enums, arrays, and nested `Nullable`/`LowCardinality` wrappers into the canonical IR.
- Renders supported canonical types to portable ClickHouse DDL and keeps unsupported/vendor-specific forms explicit.
- Integrates ClickHouse capability warnings for lossy or version-sensitive mappings, including length semantics, date range, experimental time types, JSON/XML, enum codes, and nested array elements.

## Validation

- `go test ./schema/canonical/...`
- `git diff --check main...HEAD`

This branch is one clean commit ahead of current `main` (`e1a962f`) and has no working-tree changes.