### PR TITLE
feat: adopt GitHub module path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ If you find yourself looking for these in SMT, they're intentionally gone:
 
 ## Reading the source
 
-Some files preserve DMT's original code shape unchanged (verbatim copy with module-path rewrite from `github.com/johndauphine/dmt` to `smt`). That is by design — for review, anything matching `~/repos/dmt/internal/<path>` is the same in `~/repos/smt/internal/<path>`. Files in `internal/orchestrator/`, `internal/schemadiff/`, `internal/checkpoint/snapshots.go`, and `cmd/smt/` are SMT-specific.
+Some files preserve DMT's original code shape unchanged (verbatim copy with module-path rewrite from `github.com/johndauphine/dmt` to `github.com/johndauphine/smt`). That is by design — for review, anything matching `~/repos/dmt/internal/<path>` is the same in `~/repos/smt/internal/<path>`. Files in `internal/orchestrator/`, `internal/schemadiff/`, `internal/checkpoint/snapshots.go`, and `cmd/smt/` are SMT-specific.
 
 ## Open follow-ups
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 BINARY_NAME=smt
 VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 BUILD_TIME=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-LDFLAGS=-ldflags "-s -w -X smt/internal/version.Version=$(VERSION)"
+LDFLAGS=-ldflags "-s -w -X github.com/johndauphine/smt/internal/version.Version=$(VERSION)"
 
 # Go parameters
 GOCMD=go

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ for the current release status, validation gates, and asset list.
 PostgreSQL, SQL Server, MySQL — both as source and target. New engines are added by dropping a package under `internal/driver/foo/` that implements `driver.Driver`/`Reader`/`Writer` and registers itself in `init()`.
 
 For applications that need deterministic schema DDL without using the SMT CLI,
-the public [`smt/schema`](docs/public-ddl-api.md) package exposes a registry,
+the public [`github.com/johndauphine/smt/schema`](docs/public-ddl-api.md) package exposes a registry,
 public schema values, explicit capability checks, and structured mapping
 warnings. It currently renders PostgreSQL, SQL Server, MySQL, SQLite, and
 ClickHouse DDL at schema/table/column scope.

--- a/cmd/smt/config_loader.go
+++ b/cmd/smt/config_loader.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"smt/internal/checkpoint"
-	"smt/internal/config"
+	"github.com/johndauphine/smt/internal/checkpoint"
+	"github.com/johndauphine/smt/internal/config"
 )
 
 // loadConfig returns the resolved Config along with the profile name and

