### PR TITLE
feat(schema): expose public side-object DDL API

### DIFF
--- a/docs/public-ddl-api.md
+++ b/docs/public-ddl-api.md
@@ -1,10 +1,10 @@
 # Public schema DDL API
 
 `github.com/johndauphine/smt/schema` is the supported library surface for
-deterministic schema, table, and column DDL. It uses SMT's existing renderer
-and canonical type mapper; its input and result types do not expose `internal/*`
-packages or database handles. It does not load a database driver or require a
-PostgreSQL client dependency.
+deterministic schema, table, column, index, and constraint DDL. It uses SMT's
+existing renderer and canonical type mapper; its input and result types do not
+expose `internal/*` packages or database handles. It does not load a database
+driver or require a PostgreSQL client dependency.
 
 ## Module consumption
 
@@ -59,8 +59,54 @@ for _, statement := range plan.Statements {
 ```
 
 The create plan deliberately contains only schema/database and table artifacts
-(including columns and primary keys). Indexes, foreign keys, checks, alters,
-and drops are not represented yet.
+(including inline primary keys). Use the standalone side-object methods after
+the table statements in the execution order your application chooses:
+
+```go
+orders := schema.TableRef{
+    Name: "orders",
+    Columns: []schema.Column{
+        {Name: "id", DataType: "bigint"},
+        {Name: "email", DataType: "varchar", MaxLength: 255},
+    },
+}
+
+// This is a unique index, not a UNIQUE constraint.
+index, err := renderer.CreateIndex(orders, schema.Index{
+    Name: "ix_orders_email", Columns: []string{"email"}, IsUnique: true,
+})
+if err != nil {
+    return err
+}
+
+// A named UNIQUE constraint is a distinct database object.
+unique, err := renderer.CreateUniqueConstraint(orders, schema.UniqueConstraint{
+    Name: "uq_orders_email", Columns: []string{"email"},
+})
+if err != nil {
+    return err
+}
+
+check, err := renderer.CreateCheckConstraint(orders, schema.CheckConstraint{
+    Name: "ck_orders_id", Expression: "id > 0",
+})
+if err != nil {
+    return err
+}
+for _, result := range []schema.Result{index, unique, check} {
+    if err := target.ExecRaw(ctx, result.SQL); err != nil {
+        return err
+    }
+}
+```
+
+`TableRef.Columns` is optional for named primary/unique constraints. Provide it
+for a filtered-index predicate or check expression when source column types are
+needed for deterministic translation (for example boolean conventions).
+`CreatePrimaryKey` uses an explicit name when supplied, otherwise it derives
+`pk_<table>` using the same deterministic naming convention as `CreateTable`.
+
+Foreign keys, alter, drop, and scheduling remain outside this public milestone.
 
 `SourceDialect` is optional, but callers should set it whenever it is known:
 some names have source-specific meanings, such as MySQL `TINYINT(1)` and
@@ -73,17 +119,29 @@ empty `DefaultExpression` still represents a source `DEFAULT` clause.
 
 A new `schema.Registry` starts with these dialects and aliases:
 
-| Dialect | Aliases | Schema DDL | Table/column DDL |
-| --- | --- | --- | --- |
-| `postgres` | `postgresql`, `pg` | yes | yes |
-| `mssql` | `sqlserver`, `sql-server`, `sql_server` | yes | yes |
-| `mysql` | `mariadb`, `maria` | yes | yes |
-| `sqlite` | `sqlite3` | no | yes |
-| `clickhouse` | `click-house` | database | yes |
+| Dialect | Aliases | Schema/table/column | Secondary indexes | Standalone PK / named UNIQUE / CHECK |
+| --- | --- | --- | --- | --- |
+| `postgres` | `postgresql`, `pg` | yes | yes | yes |
+| `mssql` | `sqlserver`, `sql-server`, `sql_server` | yes | yes | yes |
+| `mysql` | `mariadb`, `maria` | yes | yes | yes |
+| `sqlite` | `sqlite3` | no schema / yes table-column | yes | no |
+| `clickhouse` | `click-house` | database / yes table-column | no | no |
 
 Inspect `renderer.Capabilities()` before using identities, defaults, computed
-columns, or a named schema. If input requests an unsupported feature, rendering
-returns `*schema.UnsupportedFeatureError`; SMT never silently drops it.
+columns, a named schema, or a side-object feature. The side-object fields are
+`SecondaryIndexes`, `StandalonePrimaryKeys`, `NamedUniqueConstraints`,
+`CheckConstraints`, `IndexExpressionKeys`, `IndexPrefixLengths`,
+`IndexIncludeColumns`, and `FilteredIndexes`. If input requests an unsupported
+feature, rendering returns `*schema.UnsupportedFeatureError`; SMT never
+silently drops it.
+
+PostgreSQL supports expression-key, included-column, and filtered indexes.
+SQL Server supports included-column and filtered indexes. MySQL supports
+expression-key and prefix-length index parts. SQLite supports ordinary/unique
+and filtered indexes only. ClickHouse side objects are explicitly unsupported:
+its table primary key is a MergeTree sorting key rather than a standalone
+relational constraint, and its secondary-index model needs parameters that are
+outside this API.
 
 SQLite's named-schema creation is deliberately unsupported when called through
 `CreateSchema`. `PlanCreate` follows DMT's established SQLite create behavior:
@@ -99,7 +157,8 @@ type mapper. The canonical package never represents nullability itself.
 
 ClickHouse `PRIMARY KEY` is a sparse sorting index, not a uniqueness constraint,
 so `CreateTable` reports a `primary-key-not-unique` warning whenever a primary
-key is supplied.
+key is supplied. `CreatePrimaryKey` is unsupported for ClickHouse rather than
+pretending that table behavior can be added as a relational constraint.
 
 ClickHouse does not allow `Nullable(Array(...))`, `Nullable(Map(...))`, or a
 nullable column in its `PRIMARY KEY` / `ORDER BY` expression. The public API
@@ -131,4 +190,6 @@ renderer, err := registry.NewRenderer(schema.Options{TargetDialect: "my-db"})
 
 The dialect interface receives only public `schema.Request`, `schema.Table`,
 and `schema.Column` values and returns `schema.Result`; it is safe to implement
-without importing SMT internals. Registries do not share mutable global state.
+without importing SMT internals. A custom dialect can additionally implement
+`schema.SideObjectDialect` to render the four standalone side-object methods.
+Registries do not share mutable global state.

--- a/internal/ddl/postgres/renderer.go
+++ b/internal/ddl/postgres/renderer.go
@@ -62,6 +62,10 @@ func (r deterministicDDL) withSource(sourceDialect string) deterministicDDL {
 	return r
 }
 
+func (r deterministicDDL) crossDialect() bool {
+	return r.sourceDialect != "" && r.sourceDialect != "postgres"
+}
+
 // RenderCreateTableDDLWithSource is RenderCreateTableDDLWithPolicy that also
 // knows the source dialect, so the canonical type mapping can resolve
 // dialect-dependent source types. sourceDialect "" reproduces the source-blind
@@ -254,7 +258,7 @@ func (r deterministicDDL) createIndex(t *driver.Table, idx *driver.Index, target
 	}
 
 	if filter := strings.TrimSpace(idx.Filter); filter != "" {
-		expr, err := r.sqlServerExpression(filter)
+		expr, err := r.filteredIndexExpression(filter)
 		if err != nil {
 			return "", fmt.Errorf("mapping filter for index %s: %w", idx.Name, err)
 		}
@@ -466,6 +470,14 @@ func (r deterministicDDL) exprColInfo(col driver.Column) exprir.ColInfo {
 }
 
 func (r deterministicDDL) sqlServerExpression(expr string) (string, error) {
+	return r.rewriteSQLServerExpression(expr, true)
+}
+
+func (r deterministicDDL) filteredIndexExpression(expr string) (string, error) {
+	return r.rewriteSQLServerExpression(expr, r.crossDialect())
+}
+
+func (r deterministicDDL) rewriteSQLServerExpression(expr string, rejectUnknownFunctions bool) (string, error) {
 	out := strings.TrimSpace(expr)
 	out = replaceBracketIdentifiers(out, func(name string) string {
 		return r.dialect.QuoteIdentifier(sanitizePGIdentifier(name))
@@ -492,16 +504,18 @@ func (r deterministicDDL) sqlServerExpression(expr string) (string, error) {
 	out = strings.ReplaceAll(out, "newid()", "gen_random_uuid()")
 	out = strings.ReplaceAll(out, "ISNULL(", "COALESCE(")
 	out = strings.ReplaceAll(out, "isnull(", "COALESCE(")
-	if err := rejectUnsupportedSQLServerExpression(out); err != nil {
-		return "", err
+	if rejectUnknownFunctions {
+		if err := rejectUnsupportedSQLServerExpression(out); err != nil {
+			return "", err
+		}
 	}
 	return out, nil
 }
 
-// rejectUnsupportedSQLServerExpression is the fail-closed tail of the legacy
-// string-rewrite pipeline. It delegates to the shared per-target gate in
-// internal/expr (#175) so all three targets reject unknown functions
-// identically. (CONVERT(date, <now>) handling moved into the expression IR.)
+// rejectUnsupportedSQLServerExpression is the fail-closed tail of the
+// cross-dialect legacy string-rewrite pipeline. It delegates to the shared
+// per-target gate in internal/expr (#175). (CONVERT(date, <now>) handling
+// moved into the expression IR.)
 func rejectUnsupportedSQLServerExpression(expr string) error {
 	return exprir.RejectUnknownFunctions(expr, exprir.Postgres)
 }

--- a/internal/ddl/postgres/renderer.go
+++ b/internal/ddl/postgres/renderer.go
@@ -137,7 +137,7 @@ func (r deterministicDDL) createTable(t *driver.Table, targetSchema string, unlo
 		for i, c := range t.PrimaryKey {
 			cols[i] = r.dialect.QuoteIdentifier(sanitizePGIdentifier(c))
 		}
-		pkName := "pk_" + tableName
+		pkName := sanitizePGIdentifier("pk_" + tableName)
 		lines = append(lines, fmt.Sprintf("    CONSTRAINT %s PRIMARY KEY (%s)",
 			r.dialect.QuoteIdentifier(pkName), strings.Join(cols, ", ")))
 	}

--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -541,6 +541,9 @@ func (r Renderer) CreateIndexDDL(t *driver.Table, idx *driver.Index) (string, er
 			return "", fmt.Errorf("filtered indexes are not supported on mysql target: %s", idx.Name)
 		}
 		expr, err := r.Expression(filter, t.Columns)
+		if err == nil && r.crossDialect() {
+			err = exprir.RejectUnknownFunctions(expr, r.target)
+		}
 		if err != nil {
 			return "", fmt.Errorf("mapping filter for index %s: %w", idx.Name, err)
 		}

--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -550,6 +550,48 @@ func (r Renderer) CreateIndexDDL(t *driver.Table, idx *driver.Index) (string, er
 	return b.String(), nil
 }
 
+// CreatePrimaryKeyDDL renders a standalone, named primary-key constraint.
+// CreateTableDDL continues to render a table's initial primary key inline;
+// this method exists for callers that schedule a primary key separately.
+func (r Renderer) CreatePrimaryKeyDDL(t *driver.Table, name string, columns []string) (string, error) {
+	return r.createNamedKeyConstraint(t, name, columns, "PRIMARY KEY")
+}
+
+// CreateUniqueConstraintDDL renders a standalone, named UNIQUE constraint.
+// It is deliberately distinct from CreateIndexDDL with IsUnique: a database
+// constraint is part of a table's relational contract, while a unique index
+// is an independently managed index artifact.
+func (r Renderer) CreateUniqueConstraintDDL(t *driver.Table, name string, columns []string) (string, error) {
+	return r.createNamedKeyConstraint(t, name, columns, "UNIQUE")
+}
+
+func (r Renderer) createNamedKeyConstraint(t *driver.Table, name string, columns []string, kind string) (string, error) {
+	if r.target == "sqlite" || r.target == "clickhouse" {
+		return "", fmt.Errorf("standalone %s constraints are not supported on %s target", strings.ToLower(kind), r.target)
+	}
+	if strings.TrimSpace(t.Name) == "" {
+		return "", fmt.Errorf("%s constraint has no table name", strings.ToLower(kind))
+	}
+	if strings.TrimSpace(name) == "" {
+		return "", fmt.Errorf("%s constraint has no name", strings.ToLower(kind))
+	}
+	if len(columns) == 0 {
+		return "", fmt.Errorf("%s constraint %s has no columns", strings.ToLower(kind), name)
+	}
+	cols := make([]string, len(columns))
+	for i, column := range columns {
+		if strings.TrimSpace(column) == "" {
+			return "", fmt.Errorf("%s constraint %s has an empty column name", strings.ToLower(kind), name)
+		}
+		cols[i] = r.quote(r.normalize(column))
+	}
+	return fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s %s (%s)",
+		r.qualify(r.normalize(t.Name)),
+		r.quote(r.normalize(name)),
+		kind,
+		strings.Join(cols, ", ")), nil
+}
+
 func (r Renderer) indexKeyPartDDL(idx *driver.Index, i int, column string) (string, error) {
 	isExpression := i < len(idx.ColumnExpressions) && idx.ColumnExpressions[i]
 	if isExpression {

--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -67,7 +67,9 @@ import (
 // never sacrificed for unicode (#224).
 // "17": ClickHouse rejects Nullable(Array(...)) / Nullable(Map(...)) and
 // nullable PRIMARY KEY / ORDER BY columns instead of emitting invalid DDL.
-const RendererVersion = "17"
+// "18": standalone schema side-object DDL adds deterministic index and
+// constraint rendering, including fail-closed cross-dialect index predicates.
+const RendererVersion = "18"
 
 // ClickHouseNullableCompositeError reports a nullable composite that ClickHouse
 // cannot represent as Nullable(T). Rewriting it to Array(Nullable(T)) would

--- a/internal/ddl/renderer_test.go
+++ b/internal/ddl/renderer_test.go
@@ -91,6 +91,69 @@ func TestRenderer_FinalizationMSSQL(t *testing.T) {
 	assertEqualSQL(t, checkSQL, `ALTER TABLE [dbo].[Companies] ADD CONSTRAINT [CK_Companies_Active] CHECK ([IsActive] = 1)`)
 }
 
+func TestRenderer_StandaloneKeyConstraints(t *testing.T) {
+	cases := []struct {
+		target string
+		schema string
+		pk     string
+		unique string
+	}{
+		{
+			target: "postgres", schema: "public",
+			pk:     `ALTER TABLE "public"."companies" ADD CONSTRAINT "pk_companies" PRIMARY KEY ("companyid")`,
+			unique: `ALTER TABLE "public"."companies" ADD CONSTRAINT "uq_companies_name" UNIQUE ("name")`,
+		},
+		{
+			target: "mssql", schema: "dbo",
+			pk:     `ALTER TABLE [dbo].[Companies] ADD CONSTRAINT [PK_Companies] PRIMARY KEY ([CompanyId])`,
+			unique: `ALTER TABLE [dbo].[Companies] ADD CONSTRAINT [UQ_Companies_Name] UNIQUE ([Name])`,
+		},
+		{
+			target: "mysql", schema: "crm",
+			pk:     "ALTER TABLE `crm`.`Companies` ADD CONSTRAINT `PK_Companies` PRIMARY KEY (`CompanyId`)",
+			unique: "ALTER TABLE `crm`.`Companies` ADD CONSTRAINT `UQ_Companies_Name` UNIQUE (`Name`)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.target, func(t *testing.T) {
+			renderer, err := NewRenderer(tc.target, tc.schema, "fail")
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			table := &driver.Table{Name: "Companies"}
+			gotPK, err := renderer.CreatePrimaryKeyDDL(table, "PK_Companies", []string{"CompanyId"})
+			if err != nil {
+				t.Fatalf("CreatePrimaryKeyDDL: %v", err)
+			}
+			assertEqualSQL(t, gotPK, tc.pk)
+
+			gotUnique, err := renderer.CreateUniqueConstraintDDL(table, "UQ_Companies_Name", []string{"Name"})
+			if err != nil {
+				t.Fatalf("CreateUniqueConstraintDDL: %v", err)
+			}
+			assertEqualSQL(t, gotUnique, tc.unique)
+		})
+	}
+}
+
+func TestRenderer_StandaloneKeyConstraintsRejectUnsupportedTargets(t *testing.T) {
+	for _, target := range []string{"sqlite", "clickhouse"} {
+		t.Run(target, func(t *testing.T) {
+			renderer, err := NewRenderer(target, "analytics", "fail")
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			if _, err := renderer.CreatePrimaryKeyDDL(&driver.Table{Name: "events"}, "pk_events", []string{"id"}); err == nil {
+				t.Fatal("CreatePrimaryKeyDDL error = nil, want unsupported target error")
+			}
+			if _, err := renderer.CreateUniqueConstraintDDL(&driver.Table{Name: "events"}, "uq_events_name", []string{"name"}); err == nil {
+				t.Fatal("CreateUniqueConstraintDDL error = nil, want unsupported target error")
+			}
+		})
+	}
+}
+
 func TestRenderer_FinalizationMySQL(t *testing.T) {
 	renderer, err := NewRenderer("mysql", "crm", "fail")
 	if err != nil {

--- a/schema/ddl.go
+++ b/schema/ddl.go
@@ -204,8 +204,9 @@ type Index struct {
 }
 
 // PrimaryKey is a standalone primary-key constraint. Name is optional: when
-// omitted, CreatePrimaryKey deterministically uses "pk_" plus the supplied
-// TableRef name, matching SMT's existing CREATE TABLE convention.
+// omitted, CreatePrimaryKey deterministically uses "pk_" plus the
+// target-normalized TableRef name, matching SMT's existing CREATE TABLE
+// convention.
 type PrimaryKey struct {
 	Name    string
 	Columns []string
@@ -472,7 +473,7 @@ func (r Renderer) CreatePrimaryKey(table TableRef, primaryKey PrimaryKey) (Resul
 		return Result{}, err
 	}
 	if strings.TrimSpace(primaryKey.Name) == "" {
-		primaryKey.Name = "pk_" + table.Name
+		primaryKey.Name = "pk_" + driver.NormalizeIdentifier(r.Dialect(), table.Name)
 	}
 	dialect, err := r.sideObjectDialect("standalone primary keys")
 	if err != nil {
@@ -655,6 +656,9 @@ func validateIndex(table TableRef, index Index) error {
 	for i, length := range index.ColumnPrefixLengths {
 		if length < 0 {
 			return fmt.Errorf("render index %q: column prefix length %d is negative", index.Name, i)
+		}
+		if length > 0 && i < len(index.ColumnExpressions) && index.ColumnExpressions[i] {
+			return fmt.Errorf("render index %q: expression column %d cannot have a prefix length", index.Name, i)
 		}
 	}
 	for i, column := range index.IncludeColumns {

--- a/schema/ddl.go
+++ b/schema/ddl.go
@@ -32,13 +32,21 @@ const (
 // Callers can inspect it before constructing schemas, and Renderer returns an
 // UnsupportedFeatureError instead of silently omitting an unsupported fact.
 type Capabilities struct {
-	CreateSchema    bool
-	CreateTable     bool
-	CreateColumn    bool
-	PrimaryKeys     bool
-	IdentityColumns bool
-	Defaults        bool
-	ComputedColumns bool
+	CreateSchema           bool
+	CreateTable            bool
+	CreateColumn           bool
+	PrimaryKeys            bool
+	IdentityColumns        bool
+	Defaults               bool
+	ComputedColumns        bool
+	SecondaryIndexes       bool
+	StandalonePrimaryKeys  bool
+	NamedUniqueConstraints bool
+	CheckConstraints       bool
+	IndexExpressionKeys    bool
+	IndexPrefixLengths     bool
+	IndexIncludeColumns    bool
+	FilteredIndexes        bool
 }
 
 // Request is the rendering context supplied to a Dialect implementation.
@@ -68,8 +76,10 @@ type Result struct {
 }
 
 // StatementKind identifies the create artifact emitted by a Statement. The
-// public create plan intentionally has no index, foreign-key, check, alter, or
-// drop kinds: those artifacts are outside the first public DDL milestone.
+// public create plan contains schema and table statements only. Independent
+// side objects are rendered through Renderer.CreateIndex,
+// Renderer.CreatePrimaryKey, Renderer.CreateUniqueConstraint, and
+// Renderer.CreateCheckConstraint so callers retain their own schedule.
 type StatementKind string
 
 const (
@@ -158,13 +168,61 @@ func (c Column) TypeMeta() canonical.TypeMeta {
 }
 
 // Table is the practical create-table subset shared by all built-in dialects.
-// Secondary indexes and relationships remain SMT application-level planning
-// concerns; callers can render their tables first and emit those objects in an
-// explicit dependency order.
 type Table struct {
 	Name       string
 	Columns    []Column
 	PrimaryKey []string
+}
+
+// TableRef identifies a target table for a standalone side object. Columns are
+// optional context for source-expression translation in filtered indexes and
+// check constraints; they are not used to infer or emit table DDL.
+//
+// Schema qualification deliberately comes from Renderer Options, just as it
+// does for CreateTable. This keeps all artifact names on one deterministic
+// target-schema policy and mirrors SMT's existing DMT rendering behavior.
+type TableRef struct {
+	Name    string
+	Columns []Column
+}
+
+// Index is a named secondary index. IsUnique selects a unique index, which is
+// intentionally distinct from UniqueConstraint: an index is an independent
+// physical artifact while a named UNIQUE constraint is part of the table's
+// relational contract.
+//
+// Columns, ColumnExpressions, and ColumnPrefixLengths are positionally
+// aligned. Their input order is preserved in the rendered SQL.
+type Index struct {
+	Name                string
+	Columns             []string
+	ColumnExpressions   []bool
+	ColumnPrefixLengths []int
+	IsUnique            bool
+	IncludeColumns      []string
+	Filter              string
+}
+
+// PrimaryKey is a standalone primary-key constraint. Name is optional: when
+// omitted, CreatePrimaryKey deterministically uses "pk_" plus the supplied
+// TableRef name, matching SMT's existing CREATE TABLE convention.
+type PrimaryKey struct {
+	Name    string
+	Columns []string
+}
+
+// UniqueConstraint is a named UNIQUE constraint. It is deliberately separate
+// from Index with IsUnique so callers choose the database object they intend.
+type UniqueConstraint struct {
+	Name    string
+	Columns []string
+}
+
+// CheckConstraint is a named CHECK constraint. Expression is source-dialect
+// SQL and is translated by SMT's existing deterministic expression renderer.
+type CheckConstraint struct {
+	Name       string
+	Expression string
 }
 
 // Dialect lets applications register a custom public renderer without
@@ -177,6 +235,21 @@ type Dialect interface {
 	RenderSchema(Request) (Result, error)
 	RenderTable(Request, Table) (Result, error)
 	RenderColumn(Request, Column) (Result, error)
+}
+
+// SideObjectDialect is the optional extension implemented by a Dialect that
+// renders standalone indexes and constraints. Keeping it separate preserves
+// source compatibility for existing custom Dialect implementations that only
+// render schemas, tables, and columns.
+//
+// A SideObjectDialect should set the matching Capabilities fields to true.
+// Built-in dialects implement this interface.
+type SideObjectDialect interface {
+	Dialect
+	RenderIndex(Request, TableRef, Index) (Result, error)
+	RenderPrimaryKey(Request, TableRef, PrimaryKey) (Result, error)
+	RenderUniqueConstraint(Request, TableRef, UniqueConstraint) (Result, error)
+	RenderCheckConstraint(Request, TableRef, CheckConstraint) (Result, error)
 }
 
 var (
@@ -358,6 +431,95 @@ func (r Renderer) CreateColumn(column Column) (Result, error) {
 	return r.dialect.RenderColumn(r.request, column)
 }
 
+// CreateIndex renders a standalone secondary index. The table must already
+// exist when the returned statement is executed. Index column order is
+// preserved, and unsupported index features return UnsupportedFeatureError
+// before SMT attempts to render SQL.
+func (r Renderer) CreateIndex(table TableRef, index Index) (Result, error) {
+	caps := r.Capabilities()
+	if !caps.SecondaryIndexes {
+		return Result{}, r.unsupported("secondary indexes")
+	}
+	if hasTrue(index.ColumnExpressions) && !caps.IndexExpressionKeys {
+		return Result{}, r.unsupported("expression index key parts")
+	}
+	if hasPositive(index.ColumnPrefixLengths) && !caps.IndexPrefixLengths {
+		return Result{}, r.unsupported("index column prefix lengths")
+	}
+	if len(index.IncludeColumns) > 0 && !caps.IndexIncludeColumns {
+		return Result{}, r.unsupported("index include columns")
+	}
+	if strings.TrimSpace(index.Filter) != "" && !caps.FilteredIndexes {
+		return Result{}, r.unsupported("filtered indexes")
+	}
+	if err := validateIndex(table, index); err != nil {
+		return Result{}, err
+	}
+	dialect, err := r.sideObjectDialect("secondary indexes")
+	if err != nil {
+		return Result{}, err
+	}
+	return dialect.RenderIndex(r.request, table, index)
+}
+
+// CreatePrimaryKey renders a standalone primary-key constraint. Its optional
+// name defaults deterministically to pk_<table>, matching CreateTable.
+func (r Renderer) CreatePrimaryKey(table TableRef, primaryKey PrimaryKey) (Result, error) {
+	if !r.Capabilities().StandalonePrimaryKeys {
+		return Result{}, r.unsupported("standalone primary keys")
+	}
+	if err := validateKeyConstraint("primary key", table, primaryKey.Name, primaryKey.Columns, true); err != nil {
+		return Result{}, err
+	}
+	if strings.TrimSpace(primaryKey.Name) == "" {
+		primaryKey.Name = "pk_" + table.Name
+	}
+	dialect, err := r.sideObjectDialect("standalone primary keys")
+	if err != nil {
+		return Result{}, err
+	}
+	return dialect.RenderPrimaryKey(r.request, table, primaryKey)
+}
+
+// CreateUniqueConstraint renders a standalone, named UNIQUE constraint. Use
+// CreateIndex with Index.IsUnique for a unique index instead.
+func (r Renderer) CreateUniqueConstraint(table TableRef, unique UniqueConstraint) (Result, error) {
+	if !r.Capabilities().NamedUniqueConstraints {
+		return Result{}, r.unsupported("named unique constraints")
+	}
+	if err := validateKeyConstraint("unique", table, unique.Name, unique.Columns, false); err != nil {
+		return Result{}, err
+	}
+	dialect, err := r.sideObjectDialect("named unique constraints")
+	if err != nil {
+		return Result{}, err
+	}
+	return dialect.RenderUniqueConstraint(r.request, table, unique)
+}
+
+// CreateCheckConstraint renders a standalone, named CHECK constraint. The
+// table's optional Columns context is used for deterministic expression
+// translation, including boolean-convention rewrites.
+func (r Renderer) CreateCheckConstraint(table TableRef, check CheckConstraint) (Result, error) {
+	if !r.Capabilities().CheckConstraints {
+		return Result{}, r.unsupported("check constraints")
+	}
+	if err := validateTableRef("check constraint", table); err != nil {
+		return Result{}, err
+	}
+	if strings.TrimSpace(check.Name) == "" {
+		return Result{}, fmt.Errorf("render check constraint on table %q: empty constraint name", table.Name)
+	}
+	if strings.TrimSpace(check.Expression) == "" {
+		return Result{}, fmt.Errorf("render check constraint %q: empty expression", check.Name)
+	}
+	dialect, err := r.sideObjectDialect("check constraints")
+	if err != nil {
+		return Result{}, err
+	}
+	return dialect.RenderCheckConstraint(r.request, table, check)
+}
+
 // PlanCreate renders the supported create path in execution order: an
 // optional schema/database statement followed by the supplied tables in input
 // order. It deliberately does not infer dependency ordering or include
@@ -454,6 +616,91 @@ func (r Renderer) unsupported(feature string) error {
 	return &UnsupportedFeatureError{Dialect: r.Dialect(), Feature: feature}
 }
 
+func (r Renderer) sideObjectDialect(feature string) (SideObjectDialect, error) {
+	dialect, ok := r.dialect.(SideObjectDialect)
+	if !ok {
+		return nil, r.unsupported(feature)
+	}
+	return dialect, nil
+}
+
+func validateTableRef(artifact string, table TableRef) error {
+	if strings.TrimSpace(table.Name) == "" {
+		return fmt.Errorf("render %s: empty table name", artifact)
+	}
+	return nil
+}
+
+func validateIndex(table TableRef, index Index) error {
+	if err := validateTableRef("index", table); err != nil {
+		return err
+	}
+	if strings.TrimSpace(index.Name) == "" {
+		return fmt.Errorf("render index on table %q: empty index name", table.Name)
+	}
+	if len(index.Columns) == 0 {
+		return fmt.Errorf("render index %q: no columns", index.Name)
+	}
+	if len(index.ColumnExpressions) > len(index.Columns) {
+		return fmt.Errorf("render index %q: column expression flags exceed columns", index.Name)
+	}
+	if len(index.ColumnPrefixLengths) > len(index.Columns) {
+		return fmt.Errorf("render index %q: column prefix lengths exceed columns", index.Name)
+	}
+	for i, column := range index.Columns {
+		if strings.TrimSpace(column) == "" {
+			return fmt.Errorf("render index %q: column %d is empty", index.Name, i)
+		}
+	}
+	for i, length := range index.ColumnPrefixLengths {
+		if length < 0 {
+			return fmt.Errorf("render index %q: column prefix length %d is negative", index.Name, i)
+		}
+	}
+	for i, column := range index.IncludeColumns {
+		if strings.TrimSpace(column) == "" {
+			return fmt.Errorf("render index %q: included column %d is empty", index.Name, i)
+		}
+	}
+	return nil
+}
+
+func validateKeyConstraint(kind string, table TableRef, name string, columns []string, nameOptional bool) error {
+	if err := validateTableRef(kind+" constraint", table); err != nil {
+		return err
+	}
+	if !nameOptional && strings.TrimSpace(name) == "" {
+		return fmt.Errorf("render %s constraint on table %q: empty constraint name", kind, table.Name)
+	}
+	if len(columns) == 0 {
+		return fmt.Errorf("render %s constraint %q: no columns", kind, name)
+	}
+	for i, column := range columns {
+		if strings.TrimSpace(column) == "" {
+			return fmt.Errorf("render %s constraint %q: column %d is empty", kind, name, i)
+		}
+	}
+	return nil
+}
+
+func hasTrue(values []bool) bool {
+	for _, value := range values {
+		if value {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPositive(values []int) bool {
+	for _, value := range values {
+		if value > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 type builtinDialect struct {
 	name         string
 	aliases      []string
@@ -464,14 +711,35 @@ func builtinDialects() []Dialect {
 	full := Capabilities{
 		CreateSchema: true, CreateTable: true, CreateColumn: true,
 		PrimaryKeys: true, IdentityColumns: true, Defaults: true, ComputedColumns: true,
+		SecondaryIndexes: true, StandalonePrimaryKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
+		IndexExpressionKeys: true, IndexIncludeColumns: true, FilteredIndexes: true,
 	}
 	return []Dialect{
 		builtinDialect{name: "postgres", aliases: []string{"postgresql", "pg"}, capabilities: full},
-		builtinDialect{name: "mssql", aliases: []string{"sqlserver", "sql-server", "sql_server"}, capabilities: full},
-		builtinDialect{name: "mysql", aliases: []string{"mariadb", "maria"}, capabilities: full},
+		builtinDialect{
+			name: "mssql", aliases: []string{"sqlserver", "sql-server", "sql_server"},
+			capabilities: Capabilities{
+				CreateSchema: true, CreateTable: true, CreateColumn: true,
+				PrimaryKeys: true, IdentityColumns: true, Defaults: true, ComputedColumns: true,
+				SecondaryIndexes: true, StandalonePrimaryKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
+				IndexIncludeColumns: true, FilteredIndexes: true,
+			},
+		},
+		builtinDialect{
+			name: "mysql", aliases: []string{"mariadb", "maria"},
+			capabilities: Capabilities{
+				CreateSchema: true, CreateTable: true, CreateColumn: true,
+				PrimaryKeys: true, IdentityColumns: true, Defaults: true, ComputedColumns: true,
+				SecondaryIndexes: true, StandalonePrimaryKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
+				IndexExpressionKeys: true, IndexPrefixLengths: true,
+			},
+		},
 		builtinDialect{
 			name: "sqlite", aliases: []string{"sqlite3"},
-			capabilities: Capabilities{CreateTable: true, CreateColumn: true, PrimaryKeys: true, IdentityColumns: true, Defaults: true},
+			capabilities: Capabilities{
+				CreateTable: true, CreateColumn: true, PrimaryKeys: true, IdentityColumns: true, Defaults: true,
+				SecondaryIndexes: true, FilteredIndexes: true,
+			},
 		},
 		builtinDialect{
 			name: "clickhouse", aliases: []string{"click-house"},
@@ -545,6 +813,57 @@ func (d builtinDialect) RenderColumn(request Request, column Column) (Result, er
 	return Result{SQL: sql, Warnings: mappingWarnings(d.name, request, "", []Column{column})}, nil
 }
 
+func (d builtinDialect) RenderIndex(request Request, table TableRef, index Index) (Result, error) {
+	renderer, err := d.renderer(request)
+	if err != nil {
+		return Result{}, err
+	}
+	sql, err := renderer.CreateIndexDDL(toDriverTableRef(table), toDriverIndex(index))
+	if err != nil {
+		return Result{}, d.publicRenderError(err)
+	}
+	return Result{SQL: sql}, nil
+}
+
+func (d builtinDialect) RenderPrimaryKey(request Request, table TableRef, primaryKey PrimaryKey) (Result, error) {
+	renderer, err := d.renderer(request)
+	if err != nil {
+		return Result{}, err
+	}
+	sql, err := renderer.CreatePrimaryKeyDDL(toDriverTableRef(table), primaryKey.Name, primaryKey.Columns)
+	if err != nil {
+		return Result{}, d.publicRenderError(err)
+	}
+	return Result{SQL: sql}, nil
+}
+
+func (d builtinDialect) RenderUniqueConstraint(request Request, table TableRef, unique UniqueConstraint) (Result, error) {
+	renderer, err := d.renderer(request)
+	if err != nil {
+		return Result{}, err
+	}
+	sql, err := renderer.CreateUniqueConstraintDDL(toDriverTableRef(table), unique.Name, unique.Columns)
+	if err != nil {
+		return Result{}, d.publicRenderError(err)
+	}
+	return Result{SQL: sql}, nil
+}
+
+func (d builtinDialect) RenderCheckConstraint(request Request, table TableRef, check CheckConstraint) (Result, error) {
+	renderer, err := d.renderer(request)
+	if err != nil {
+		return Result{}, err
+	}
+	sql, err := renderer.CreateCheckConstraintDDL(toDriverTableRef(table), &driver.CheckConstraint{
+		Name:       check.Name,
+		Definition: check.Expression,
+	})
+	if err != nil {
+		return Result{}, d.publicRenderError(err)
+	}
+	return Result{SQL: sql}, nil
+}
+
 func (d builtinDialect) publicRenderError(err error) error {
 	var composite *ddl.ClickHouseNullableCompositeError
 	if errors.As(err, &composite) {
@@ -579,14 +898,35 @@ func (d builtinDialect) renderer(request Request) (ddl.Renderer, error) {
 }
 
 func toDriverTable(table Table) *driver.Table {
-	columns := make([]driver.Column, len(table.Columns))
-	for i, column := range table.Columns {
-		columns[i] = toDriverColumn(column)
-	}
+	columns := toDriverColumns(table.Columns)
 	return &driver.Table{
 		Name:       table.Name,
 		Columns:    columns,
 		PrimaryKey: append([]string(nil), table.PrimaryKey...),
+	}
+}
+
+func toDriverTableRef(table TableRef) *driver.Table {
+	return &driver.Table{Name: table.Name, Columns: toDriverColumns(table.Columns)}
+}
+
+func toDriverColumns(columns []Column) []driver.Column {
+	driverColumns := make([]driver.Column, len(columns))
+	for i, column := range columns {
+		driverColumns[i] = toDriverColumn(column)
+	}
+	return driverColumns
+}
+
+func toDriverIndex(index Index) *driver.Index {
+	return &driver.Index{
+		Name:                index.Name,
+		Columns:             append([]string(nil), index.Columns...),
+		ColumnExpressions:   append([]bool(nil), index.ColumnExpressions...),
+		ColumnPrefixLengths: append([]int(nil), index.ColumnPrefixLengths...),
+		IsUnique:            index.IsUnique,
+		IncludeCols:         append([]string(nil), index.IncludeColumns...),
+		Filter:              index.Filter,
 	}
 }
 

--- a/schema/ddl.go
+++ b/schema/ddl.go
@@ -655,7 +655,7 @@ func validateIndex(table TableRef, index Index) error {
 	}
 	for i, length := range index.ColumnPrefixLengths {
 		if length < 0 {
-			return fmt.Errorf("render index %q: column prefix length %d is negative", index.Name, i)
+			return fmt.Errorf("render index %q: column prefix length %d is negative", index.Name, length)
 		}
 		if length > 0 && i < len(index.ColumnExpressions) && index.ColumnExpressions[i] {
 			return fmt.Errorf("render index %q: expression column %d cannot have a prefix length", index.Name, i)

--- a/schema/ddl_side_objects_public_test.go
+++ b/schema/ddl_side_objects_public_test.go
@@ -225,6 +225,21 @@ func TestPublicDDLRejectsExpressionIndexPrefixCombination(t *testing.T) {
 	}
 }
 
+func TestPublicDDLRejectsNegativeIndexPrefixLength(t *testing.T) {
+	renderer, err := schema.NewRenderer(schema.Options{TargetDialect: "mysql", Schema: "app"})
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	_, err = renderer.CreateIndex(schema.TableRef{Name: "orders"}, schema.Index{
+		Name:                "ix_orders_email",
+		Columns:             []string{"email"},
+		ColumnPrefixLengths: []int{-7},
+	})
+	if err == nil || !strings.Contains(err.Error(), "column prefix length -7 is negative") {
+		t.Fatalf("CreateIndex error = %v, want negative prefix-length validation error", err)
+	}
+}
+
 func TestPublicDDLSideObjectCapabilitiesAndUnsupportedErrors(t *testing.T) {
 	cases := []struct {
 		dialect                  string

--- a/schema/ddl_side_objects_public_test.go
+++ b/schema/ddl_side_objects_public_test.go
@@ -1,0 +1,394 @@
+package schema_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/johndauphine/smt/internal/ddl"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/schema"
+)
+
+func TestPublicDDLSideObjectGoldens(t *testing.T) {
+	cases := []struct {
+		name   string
+		opts   schema.Options
+		table  schema.TableRef
+		index  schema.Index
+		golden string
+	}{
+		{
+			name: "postgres",
+			opts: schema.Options{TargetDialect: "postgres", Schema: "public", SourceDialect: "postgres"},
+			table: schema.TableRef{
+				Name:    "Orders",
+				Columns: []schema.Column{{Name: "ID", DataType: "int4"}, {Name: "Email", DataType: "varchar", MaxLength: 255}, {Name: "Total", DataType: "numeric", Precision: 12, Scale: 2}},
+			},
+			index:  schema.Index{Name: "IX_Orders_Email", Columns: []string{"Email"}, IsUnique: true, IncludeColumns: []string{"ID"}, Filter: "Email IS NOT NULL"},
+			golden: "postgres_side_objects.sql.golden",
+		},
+		{
+			name: "mssql",
+			opts: schema.Options{TargetDialect: "mssql", Schema: "dbo", SourceDialect: "mssql"},
+			table: schema.TableRef{
+				Name:    "Orders",
+				Columns: []schema.Column{{Name: "ID", DataType: "int"}, {Name: "Email", DataType: "varchar", MaxLength: 255}, {Name: "Total", DataType: "decimal", Precision: 12, Scale: 2}},
+			},
+			index:  schema.Index{Name: "IX_Orders_Email", Columns: []string{"Email"}, IsUnique: true, IncludeColumns: []string{"ID"}, Filter: "Email IS NOT NULL"},
+			golden: "mssql_side_objects.sql.golden",
+		},
+		{
+			name: "mysql",
+			opts: schema.Options{TargetDialect: "mysql", Schema: "crm", SourceDialect: "mysql"},
+			table: schema.TableRef{
+				Name:    "Orders",
+				Columns: []schema.Column{{Name: "ID", DataType: "int"}, {Name: "Email", DataType: "varchar", MaxLength: 255}, {Name: "Total", DataType: "decimal", Precision: 12, Scale: 2}},
+			},
+			index:  schema.Index{Name: "IX_Orders_Email", Columns: []string{"Email"}, IsUnique: true, ColumnPrefixLengths: []int{16}},
+			golden: "mysql_side_objects.sql.golden",
+		},
+		{
+			name: "sqlite",
+			opts: schema.Options{TargetDialect: "sqlite", Schema: "ignored_by_sqlite", SourceDialect: "postgres"},
+			table: schema.TableRef{
+				Name:    "orders",
+				Columns: []schema.Column{{Name: "id", DataType: "int4"}, {Name: "email", DataType: "varchar", MaxLength: 255}},
+			},
+			index:  schema.Index{Name: "ix_orders_email", Columns: []string{"email"}, IsUnique: true, Filter: "email IS NOT NULL"},
+			golden: "sqlite_side_objects.sql.golden",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			renderer, err := schema.NewRenderer(tc.opts)
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			index, err := renderer.CreateIndex(tc.table, tc.index)
+			if err != nil {
+				t.Fatalf("CreateIndex: %v", err)
+			}
+
+			var statements []string
+			statements = append(statements, "create_index\n"+index.SQL)
+			if tc.name != "sqlite" {
+				primaryKey, err := renderer.CreatePrimaryKey(tc.table, schema.PrimaryKey{Columns: []string{"ID"}})
+				if err != nil {
+					t.Fatalf("CreatePrimaryKey: %v", err)
+				}
+				unique, err := renderer.CreateUniqueConstraint(tc.table, schema.UniqueConstraint{Name: "UQ_Orders_Email", Columns: []string{"Email"}})
+				if err != nil {
+					t.Fatalf("CreateUniqueConstraint: %v", err)
+				}
+				check, err := renderer.CreateCheckConstraint(tc.table, schema.CheckConstraint{Name: "CK_Orders_Total", Expression: "Total >= 0"})
+				if err != nil {
+					t.Fatalf("CreateCheckConstraint: %v", err)
+				}
+				statements = append(statements,
+					"create_primary_key\n"+primaryKey.SQL,
+					"create_unique_constraint\n"+unique.SQL,
+					"create_check_constraint\n"+check.SQL,
+				)
+			}
+			assertGolden(t, strings.Join(statements, "\n\n"), tc.golden)
+		})
+	}
+}
+
+func TestPublicDDLSideObjectCapabilitiesAndUnsupportedErrors(t *testing.T) {
+	cases := []struct {
+		dialect                  string
+		secondaryIndexes         bool
+		standalonePrimaryKeys    bool
+		namedUniqueConstraints   bool
+		checkConstraints         bool
+		expressionKeys           bool
+		prefixLengths            bool
+		includeColumns           bool
+		filteredIndexes          bool
+		unsupportedSideArtifacts []string
+	}{
+		{
+			dialect: "postgres", secondaryIndexes: true, standalonePrimaryKeys: true, namedUniqueConstraints: true, checkConstraints: true,
+			expressionKeys: true, includeColumns: true, filteredIndexes: true,
+		},
+		{
+			dialect: "mssql", secondaryIndexes: true, standalonePrimaryKeys: true, namedUniqueConstraints: true, checkConstraints: true,
+			includeColumns: true, filteredIndexes: true,
+		},
+		{
+			dialect: "mysql", secondaryIndexes: true, standalonePrimaryKeys: true, namedUniqueConstraints: true, checkConstraints: true,
+			expressionKeys: true, prefixLengths: true,
+		},
+		{
+			dialect: "sqlite", secondaryIndexes: true,
+			filteredIndexes:          true,
+			unsupportedSideArtifacts: []string{"standalone primary keys", "named unique constraints", "check constraints"},
+		},
+		{
+			dialect:                  "clickhouse",
+			unsupportedSideArtifacts: []string{"secondary indexes", "standalone primary keys", "named unique constraints", "check constraints"},
+		},
+	}
+
+	table := schema.TableRef{Name: "items", Columns: []schema.Column{{Name: "id", DataType: "int"}, {Name: "name", DataType: "varchar", MaxLength: 80}}}
+	for _, tc := range cases {
+		t.Run(tc.dialect, func(t *testing.T) {
+			renderer, err := schema.NewRenderer(schema.Options{TargetDialect: tc.dialect})
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			got := renderer.Capabilities()
+			if got.SecondaryIndexes != tc.secondaryIndexes || got.StandalonePrimaryKeys != tc.standalonePrimaryKeys ||
+				got.NamedUniqueConstraints != tc.namedUniqueConstraints || got.CheckConstraints != tc.checkConstraints ||
+				got.IndexExpressionKeys != tc.expressionKeys || got.IndexPrefixLengths != tc.prefixLengths ||
+				got.IndexIncludeColumns != tc.includeColumns || got.FilteredIndexes != tc.filteredIndexes {
+				t.Fatalf("Capabilities() = %#v", got)
+			}
+
+			for _, feature := range tc.unsupportedSideArtifacts {
+				var err error
+				switch feature {
+				case "secondary indexes":
+					_, err = renderer.CreateIndex(table, schema.Index{Name: "ix_items_name", Columns: []string{"name"}})
+				case "standalone primary keys":
+					_, err = renderer.CreatePrimaryKey(table, schema.PrimaryKey{Columns: []string{"id"}})
+				case "named unique constraints":
+					_, err = renderer.CreateUniqueConstraint(table, schema.UniqueConstraint{Name: "uq_items_name", Columns: []string{"name"}})
+				case "check constraints":
+					_, err = renderer.CreateCheckConstraint(table, schema.CheckConstraint{Name: "ck_items_id", Expression: "id > 0"})
+				}
+				var unsupported *schema.UnsupportedFeatureError
+				if !errors.As(err, &unsupported) || unsupported.Dialect != tc.dialect || unsupported.Feature != feature {
+					t.Fatalf("%s error = %#v, want UnsupportedFeatureError for %q", feature, err, feature)
+				}
+			}
+		})
+	}
+}
+
+func TestPublicDDLSideObjectFeatureValidation(t *testing.T) {
+	table := schema.TableRef{Name: "items", Columns: []schema.Column{{Name: "id", DataType: "int"}, {Name: "name", DataType: "varchar", MaxLength: 80}}}
+
+	tests := []struct {
+		name    string
+		dialect string
+		call    func(schema.Renderer) error
+		feature string
+	}{
+		{
+			name: "postgres prefix lengths", dialect: "postgres", feature: "index column prefix lengths",
+			call: func(r schema.Renderer) error {
+				_, err := r.CreateIndex(table, schema.Index{Name: "ix", Columns: []string{"name"}, ColumnPrefixLengths: []int{4}})
+				return err
+			},
+		},
+		{
+			name: "mssql expression keys", dialect: "mssql", feature: "expression index key parts",
+			call: func(r schema.Renderer) error {
+				_, err := r.CreateIndex(table, schema.Index{Name: "ix", Columns: []string{"LOWER(name)"}, ColumnExpressions: []bool{true}})
+				return err
+			},
+		},
+		{
+			name: "mysql include columns", dialect: "mysql", feature: "index include columns",
+			call: func(r schema.Renderer) error {
+				_, err := r.CreateIndex(table, schema.Index{Name: "ix", Columns: []string{"name"}, IncludeColumns: []string{"id"}})
+				return err
+			},
+		},
+		{
+			name: "sqlite expression keys", dialect: "sqlite", feature: "expression index key parts",
+			call: func(r schema.Renderer) error {
+				_, err := r.CreateIndex(table, schema.Index{Name: "ix", Columns: []string{"LOWER(name)"}, ColumnExpressions: []bool{true}})
+				return err
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			renderer, err := schema.NewRenderer(schema.Options{TargetDialect: tc.dialect})
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			err = tc.call(renderer)
+			var unsupported *schema.UnsupportedFeatureError
+			if !errors.As(err, &unsupported) || unsupported.Dialect != tc.dialect || unsupported.Feature != tc.feature {
+				t.Fatalf("error = %#v, want UnsupportedFeatureError for %q", err, tc.feature)
+			}
+		})
+	}
+
+	postgres, err := schema.NewRenderer(schema.Options{TargetDialect: "postgres"})
+	if err != nil {
+		t.Fatalf("NewRenderer postgres: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		call func() error
+		want string
+	}{
+		{
+			name: "index has too many expressions",
+			call: func() error {
+				_, err := postgres.CreateIndex(table, schema.Index{Name: "ix", Columns: []string{"name"}, ColumnExpressions: []bool{false, true}})
+				return err
+			},
+			want: "column expression flags exceed columns",
+		},
+		{
+			name: "unique name required",
+			call: func() error {
+				_, err := postgres.CreateUniqueConstraint(table, schema.UniqueConstraint{Columns: []string{"name"}})
+				return err
+			},
+			want: "empty constraint name",
+		},
+		{
+			name: "check expression required",
+			call: func() error {
+				_, err := postgres.CreateCheckConstraint(table, schema.CheckConstraint{Name: "ck_items_name"})
+				return err
+			},
+			want: "empty expression",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.call(); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want text %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestPublicDDLSideObjectAdapterParity(t *testing.T) {
+	cases := []struct {
+		name       string
+		options    schema.Options
+		coreSchema string
+		table      schema.TableRef
+		index      schema.Index
+	}{
+		{
+			name: "postgres", options: schema.Options{TargetDialect: "postgres", Schema: "public", SourceDialect: "postgres"}, coreSchema: "public",
+			table: schema.TableRef{Name: "Orders", Columns: []schema.Column{{Name: "ID", DataType: "int4"}, {Name: "Email", DataType: "varchar", MaxLength: 255}, {Name: "Total", DataType: "numeric", Precision: 12, Scale: 2}}},
+			index: schema.Index{Name: "IX_Orders_Email", Columns: []string{"Email"}, IsUnique: true, IncludeColumns: []string{"ID"}, Filter: "Email IS NOT NULL"},
+		},
+		{
+			name: "mssql", options: schema.Options{TargetDialect: "mssql", Schema: "dbo", SourceDialect: "mssql"}, coreSchema: "dbo",
+			table: schema.TableRef{Name: "Orders", Columns: []schema.Column{{Name: "ID", DataType: "int"}, {Name: "Email", DataType: "varchar", MaxLength: 255}, {Name: "Total", DataType: "decimal", Precision: 12, Scale: 2}}},
+			index: schema.Index{Name: "IX_Orders_Email", Columns: []string{"Email"}, IsUnique: true, IncludeColumns: []string{"ID"}, Filter: "Email IS NOT NULL"},
+		},
+		{
+			name: "mysql", options: schema.Options{TargetDialect: "mysql", Schema: "crm", SourceDialect: "mysql"}, coreSchema: "crm",
+			table: schema.TableRef{Name: "Orders", Columns: []schema.Column{{Name: "ID", DataType: "int"}, {Name: "Email", DataType: "varchar", MaxLength: 255}, {Name: "Total", DataType: "decimal", Precision: 12, Scale: 2}}},
+			index: schema.Index{Name: "IX_Orders_Email", Columns: []string{"Email"}, IsUnique: true, ColumnPrefixLengths: []int{16}},
+		},
+		{
+			name: "sqlite", options: schema.Options{TargetDialect: "sqlite", Schema: "ignored_by_sqlite", SourceDialect: "postgres"},
+			table: schema.TableRef{Name: "orders", Columns: []schema.Column{{Name: "id", DataType: "int4"}, {Name: "email", DataType: "varchar", MaxLength: 255}}},
+			index: schema.Index{Name: "ix_orders_email", Columns: []string{"email"}, IsUnique: true, Filter: "email IS NOT NULL"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			public, err := schema.NewRenderer(tc.options)
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			core, err := ddl.NewRenderer(tc.options.TargetDialect, tc.coreSchema, string(schema.UnknownTypeFail))
+			if err != nil {
+				t.Fatalf("ddl.NewRenderer: %v", err)
+			}
+			core = core.WithSource(tc.options.SourceDialect)
+			coreTable := &driver.Table{Name: tc.table.Name, Columns: toDriverColumns(tc.table.Columns)}
+			coreIndex := &driver.Index{
+				Name: tc.index.Name, Columns: append([]string(nil), tc.index.Columns...),
+				ColumnExpressions: append([]bool(nil), tc.index.ColumnExpressions...), ColumnPrefixLengths: append([]int(nil), tc.index.ColumnPrefixLengths...),
+				IsUnique: tc.index.IsUnique, IncludeCols: append([]string(nil), tc.index.IncludeColumns...), Filter: tc.index.Filter,
+			}
+
+			got, err := public.CreateIndex(tc.table, tc.index)
+			if err != nil {
+				t.Fatalf("CreateIndex: %v", err)
+			}
+			want, err := core.CreateIndexDDL(coreTable, coreIndex)
+			if err != nil {
+				t.Fatalf("core CreateIndexDDL: %v", err)
+			}
+			if got.SQL != want {
+				t.Fatalf("index adapter SQL = %q, want core SQL %q", got.SQL, want)
+			}
+
+			if tc.name == "sqlite" {
+				return
+			}
+			gotPrimaryKey, err := public.CreatePrimaryKey(tc.table, schema.PrimaryKey{Columns: []string{"ID"}})
+			if err != nil {
+				t.Fatalf("CreatePrimaryKey: %v", err)
+			}
+			wantPrimaryKey, err := core.CreatePrimaryKeyDDL(coreTable, "pk_"+tc.table.Name, []string{"ID"})
+			if err != nil {
+				t.Fatalf("core CreatePrimaryKeyDDL: %v", err)
+			}
+			if gotPrimaryKey.SQL != wantPrimaryKey {
+				t.Fatalf("primary-key adapter SQL = %q, want core SQL %q", gotPrimaryKey.SQL, wantPrimaryKey)
+			}
+
+			gotUnique, err := public.CreateUniqueConstraint(tc.table, schema.UniqueConstraint{Name: "UQ_Orders_Email", Columns: []string{"Email"}})
+			if err != nil {
+				t.Fatalf("CreateUniqueConstraint: %v", err)
+			}
+			wantUnique, err := core.CreateUniqueConstraintDDL(coreTable, "UQ_Orders_Email", []string{"Email"})
+			if err != nil {
+				t.Fatalf("core CreateUniqueConstraintDDL: %v", err)
+			}
+			if gotUnique.SQL != wantUnique {
+				t.Fatalf("unique-constraint adapter SQL = %q, want core SQL %q", gotUnique.SQL, wantUnique)
+			}
+
+			gotCheck, err := public.CreateCheckConstraint(tc.table, schema.CheckConstraint{Name: "CK_Orders_Total", Expression: "Total >= 0"})
+			if err != nil {
+				t.Fatalf("CreateCheckConstraint: %v", err)
+			}
+			wantCheck, err := core.CreateCheckConstraintDDL(coreTable, &driver.CheckConstraint{Name: "CK_Orders_Total", Definition: "Total >= 0"})
+			if err != nil {
+				t.Fatalf("core CreateCheckConstraintDDL: %v", err)
+			}
+			if gotCheck.SQL != wantCheck {
+				t.Fatalf("check adapter SQL = %q, want core SQL %q", gotCheck.SQL, wantCheck)
+			}
+		})
+	}
+}
+
+func toDriverColumns(columns []schema.Column) []driver.Column {
+	out := make([]driver.Column, len(columns))
+	for i, column := range columns {
+		out[i] = driver.Column{
+			Name:               column.Name,
+			DataType:           column.DataType,
+			MaxLength:          column.MaxLength,
+			Precision:          column.Precision,
+			Scale:              column.Scale,
+			DatetimePrecision:  column.DatetimePrecision,
+			IsNullable:         column.IsNullable,
+			IsIdentity:         column.IsIdentity,
+			IsUnsigned:         column.IsUnsigned,
+			DisplayWidth:       column.DisplayWidth,
+			DefaultExpression:  column.DefaultExpression,
+			HasDefault:         column.HasDefault,
+			OnUpdateExpression: column.OnUpdateExpression,
+			IsComputed:         column.IsComputed,
+			ComputedExpression: column.ComputedExpression,
+			ComputedPersisted:  column.ComputedPersisted,
+			EnumValues:         append([]string(nil), column.EnumValues...),
+			SRID:               column.SRID,
+			SpatialSubType:     column.SpatialSubType,
+		}
+	}
+	return out
+}

--- a/schema/ddl_side_objects_public_test.go
+++ b/schema/ddl_side_objects_public_test.go
@@ -240,6 +240,24 @@ func TestPublicDDLRejectsNegativeIndexPrefixLength(t *testing.T) {
 	}
 }
 
+func TestPublicDDLFilteredIndexRejectsUnsupportedCrossDialectFunction(t *testing.T) {
+	renderer, err := schema.NewRenderer(schema.Options{TargetDialect: "mssql", Schema: "dbo", SourceDialect: "postgres"})
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	_, err = renderer.CreateIndex(schema.TableRef{
+		Name:    "orders",
+		Columns: []schema.Column{{Name: "email", DataType: "varchar", MaxLength: 255}, {Name: "created_at", DataType: "timestamp"}},
+	}, schema.Index{
+		Name:    "ix_orders_active_email",
+		Columns: []string{"email"},
+		Filter:  "date_trunc('day', created_at) IS NOT NULL",
+	})
+	if err == nil || !strings.Contains(err.Error(), `unsupported SQL expression function "date_trunc"`) {
+		t.Fatalf("CreateIndex error = %v, want cross-dialect function validation error", err)
+	}
+}
+
 func TestPublicDDLSideObjectCapabilitiesAndUnsupportedErrors(t *testing.T) {
 	cases := []struct {
 		dialect                  string

--- a/schema/ddl_side_objects_public_test.go
+++ b/schema/ddl_side_objects_public_test.go
@@ -258,6 +258,27 @@ func TestPublicDDLFilteredIndexRejectsUnsupportedCrossDialectFunction(t *testing
 	}
 }
 
+func TestPublicDDLFilteredIndexPreservesSameDialectFunction(t *testing.T) {
+	renderer, err := schema.NewRenderer(schema.Options{TargetDialect: "postgres", Schema: "public", SourceDialect: "postgres"})
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	result, err := renderer.CreateIndex(schema.TableRef{
+		Name:    "orders",
+		Columns: []schema.Column{{Name: "email", DataType: "varchar", MaxLength: 255}, {Name: "created_at", DataType: "timestamp"}},
+	}, schema.Index{
+		Name:    "ix_orders_active_email",
+		Columns: []string{"email"},
+		Filter:  "date_trunc('day', created_at) IS NOT NULL",
+	})
+	if err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	if !strings.Contains(result.SQL, "date_trunc('day', created_at)") {
+		t.Fatalf("CreateIndex SQL = %q, want same-dialect date_trunc predicate", result.SQL)
+	}
+}
+
 func TestPublicDDLSideObjectCapabilitiesAndUnsupportedErrors(t *testing.T) {
 	cases := []struct {
 		dialect                  string

--- a/schema/ddl_side_objects_public_test.go
+++ b/schema/ddl_side_objects_public_test.go
@@ -177,6 +177,54 @@ func TestPublicDDLSideObjectsPreserveOrderAndIdentifierConvention(t *testing.T) 
 	}
 }
 
+func TestPublicDDLStandalonePrimaryKeyDefaultMatchesCreateTableNaming(t *testing.T) {
+	renderer, err := schema.NewRenderer(schema.Options{TargetDialect: "postgres", Schema: "public"})
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+
+	for _, tableName := range []string{"1Orders", strings.Repeat("order_", 12)} {
+		t.Run(tableName, func(t *testing.T) {
+			wantName := driver.NormalizeIdentifier("postgres", "pk_"+driver.NormalizeIdentifier("postgres", tableName))
+			createTable, err := renderer.CreateTable(schema.Table{
+				Name:       tableName,
+				Columns:    []schema.Column{{Name: "ID", DataType: "int4"}},
+				PrimaryKey: []string{"ID"},
+			})
+			if err != nil {
+				t.Fatalf("CreateTable: %v", err)
+			}
+			primaryKey, err := renderer.CreatePrimaryKey(schema.TableRef{Name: tableName}, schema.PrimaryKey{Columns: []string{"ID"}})
+			if err != nil {
+				t.Fatalf("CreatePrimaryKey: %v", err)
+			}
+			wantConstraint := `CONSTRAINT "` + wantName + `" PRIMARY KEY`
+			if !strings.Contains(createTable.SQL, wantConstraint) {
+				t.Fatalf("CreateTable SQL = %q, want %q", createTable.SQL, wantConstraint)
+			}
+			if !strings.Contains(primaryKey.SQL, wantConstraint) {
+				t.Fatalf("CreatePrimaryKey SQL = %q, want %q", primaryKey.SQL, wantConstraint)
+			}
+		})
+	}
+}
+
+func TestPublicDDLRejectsExpressionIndexPrefixCombination(t *testing.T) {
+	renderer, err := schema.NewRenderer(schema.Options{TargetDialect: "mysql", Schema: "app"})
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	_, err = renderer.CreateIndex(schema.TableRef{Name: "orders"}, schema.Index{
+		Name:                "ix_orders_email_expression",
+		Columns:             []string{"LOWER(email)"},
+		ColumnExpressions:   []bool{true},
+		ColumnPrefixLengths: []int{16},
+	})
+	if err == nil || !strings.Contains(err.Error(), "expression column 0 cannot have a prefix length") {
+		t.Fatalf("CreateIndex error = %v, want expression-prefix validation error", err)
+	}
+}
+
 func TestPublicDDLSideObjectCapabilitiesAndUnsupportedErrors(t *testing.T) {
 	cases := []struct {
 		dialect                  string

--- a/schema/ddl_side_objects_public_test.go
+++ b/schema/ddl_side_objects_public_test.go
@@ -97,6 +97,86 @@ func TestPublicDDLSideObjectGoldens(t *testing.T) {
 	}
 }
 
+func TestPublicDDLClickHouseSideObjectErrorGolden(t *testing.T) {
+	renderer, err := schema.NewRenderer(schema.Options{TargetDialect: "clickhouse", Schema: "analytics"})
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	table := schema.TableRef{Name: "events", Columns: []schema.Column{{Name: "id", DataType: "Int64"}}}
+	cases := []struct {
+		kind string
+		call func() error
+	}{
+		{
+			kind: "create_index",
+			call: func() error {
+				_, err := renderer.CreateIndex(table, schema.Index{Name: "ix_events_id", Columns: []string{"id"}})
+				return err
+			},
+		},
+		{
+			kind: "create_primary_key",
+			call: func() error {
+				_, err := renderer.CreatePrimaryKey(table, schema.PrimaryKey{Columns: []string{"id"}})
+				return err
+			},
+		},
+		{
+			kind: "create_unique_constraint",
+			call: func() error {
+				_, err := renderer.CreateUniqueConstraint(table, schema.UniqueConstraint{Name: "uq_events_id", Columns: []string{"id"}})
+				return err
+			},
+		},
+		{
+			kind: "create_check_constraint",
+			call: func() error {
+				_, err := renderer.CreateCheckConstraint(table, schema.CheckConstraint{Name: "ck_events_id", Expression: "id > 0"})
+				return err
+			},
+		},
+	}
+
+	lines := make([]string, 0, len(cases))
+	for _, tc := range cases {
+		err := tc.call()
+		var unsupported *schema.UnsupportedFeatureError
+		if !errors.As(err, &unsupported) {
+			t.Fatalf("%s error = %v, want UnsupportedFeatureError", tc.kind, err)
+		}
+		lines = append(lines, tc.kind+"\n"+unsupported.Error())
+	}
+	assertGolden(t, strings.Join(lines, "\n\n"), "clickhouse_side_objects.error.golden")
+}
+
+func TestPublicDDLSideObjectsPreserveOrderAndIdentifierConvention(t *testing.T) {
+	renderer, err := schema.NewRenderer(schema.Options{TargetDialect: "postgres", Schema: "public"})
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	table := schema.TableRef{Name: "Order Lines"}
+
+	index, err := renderer.CreateIndex(table, schema.Index{
+		Name: "IX Order Lines", Columns: []string{"Tenant ID", "Order ID"},
+	})
+	if err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	const wantIndex = `CREATE INDEX "ix_order_lines" ON "public"."order_lines" ("tenant_id", "order_id")`
+	if index.SQL != wantIndex {
+		t.Fatalf("index SQL = %q, want %q", index.SQL, wantIndex)
+	}
+
+	primaryKey, err := renderer.CreatePrimaryKey(table, schema.PrimaryKey{Columns: []string{"Tenant ID", "Order ID"}})
+	if err != nil {
+		t.Fatalf("CreatePrimaryKey: %v", err)
+	}
+	const wantPrimaryKey = `ALTER TABLE "public"."order_lines" ADD CONSTRAINT "pk_order_lines" PRIMARY KEY ("tenant_id", "order_id")`
+	if primaryKey.SQL != wantPrimaryKey {
+		t.Fatalf("primary-key SQL = %q, want %q", primaryKey.SQL, wantPrimaryKey)
+	}
+}
+
 func TestPublicDDLSideObjectCapabilitiesAndUnsupportedErrors(t *testing.T) {
 	cases := []struct {
 		dialect                  string

--- a/schema/testdata/ddl/clickhouse_side_objects.error.golden
+++ b/schema/testdata/ddl/clickhouse_side_objects.error.golden
@@ -1,0 +1,11 @@
+create_index
+DDL dialect "clickhouse" does not support secondary indexes
+
+create_primary_key
+DDL dialect "clickhouse" does not support standalone primary keys
+
+create_unique_constraint
+DDL dialect "clickhouse" does not support named unique constraints
+
+create_check_constraint
+DDL dialect "clickhouse" does not support check constraints

--- a/schema/testdata/ddl/mssql_side_objects.sql.golden
+++ b/schema/testdata/ddl/mssql_side_objects.sql.golden
@@ -1,0 +1,11 @@
+create_index
+CREATE UNIQUE INDEX [IX_Orders_Email] ON [dbo].[Orders] ([Email]) INCLUDE ([ID]) WHERE Email IS NOT NULL
+
+create_primary_key
+ALTER TABLE [dbo].[Orders] ADD CONSTRAINT [pk_Orders] PRIMARY KEY ([ID])
+
+create_unique_constraint
+ALTER TABLE [dbo].[Orders] ADD CONSTRAINT [UQ_Orders_Email] UNIQUE ([Email])
+
+create_check_constraint
+ALTER TABLE [dbo].[Orders] ADD CONSTRAINT [CK_Orders_Total] CHECK ([Total] >= 0)

--- a/schema/testdata/ddl/mysql_side_objects.sql.golden
+++ b/schema/testdata/ddl/mysql_side_objects.sql.golden
@@ -1,0 +1,11 @@
+create_index
+CREATE UNIQUE INDEX `IX_Orders_Email` ON `crm`.`Orders` (`Email`(16))
+
+create_primary_key
+ALTER TABLE `crm`.`Orders` ADD CONSTRAINT `pk_Orders` PRIMARY KEY (`ID`)
+
+create_unique_constraint
+ALTER TABLE `crm`.`Orders` ADD CONSTRAINT `UQ_Orders_Email` UNIQUE (`Email`)
+
+create_check_constraint
+ALTER TABLE `crm`.`Orders` ADD CONSTRAINT `CK_Orders_Total` CHECK (`Total` >= 0)

--- a/schema/testdata/ddl/postgres_side_objects.sql.golden
+++ b/schema/testdata/ddl/postgres_side_objects.sql.golden
@@ -1,0 +1,11 @@
+create_index
+CREATE UNIQUE INDEX "ix_orders_email" ON "public"."orders" ("email") INCLUDE ("id") WHERE Email IS NOT NULL
+
+create_primary_key
+ALTER TABLE "public"."orders" ADD CONSTRAINT "pk_orders" PRIMARY KEY ("id")
+
+create_unique_constraint
+ALTER TABLE "public"."orders" ADD CONSTRAINT "uq_orders_email" UNIQUE ("email")
+
+create_check_constraint
+ALTER TABLE "public"."orders" ADD CONSTRAINT "ck_orders_total" CHECK ("total" >= 0)

--- a/schema/testdata/ddl/sqlite_side_objects.sql.golden
+++ b/schema/testdata/ddl/sqlite_side_objects.sql.golden
@@ -1,0 +1,2 @@
+create_index
+CREATE UNIQUE INDEX "ix_orders_email" ON "orders" ("email") WHERE email IS NOT NULL


### PR DESCRIPTION
## Summary

- expose public DDL APIs for indexes, primary keys, unique constraints, and check constraints
- provide typed capability errors across PostgreSQL, MSSQL, MySQL, SQLite, and ClickHouse
- align internal adapters and renderer coverage with public schema behavior

## Why

Applications need a stable, dialect-aware schema API for standalone side objects without relying on raw SQL or internal adapters.

## Validation

- full and race test suites
- lint, vet, and build
- module tidy diff and repository diff checks
- targeted public API and renderer golden tests