--- a/cmd/smt/drift.go
+++ b/cmd/smt/drift.go
@@ -19,13 +19,13 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"smt/internal/config"
-	"smt/internal/driver"
-	"smt/internal/exitcodes"
-	"smt/internal/logging"
-	"smt/internal/orchestrator"
-	"smt/internal/pool"
-	"smt/internal/schemadiff"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/exitcodes"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/orchestrator"
+	"github.com/johndauphine/smt/internal/pool"
+	"github.com/johndauphine/smt/internal/schemadiff"
 )
 
 func driftCommand() *cli.Command {

--- a/cmd/smt/drift_test.go
+++ b/cmd/smt/drift_test.go
@@ -3,8 +3,8 @@ package main
 import (
 	"testing"
 
-	"smt/internal/config"
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // targetAsSource must carry the connection details the target reader needs,

--- a/cmd/smt/init.go
+++ b/cmd/smt/init.go
@@ -16,8 +16,8 @@ import (
 	xterm "github.com/charmbracelet/x/term"
 	"github.com/urfave/cli/v2"
 
-	"smt/internal/orchestrator"
-	"smt/internal/wizard"
+	"github.com/johndauphine/smt/internal/orchestrator"
+	"github.com/johndauphine/smt/internal/wizard"
 )
 
 func initCommand() *cli.Command {

--- a/cmd/smt/main.go
+++ b/cmd/smt/main.go
@@ -15,10 +15,10 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"smt/internal/exitcodes"
-	"smt/internal/logging"
-	"smt/internal/tui"
-	"smt/internal/version"
+	"github.com/johndauphine/smt/internal/exitcodes"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/tui"
+	"github.com/johndauphine/smt/internal/version"
 )
 
 func main() {

--- a/cmd/smt/main_test.go
+++ b/cmd/smt/main_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"smt/internal/exitcodes"
+	"github.com/johndauphine/smt/internal/exitcodes"
 )
 
 func TestTopLevelAction_UnknownCommandReturnsError(t *testing.T) {

--- a/cmd/smt/profile.go
+++ b/cmd/smt/profile.go
@@ -14,8 +14,8 @@ import (
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v3"
 
-	"smt/internal/checkpoint"
-	"smt/internal/config"
+	"github.com/johndauphine/smt/internal/checkpoint"
+	"github.com/johndauphine/smt/internal/config"
 )
 
 func profileCommand() *cli.Command {

--- a/cmd/smt/run.go
+++ b/cmd/smt/run.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"smt/internal/config"
-	"smt/internal/ddl"
-	"smt/internal/exitcodes"
-	"smt/internal/orchestrator"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/ddl"
+	"github.com/johndauphine/smt/internal/exitcodes"
+	"github.com/johndauphine/smt/internal/orchestrator"
 )
 
 // createCommand defines `smt create`: extract the source schema and apply

--- a/cmd/smt/run_test.go
+++ b/cmd/smt/run_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/config"
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 func TestValidateCreateSupport(t *testing.T) {

--- a/cmd/smt/secrets.go
+++ b/cmd/smt/secrets.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"smt/internal/secrets"
+	"github.com/johndauphine/smt/internal/secrets"
 )
 
 func initSecretsCommand() *cli.Command {

--- a/cmd/smt/snapshot_list_test.go
+++ b/cmd/smt/snapshot_list_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"smt/internal/checkpoint"
-	"smt/internal/driver"
-	"smt/internal/schemadiff"
+	"github.com/johndauphine/smt/internal/checkpoint"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/schemadiff"
 )
 
 // saveSnap stores a schemadiff.Snapshot with tableCount empty tables.

--- a/cmd/smt/sync.go
+++ b/cmd/smt/sync.go
@@ -30,16 +30,16 @@ import (
 	"github.com/google/uuid"
 	"github.com/urfave/cli/v2"
 
-	"smt/internal/checkpoint"
-	"smt/internal/config"
-	"smt/internal/ddl"
-	"smt/internal/driver"
-	"smt/internal/exitcodes"
-	"smt/internal/logging"
-	"smt/internal/orchestrator"
-	"smt/internal/pool"
-	"smt/internal/schemadiff"
-	"smt/internal/version"
+	"github.com/johndauphine/smt/internal/checkpoint"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/ddl"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/exitcodes"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/orchestrator"
+	"github.com/johndauphine/smt/internal/pool"
+	"github.com/johndauphine/smt/internal/schemadiff"
+	"github.com/johndauphine/smt/internal/version"
 )
 
 func snapshotCommand() *cli.Command {

--- a/cmd/smt/sync_test.go
+++ b/cmd/smt/sync_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"smt/internal/checkpoint"
-	"smt/internal/config"
-	"smt/internal/driver"
-	"smt/internal/schemadiff"
+	"github.com/johndauphine/smt/internal/checkpoint"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/schemadiff"
 )
 
 // stubExecutor records every SQL it's asked to run and optionally fails

--- a/docs/public-ddl-api.md
+++ b/docs/public-ddl-api.md
@@ -1,9 +1,18 @@
 # Public schema DDL API
 
-`smt/schema` is the supported library surface for deterministic schema, table,
-and column DDL. It uses SMT's existing renderer and canonical type mapper; its
-input and result types do not expose `internal/*` packages or database handles.
-It does not load a database driver or require a PostgreSQL client dependency.
+`github.com/johndauphine/smt/schema` is the supported library surface for
+deterministic schema, table, and column DDL. It uses SMT's existing renderer
+and canonical type mapper; its input and result types do not expose `internal/*`
+packages or database handles. It does not load a database driver or require a
+PostgreSQL client dependency.
+
+## Module consumption
+
+Require the module as `github.com/johndauphine/smt`; the public canonical type
+API is `github.com/johndauphine/smt/schema/canonical`. SMT declares Go 1.25.7.
+Downstream DMT currently declares Go 1.25.0, so its module directive must be
+raised to Go 1.25.7 when it adds this dependency. No `replace` directive is
+needed after an SMT release is available.
 
 ```go
 renderer, err := schema.NewRenderer(schema.Options{

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module smt
+module github.com/johndauphine/smt
 
 go 1.25.7
 

--- a/internal/canonical/compat.go
+++ b/internal/canonical/compat.go
@@ -1,10 +1,10 @@
 // Package canonical preserves SMT's former internal import path.
 //
-// Deprecated: new code should import smt/schema/canonical. The implementation
+// Deprecated: new code should import github.com/johndauphine/smt/schema/canonical. The implementation
 // lives there so it can be consumed as a public, dependency-free leaf package.
 package canonical
 
-import public "smt/schema/canonical"
+import public "github.com/johndauphine/smt/schema/canonical"
 
 type (
 	Kind           = public.Kind

--- a/internal/checkpoint/profiles.go
+++ b/internal/checkpoint/profiles.go
@@ -12,8 +12,8 @@ import (
 	"os"
 	"time"
 
-	"smt/internal/logging"
-	"smt/internal/secrets"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/secrets"
 )
 
 const (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,16 +8,16 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/johndauphine/smt/internal/dbconfig"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/secrets"
 	"gopkg.in/yaml.v3"
-	"smt/internal/dbconfig"
-	"smt/internal/driver"
-	"smt/internal/logging"
-	"smt/internal/secrets"
 
 	// Import driver packages to trigger init() registration before validation
-	_ "smt/internal/driver/mssql"
-	_ "smt/internal/driver/mysql"
-	_ "smt/internal/driver/postgres"
+	_ "github.com/johndauphine/smt/internal/driver/mssql"
+	_ "github.com/johndauphine/smt/internal/driver/mysql"
+	_ "github.com/johndauphine/smt/internal/driver/postgres"
 )
 
 // Type aliases for database configuration types.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/secrets"
+	"github.com/johndauphine/smt/internal/secrets"
 )
 
 func disableSecretsForTest(t *testing.T) {

--- a/internal/ddl/postgres/exprerror_test.go
+++ b/internal/ddl/postgres/exprerror_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // The deterministic renderer must surface an unsupported DEFAULT as a structured

--- a/internal/ddl/postgres/renderer.go
+++ b/internal/ddl/postgres/renderer.go
@@ -6,10 +6,10 @@ import (
 	"regexp"
 	"strings"
 
-	"smt/internal/driver"
-	exprir "smt/internal/expr"
-	"smt/internal/logging"
-	"smt/schema/canonical"
+	"github.com/johndauphine/smt/internal/driver"
+	exprir "github.com/johndauphine/smt/internal/expr"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/schema/canonical"
 )
 
 type deterministicDDL struct {

--- a/internal/ddl/postgres/renderer_fixes_test.go
+++ b/internal/ddl/postgres/renderer_fixes_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // #79 — DEFAULT (NULL) on a textual column must stay SQL NULL, not become the

--- a/internal/ddl/postgres/renderer_test.go
+++ b/internal/ddl/postgres/renderer_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 func TestDeterministicCreateTableMSSQLToPostgres(t *testing.T) {

--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"sync"
 
-	pgddl "smt/internal/ddl/postgres"
-	"smt/internal/driver"
-	exprir "smt/internal/expr"
-	"smt/internal/logging"
-	"smt/schema/canonical"
+	pgddl "github.com/johndauphine/smt/internal/ddl/postgres"
+	"github.com/johndauphine/smt/internal/driver"
+	exprir "github.com/johndauphine/smt/internal/expr"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/schema/canonical"
 )
 
 // RendererVersion identifies the deterministic renderer's output contract.

--- a/internal/ddl/renderer_fixes_test.go
+++ b/internal/ddl/renderer_fixes_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/driver"
-	"smt/internal/logging"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/logging"
 )
 
 // #86 — the CHECK keyword must only be stripped at a word boundary, not off

--- a/internal/ddl/renderer_fsp_test.go
+++ b/internal/ddl/renderer_fsp_test.go
@@ -3,7 +3,7 @@ package ddl
 import (
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 func intp(v int) *int { return &v }

--- a/internal/ddl/renderer_source_dialect_test.go
+++ b/internal/ddl/renderer_source_dialect_test.go
@@ -3,7 +3,7 @@ package ddl
 import (
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // #101 — mysql→mysql round-trips must preserve TIMESTAMP (UTC-normalized,

--- a/internal/ddl/renderer_test.go
+++ b/internal/ddl/renderer_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 func TestRenderer_CreateTableMSSQL(t *testing.T) {

--- a/internal/driver/ai_errordiag.go
+++ b/internal/driver/ai_errordiag.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"unicode/utf8"
 
-	"smt/internal/logging"
+	"github.com/johndauphine/smt/internal/logging"
 )
 
 // ErrorDiagnosis contains AI-generated analysis of a migration error.

--- a/internal/driver/ai_typemapper.go
+++ b/internal/driver/ai_typemapper.go
@@ -16,8 +16,8 @@ import (
 	"sync"
 	"time"
 
-	"smt/internal/logging"
-	"smt/internal/secrets"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/secrets"
 )
 
 // Retry configuration constants

--- a/internal/driver/ai_typemapper_test.go
+++ b/internal/driver/ai_typemapper_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"smt/internal/secrets"
+	"github.com/johndauphine/smt/internal/secrets"
 )
 
 func testProvider(apiKey string) *secrets.Provider {

--- a/internal/driver/ai_verify.go
+++ b/internal/driver/ai_verify.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"smt/internal/logging"
+	"github.com/johndauphine/smt/internal/logging"
 )
 
 // VerifyTableDDL audits a generated CREATE TABLE statement against the

--- a/internal/driver/conformance/conformance.go
+++ b/internal/driver/conformance/conformance.go
@@ -32,7 +32,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // DriverCase describes one engine's driver-contract expectations. Every field

--- a/internal/driver/conformance/mssql_conformance_test.go
+++ b/internal/driver/conformance/mssql_conformance_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"smt/internal/driver"
-	"smt/internal/driver/mssql"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver/mssql"
 )
 
 // TestMSSQLConformance pins the SQL Server driver contract.

--- a/internal/driver/conformance/mysql_conformance_test.go
+++ b/internal/driver/conformance/mysql_conformance_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"smt/internal/driver"
-	"smt/internal/driver/mysql"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver/mysql"
 )
 
 // TestMySQLConformance pins the MySQL/MariaDB driver contract.

--- a/internal/driver/conformance/postgres_conformance_test.go
+++ b/internal/driver/conformance/postgres_conformance_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"smt/internal/driver"
-	"smt/internal/driver/postgres"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver/postgres"
 )
 
 // TestPostgresConformance pins the PostgreSQL driver contract.

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -4,7 +4,7 @@
 package driver
 
 import (
-	"smt/internal/dbconfig"
+	"github.com/johndauphine/smt/internal/dbconfig"
 )
 
 // DriverDefaults contains default values for a database driver.

--- a/internal/driver/live_ai_smoke_test.go
+++ b/internal/driver/live_ai_smoke_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"smt/internal/secrets"
+	"github.com/johndauphine/smt/internal/secrets"
 )
 
 type liveAISmokeReport struct {

--- a/internal/driver/mssql/driver.go
+++ b/internal/driver/mssql/driver.go
@@ -1,8 +1,8 @@
 package mssql
 
 import (
-	"smt/internal/dbconfig"
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/dbconfig"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 func init() {

--- a/internal/driver/mssql/driver_test.go
+++ b/internal/driver/mssql/driver_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // TestReaderDatabaseContext_Populated is the mssql side of the issue #13

--- a/internal/driver/mssql/reader.go
+++ b/internal/driver/mssql/reader.go
@@ -8,12 +8,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/johndauphine/smt/internal/dbconfig"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/stats"
+	"github.com/johndauphine/smt/internal/util"
 	_ "github.com/microsoft/go-mssqldb"
-	"smt/internal/dbconfig"
-	"smt/internal/driver"
-	"smt/internal/logging"
-	"smt/internal/stats"
-	"smt/internal/util"
 )
 
 // Reader implements driver.Reader for SQL Server.

--- a/internal/driver/mssql/writer.go
+++ b/internal/driver/mssql/writer.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"time"
 
-	"smt/internal/dbconfig"
-	"smt/internal/driver"
-	"smt/internal/logging"
-	"smt/internal/stats"
+	"github.com/johndauphine/smt/internal/dbconfig"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/stats"
 )
 
 // Writer implements driver.Writer for SQL Server.

--- a/internal/driver/mysql/driver.go
+++ b/internal/driver/mysql/driver.go
@@ -3,8 +3,8 @@
 package mysql
 
 import (
-	"smt/internal/dbconfig"
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/dbconfig"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 func init() {

--- a/internal/driver/mysql/reader.go
+++ b/internal/driver/mysql/reader.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql" // MySQL driver
-	"smt/internal/dbconfig"
-	"smt/internal/driver"
-	"smt/internal/logging"
-	"smt/internal/stats"
+	"github.com/johndauphine/smt/internal/dbconfig"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/stats"
 )
 
 // Reader implements driver.Reader for MySQL/MariaDB.

--- a/internal/driver/mysql/reader_test.go
+++ b/internal/driver/mysql/reader_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // TestParseGeneratedColumnExtra is the regression test for issue #18.

--- a/internal/driver/mysql/writer.go
+++ b/internal/driver/mysql/writer.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
-	"smt/internal/dbconfig"
-	"smt/internal/driver"
-	"smt/internal/logging"
-	"smt/internal/stats"
+	"github.com/johndauphine/smt/internal/dbconfig"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/stats"
 )
 
 // Writer implements driver.Writer for MySQL/MariaDB.

--- a/internal/driver/postgres/deterministic.go
+++ b/internal/driver/postgres/deterministic.go
@@ -1,8 +1,8 @@
 package postgres
 
 import (
-	pgddl "smt/internal/ddl/postgres"
-	"smt/internal/driver"
+	pgddl "github.com/johndauphine/smt/internal/ddl/postgres"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // The deterministic DDL implementation lives in internal/ddl/postgres so it

--- a/internal/driver/postgres/deterministic_adapter_test.go
+++ b/internal/driver/postgres/deterministic_adapter_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	purepostgres "smt/internal/ddl/postgres"
-	"smt/internal/driver"
+	purepostgres "github.com/johndauphine/smt/internal/ddl/postgres"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 func TestDeterministicDDLAdapterMatchesPureRenderer(t *testing.T) {

--- a/internal/driver/postgres/driver.go
+++ b/internal/driver/postgres/driver.go
@@ -3,8 +3,8 @@
 package postgres
 
 import (
-	"smt/internal/dbconfig"
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/dbconfig"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 func init() {

--- a/internal/driver/postgres/driver_test.go
+++ b/internal/driver/postgres/driver_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // TestLoadColumnsSQL_DetectsModernIdentity is a regression guard for the

--- a/internal/driver/postgres/reader.go
+++ b/internal/driver/postgres/reader.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // pgx driver for database/sql
-	"smt/internal/dbconfig"
-	"smt/internal/driver"
-	"smt/internal/logging"
-	"smt/internal/stats"
+	"github.com/johndauphine/smt/internal/dbconfig"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/stats"
 )
 
 // Reader implements driver.Reader for PostgreSQL using pgx.

--- a/internal/driver/postgres/writer.go
+++ b/internal/driver/postgres/writer.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
-	"smt/internal/dbconfig"
-	"smt/internal/driver"
-	"smt/internal/logging"
-	"smt/internal/stats"
+	"github.com/johndauphine/smt/internal/dbconfig"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/stats"
 )
 
 // sanitizePGIdentifier delegates to driver.NormalizeIdentifier so the

--- a/internal/driver/reader.go
+++ b/internal/driver/reader.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 
-	"smt/internal/stats"
+	"github.com/johndauphine/smt/internal/stats"
 )
 
 // Reader represents a database reader that extracts schema metadata from a

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -6,7 +6,7 @@ import (
 	"time"
 	"unsafe"
 
-	"smt/schema/canonical"
+	"github.com/johndauphine/smt/schema/canonical"
 )
 
 // Table represents a database table with its metadata.

--- a/internal/driver/verify_compare.go
+++ b/internal/driver/verify_compare.go
@@ -20,8 +20,8 @@ import (
 	"regexp"
 	"strings"
 
-	exprir "smt/internal/expr"
-	"smt/schema/canonical"
+	exprir "github.com/johndauphine/smt/internal/expr"
+	"github.com/johndauphine/smt/schema/canonical"
 )
 
 var renderedTypeArgsRE = regexp.MustCompile(`\([^)]*\)`)

--- a/internal/driver/verify_finalization.go
+++ b/internal/driver/verify_finalization.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	exprir "smt/internal/expr"
+	exprir "github.com/johndauphine/smt/internal/expr"
 )
 
 // VerifyFinalizationDDLDeterministic parses SMT-rendered side-object DDL and

--- a/internal/driver/verify_parse_test.go
+++ b/internal/driver/verify_parse_test.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"smt/internal/secrets"
+	"github.com/johndauphine/smt/internal/secrets"
 )
 
 // TestParseTargetDDLToColumns_HappyPath asserts the parser threads a clean

--- a/internal/driver/writer.go
+++ b/internal/driver/writer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 
-	"smt/internal/stats"
+	"github.com/johndauphine/smt/internal/stats"
 )
 
 // Writer represents a database writer that executes DDL against a target

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"smt/internal/secrets"
+	"github.com/johndauphine/smt/internal/secrets"
 )
 
 // SlackConfig holds Slack notification settings (loaded from global secrets)

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"smt/internal/secrets"
+	"github.com/johndauphine/smt/internal/secrets"
 )
 
 func TestNew(t *testing.T) {

--- a/internal/orchestrator/crm_acceptance_test.go
+++ b/internal/orchestrator/crm_acceptance_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"smt/internal/config"
-	"smt/internal/driver"
-	"smt/internal/pool"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/pool"
 )
 
 type crmAcceptanceCase struct {

--- a/internal/orchestrator/ddl_plan.go
+++ b/internal/orchestrator/ddl_plan.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/google/uuid"
 
-	"smt/internal/checkpoint"
-	"smt/internal/ddl"
-	"smt/internal/driver"
-	"smt/internal/logging"
-	"smt/internal/schemadiff"
-	"smt/internal/source"
+	"github.com/johndauphine/smt/internal/checkpoint"
+	"github.com/johndauphine/smt/internal/ddl"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/schemadiff"
+	"github.com/johndauphine/smt/internal/source"
 )
 
 // GenerateDDL renders the full create-schema plan without opening or applying

--- a/internal/orchestrator/diagnose.go
+++ b/internal/orchestrator/diagnose.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"smt/internal/driver"
-	"smt/internal/logging"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/logging"
 )
 
 // diagnoseSchemaFailure is the opt-in AI advisory hook (ai_review.

--- a/internal/orchestrator/diagnose_test.go
+++ b/internal/orchestrator/diagnose_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/config"
-	ddlpkg "smt/internal/ddl"
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/config"
+	ddlpkg "github.com/johndauphine/smt/internal/ddl"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 type fakeExpressionFixSuggester struct {

--- a/internal/orchestrator/execute_plan_test.go
+++ b/internal/orchestrator/execute_plan_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/checkpoint"
-	"smt/internal/config"
-	"smt/internal/driver"
-	"smt/internal/logging"
-	"smt/internal/schemadiff"
+	"github.com/johndauphine/smt/internal/checkpoint"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/schemadiff"
 )
 
 type fakeWriter struct {

--- a/internal/orchestrator/history.go
+++ b/internal/orchestrator/history.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"smt/internal/checkpoint"
+	"github.com/johndauphine/smt/internal/checkpoint"
 )
 
 // ShowHistory renders all known runs (most recent first) into w as a small

--- a/internal/orchestrator/manifest.go
+++ b/internal/orchestrator/manifest.go
@@ -20,9 +20,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"smt/internal/ddl"
-	"smt/internal/driver"
-	"smt/internal/version"
+	"github.com/johndauphine/smt/internal/ddl"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/version"
 )
 
 // manifestArtifactName is the filename of the run manifest. It lives in the

--- a/internal/orchestrator/manifest_test.go
+++ b/internal/orchestrator/manifest_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // Fingerprints must be stable for identical input and change when the input

--- a/internal/orchestrator/mapping_warnings.go
+++ b/internal/orchestrator/mapping_warnings.go
@@ -3,8 +3,8 @@ package orchestrator
 import (
 	"strings"
 
-	"smt/internal/driver"
-	"smt/schema/canonical"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/schema/canonical"
 )
 
 type mappingWarning struct {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -16,12 +16,12 @@ import (
 	"fmt"
 	"sync"
 
-	"smt/internal/checkpoint"
-	"smt/internal/config"
-	"smt/internal/driver"
-	"smt/internal/notify"
-	"smt/internal/pool"
-	"smt/internal/source"
+	"github.com/johndauphine/smt/internal/checkpoint"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/notify"
+	"github.com/johndauphine/smt/internal/pool"
+	"github.com/johndauphine/smt/internal/source"
 )
 
 // Options configures the orchestrator.

--- a/internal/orchestrator/parallel_test.go
+++ b/internal/orchestrator/parallel_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"smt/internal/config"
+	"github.com/johndauphine/smt/internal/config"
 )
 
 // makeConfig builds the minimal config needed by tests that exercise

--- a/internal/orchestrator/phases.go
+++ b/internal/orchestrator/phases.go
@@ -16,10 +16,10 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 
-	"smt/internal/checkpoint"
-	"smt/internal/logging"
-	"smt/internal/schemadiff"
-	"smt/internal/source"
+	"github.com/johndauphine/smt/internal/checkpoint"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/schemadiff"
+	"github.com/johndauphine/smt/internal/source"
 )
 
 // defaultAIConcurrency is the number of concurrent AI calls used when

--- a/internal/orchestrator/phases_test.go
+++ b/internal/orchestrator/phases_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/config"
-	"smt/internal/ddl"
-	"smt/internal/source"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/ddl"
+	"github.com/johndauphine/smt/internal/source"
 )
 
 func tbl(name string) source.Table { return source.Table{Name: name} }

--- a/internal/orchestrator/review_contract_test.go
+++ b/internal/orchestrator/review_contract_test.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/config"
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // fakeReviewer implements both reviewer interfaces with scripted behavior and

--- a/internal/orchestrator/slack_test.go
+++ b/internal/orchestrator/slack_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"smt/internal/config"
-	"smt/internal/secrets"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/secrets"
 )
 
 func TestNewNotifierHonorsDisabledSlackConfig(t *testing.T) {

--- a/internal/orchestrator/so2010_acceptance_test.go
+++ b/internal/orchestrator/so2010_acceptance_test.go
@@ -29,10 +29,10 @@ import (
 	"testing"
 	"time"
 
-	"smt/internal/config"
-	"smt/internal/ddl"
-	"smt/internal/driver"
-	"smt/internal/pool"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/ddl"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/pool"
 )
 
 func env(key, def string) string {

--- a/internal/pool/factory.go
+++ b/internal/pool/factory.go
@@ -3,14 +3,14 @@ package pool
 import (
 	"fmt"
 
-	"smt/internal/config"
-	"smt/internal/dbconfig"
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/dbconfig"
+	"github.com/johndauphine/smt/internal/driver"
 
 	// Import driver packages to trigger init() registration
-	_ "smt/internal/driver/mssql"
-	_ "smt/internal/driver/mysql"
-	_ "smt/internal/driver/postgres"
+	_ "github.com/johndauphine/smt/internal/driver/mssql"
+	_ "github.com/johndauphine/smt/internal/driver/mysql"
+	_ "github.com/johndauphine/smt/internal/driver/postgres"
 )
 
 // NewSourcePool creates a source pool based on the configuration type.

--- a/internal/pool/interfaces.go
+++ b/internal/pool/interfaces.go
@@ -3,7 +3,7 @@
 package pool
 
 import (
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // SourcePool is an alias for driver.Reader for backward compatibility.

--- a/internal/schemadiff/compat_test.go
+++ b/internal/schemadiff/compat_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 func TestSnapshotV1FixtureDeserializes(t *testing.T) {

--- a/internal/schemadiff/diff.go
+++ b/internal/schemadiff/diff.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // Diff is the delta between a previous snapshot and the current source state.

--- a/internal/schemadiff/diff_test.go
+++ b/internal/schemadiff/diff_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 func col(name, dtype string, nullable bool) driver.Column {

--- a/internal/schemadiff/drift.go
+++ b/internal/schemadiff/drift.go
@@ -18,7 +18,7 @@ import (
 	"strconv"
 	"strings"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // Drift is the classified difference between the desired and existing target

--- a/internal/schemadiff/drift_test.go
+++ b/internal/schemadiff/drift_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 func dcol(name, dt string, opts ...func(*driver.Column)) driver.Column {

--- a/internal/schemadiff/golden_test.go
+++ b/internal/schemadiff/golden_test.go
@@ -16,7 +16,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // goldenDiff builds a diff that exercises every statement family the sync

--- a/internal/schemadiff/live_diff.go
+++ b/internal/schemadiff/live_diff.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // ComputeLiveDiff compares the desired target schema derived from the current

--- a/internal/schemadiff/live_diff_test.go
+++ b/internal/schemadiff/live_diff_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 func TestComputeLiveDiff_NoFalsePositiveCrossDialect(t *testing.T) {

--- a/internal/schemadiff/render_deterministic.go
+++ b/internal/schemadiff/render_deterministic.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"smt/internal/ddl"
-	"smt/internal/driver"
-	"smt/schema/canonical"
+	"github.com/johndauphine/smt/internal/ddl"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/schema/canonical"
 )
 
 // RenderDeterministic converts a structural diff into a local, deterministic

--- a/internal/schemadiff/snapshot.go
+++ b/internal/schemadiff/snapshot.go
@@ -12,7 +12,7 @@ package schemadiff
 import (
 	"time"
 
-	"smt/internal/driver"
+	"github.com/johndauphine/smt/internal/driver"
 )
 
 // CurrentSnapshotVersion is stamped into every new snapshot. Bump it whenever

--- a/internal/secrets/migration_defaults_test.go
+++ b/internal/secrets/migration_defaults_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/logging"
+	"github.com/johndauphine/smt/internal/logging"
 )
 
 // TestMigrationDefaultsV1Shape pins the v1 migration_defaults contract: exactly

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -10,7 +10,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"smt/internal/logging"
+	"github.com/johndauphine/smt/internal/logging"
 )
 
 const (

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -2,7 +2,7 @@
 // All types are now defined in the driver package.
 package source
 
-import "smt/internal/driver"
+import "github.com/johndauphine/smt/internal/driver"
 
 // Type aliases for backward compatibility.
 // These allow existing code using source.Table, source.Column, etc.

--- a/internal/tui/capture.go
+++ b/internal/tui/capture.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"smt/internal/logging"
+	"github.com/johndauphine/smt/internal/logging"
 )
 
 // CaptureOutput pipes stdout and stderr to a channel that feeds the TUI

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -15,13 +15,13 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/johndauphine/smt/internal/checkpoint"
+	"github.com/johndauphine/smt/internal/config"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/internal/logging"
+	"github.com/johndauphine/smt/internal/orchestrator"
+	"github.com/johndauphine/smt/internal/version"
 	"gopkg.in/yaml.v3"
-	"smt/internal/checkpoint"
-	"smt/internal/config"
-	"smt/internal/driver"
-	"smt/internal/logging"
-	"smt/internal/orchestrator"
-	"smt/internal/version"
 )
 
 // maxContentLines limits output retained in memory to prevent unbounded growth

--- a/internal/tui/wizard.go
+++ b/internal/tui/wizard.go
@@ -13,7 +13,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
-	"smt/internal/wizard"
+	"github.com/johndauphine/smt/internal/wizard"
 )
 
 // wizardState holds the in-progress wizard for ModeWizard.

--- a/internal/tui/wizard_test.go
+++ b/internal/tui/wizard_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
-	"smt/internal/config"
+	"github.com/johndauphine/smt/internal/config"
 )
 
 // ready returns an initialized model with a sized viewport so appendOutput is

--- a/internal/wizard/answers.go
+++ b/internal/wizard/answers.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"strings"
 
-	"smt/internal/config"
+	"github.com/johndauphine/smt/internal/config"
 )
 
 // Engines are the supported database engines, used for both source and target.

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/config"
+	"github.com/johndauphine/smt/internal/config"
 )
 
 // fullAnswers returns a maximal set of answers exercising every optional block.

--- a/schema/canonical/canonical_public_test.go
+++ b/schema/canonical/canonical_public_test.go
@@ -3,7 +3,7 @@ package canonical_test
 import (
 	"testing"
 
-	"smt/schema/canonical"
+	"github.com/johndauphine/smt/schema/canonical"
 )
 
 func TestPublicPackageSupportsTypeMapping(t *testing.T) {

--- a/schema/canonical/from_canonical_tz_test.go
+++ b/schema/canonical/from_canonical_tz_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/schema/canonical"
+	"github.com/johndauphine/smt/schema/canonical"
 )
 
 func TestFromCanonical_TZAwareTimestampMapping(t *testing.T) {

--- a/schema/canonical/oracle_all_test.go
+++ b/schema/canonical/oracle_all_test.go
@@ -6,8 +6,8 @@ package canonical_test
 import (
 	"testing"
 
-	"smt/internal/ddl"
-	"smt/schema/canonical"
+	"github.com/johndauphine/smt/internal/ddl"
+	"github.com/johndauphine/smt/schema/canonical"
 )
 
 func runOracle(t *testing.T, target string) {

--- a/schema/canonical/oracle_pg_test.go
+++ b/schema/canonical/oracle_pg_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"smt/internal/driver"
-	pgddl "smt/internal/driver/postgres"
-	"smt/schema/canonical"
+	"github.com/johndauphine/smt/internal/driver"
+	pgddl "github.com/johndauphine/smt/internal/driver/postgres"
+	"github.com/johndauphine/smt/schema/canonical"
 )
 
 type tcase struct {

--- a/schema/ddl.go
+++ b/schema/ddl.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"sync"
 
-	"smt/internal/ddl"
-	"smt/internal/driver"
-	"smt/schema/canonical"
+	"github.com/johndauphine/smt/internal/ddl"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/schema/canonical"
 )
 
 // UnknownTypePolicy controls what built-in dialects do with a source type

--- a/schema/ddl_public_test.go
+++ b/schema/ddl_public_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"smt/schema"
+	"github.com/johndauphine/smt/schema"
 )
 
 func TestPublicDDLRepresentativeGoldens(t *testing.T) {


### PR DESCRIPTION
## Summary

Migrates SMT to the canonical Go module path `github.com/johndauphine/smt`.

- Updates all in-repository Go imports plus documentation and build metadata to the GitHub module path.
- Preserves the public `schema` and `schema/canonical` packages for downstream users.
- Keeps the DMT consumer requirement at Go 1.25.7; SMT's `go.mod` declares `go 1.25.7`.
- Makes no behavioral or source-logic changes beyond the module-path migration.

## Verification

- `git diff --check origin/main...HEAD`
- `go test ./... -count=1`
- `go build -trimpath -o /private/tmp/smt-module-path-build ./cmd/smt`
- Clean, isolated downstream-consumer check: resolved `github.com/johndauphine/smt/schema/canonical@914fb4b` from public GitHub with `GOPROXY=direct`, then built it offline with `GOPROXY=off`; the generated consumer `go.mod` contains no `replace` directive.

The local race run could not load `runtime/race` from this host's Go installation, so the required GitHub Actions Race Tests check remains the authoritative gate alongside Unit Tests, Lint, Build CLI, and the CRM Fixture Matrix.

## Review policy

Only valid, actionable feedback will be addressed. Copilot review is requested when available; if no usable automated review arrives within 10 minutes, an independent review will be performed. This PR must not merge until all required checks are green.