### PR TITLE
feat(schema): expose public foreign-key DDL API

### DIFF
--- a/docs/public-ddl-api.md
+++ b/docs/public-ddl-api.md
@@ -216,5 +216,7 @@ renderer, err := registry.NewRenderer(schema.Options{TargetDialect: "my-db"})
 The dialect interface receives only public `schema.Request`, `schema.Table`,
 and `schema.Column` values and returns `schema.Result`; it is safe to implement
 without importing SMT internals. A custom dialect can additionally implement
-`schema.SideObjectDialect` to render the five standalone side-object methods.
-Registries do not share mutable global state.
+`schema.SideObjectDialect` to render indexes and constraints, and
+`schema.ForeignKeyDialect` to render standalone foreign keys. These optional
+extensions are separate so existing custom side-object dialects remain source
+compatible. Registries do not share mutable global state.

--- a/docs/public-ddl-api.md
+++ b/docs/public-ddl-api.md
@@ -1,7 +1,7 @@
 # Public schema DDL API
 
 `github.com/johndauphine/smt/schema` is the supported library surface for
-deterministic schema, table, column, index, and constraint DDL. It uses SMT's
+deterministic schema, table, column, index, constraint, and foreign-key DDL. It uses SMT's
 existing renderer and canonical type mapper; its input and result types do not
 expose `internal/*` packages or database handles. It does not load a database
 driver or require a PostgreSQL client dependency.
@@ -93,7 +93,20 @@ check, err := renderer.CreateCheckConstraint(orders, schema.CheckConstraint{
 if err != nil {
     return err
 }
-for _, result := range []schema.Result{index, unique, check} {
+
+foreignKey, err := renderer.CreateForeignKey(orders, schema.ForeignKey{
+    Name:       "fk_orders_accounts",
+    Columns:    []string{"account_id"},
+    RefSchema:  "identity",
+    RefTable:   "accounts",
+    RefColumns: []string{"id"},
+    OnDelete:   schema.ReferentialActionCascade,
+    OnUpdate:   schema.ReferentialActionNoAction,
+})
+if err != nil {
+    return err
+}
+for _, result := range []schema.Result{index, unique, check, foreignKey} {
     if err := target.ExecRaw(ctx, result.SQL); err != nil {
         return err
     }
@@ -106,7 +119,17 @@ needed for deterministic translation (for example boolean conventions).
 `CreatePrimaryKey` uses an explicit name when supplied, otherwise it derives
 `pk_<table>` using the same deterministic naming convention as `CreateTable`.
 
-Foreign keys, alter, drop, and scheduling remain outside this public milestone.
+`CreateForeignKey` adds one named standalone foreign key. `Columns` and
+`RefColumns` are positional and must have the same non-zero length, so composite
+keys are supported directly. The local table uses the renderer's configured
+schema; set `RefSchema` to qualify the referenced table, or leave it empty to
+use that same schema. `OnDelete` and `OnUpdate` use `ReferentialAction` values.
+The empty value omits the clause, while `ReferentialActionNoAction` emits an
+explicit `NO ACTION` clause. SQL Server rejects `RESTRICT`, and MySQL rejects
+`SET DEFAULT`, with `*schema.UnsupportedFeatureError` rather than emitting
+invalid target SQL.
+
+Alter, drop, and scheduling remain outside this public milestone.
 
 `SourceDialect` is optional, but callers should set it whenever it is known:
 some names have source-specific meanings, such as MySQL `TINYINT(1)` and
@@ -119,7 +142,7 @@ empty `DefaultExpression` still represents a source `DEFAULT` clause.
 
 A new `schema.Registry` starts with these dialects and aliases:
 
-| Dialect | Aliases | Schema/table/column | Secondary indexes | Standalone PK / named UNIQUE / CHECK |
+| Dialect | Aliases | Schema/table/column | Secondary indexes | Standalone PK / named UNIQUE / CHECK / FK |
 | --- | --- | --- | --- | --- |
 | `postgres` | `postgresql`, `pg` | yes | yes | yes |
 | `mssql` | `sqlserver`, `sql-server`, `sql_server` | yes | yes | yes |
@@ -130,10 +153,10 @@ A new `schema.Registry` starts with these dialects and aliases:
 Inspect `renderer.Capabilities()` before using identities, defaults, computed
 columns, a named schema, or a side-object feature. The side-object fields are
 `SecondaryIndexes`, `StandalonePrimaryKeys`, `NamedUniqueConstraints`,
-`CheckConstraints`, `IndexExpressionKeys`, `IndexPrefixLengths`,
-`IndexIncludeColumns`, and `FilteredIndexes`. If input requests an unsupported
-feature, rendering returns `*schema.UnsupportedFeatureError`; SMT never
-silently drops it.
+`CheckConstraints`, `StandaloneForeignKeys`, `IndexExpressionKeys`,
+`IndexPrefixLengths`, `IndexIncludeColumns`, and `FilteredIndexes`. If input
+requests an unsupported feature, rendering returns
+`*schema.UnsupportedFeatureError`; SMT never silently drops it.
 
 PostgreSQL supports expression-key, included-column, and filtered indexes.
 SQL Server supports included-column and filtered indexes. MySQL supports
@@ -149,6 +172,8 @@ it treats a configured schema as connection selection and emits unqualified
 table DDL. SQLite identities are supported through `CreateTable` only when the
 identity is the sole primary-key column, using `INTEGER PRIMARY KEY
 AUTOINCREMENT`; a standalone identity `CreateColumn` returns an explicit
+unsupported-feature error. SQLite cannot add a standalone foreign-key
+constraint through `ALTER TABLE`, so `CreateForeignKey` returns an explicit
 unsupported-feature error. ClickHouse supports
 the practical create-table subset: it emits `MergeTree` with `ORDER BY` set to
 the primary-key columns (or `tuple()` when there is no primary key). ClickHouse
@@ -191,5 +216,5 @@ renderer, err := registry.NewRenderer(schema.Options{TargetDialect: "my-db"})
 The dialect interface receives only public `schema.Request`, `schema.Table`,
 and `schema.Column` values and returns `schema.Result`; it is safe to implement
 without importing SMT internals. A custom dialect can additionally implement
-`schema.SideObjectDialect` to render the four standalone side-object methods.
+`schema.SideObjectDialect` to render the five standalone side-object methods.
 Registries do not share mutable global state.

--- a/internal/ddl/postgres/renderer.go
+++ b/internal/ddl/postgres/renderer.go
@@ -290,12 +290,16 @@ func (r deterministicDDL) createForeignKey(t *driver.Table, fk *driver.ForeignKe
 	}
 
 	refTable := sanitizePGTableName(fk.RefTable)
+	refSchema := targetSchema
+	if strings.TrimSpace(fk.RefSchema) != "" {
+		refSchema = sanitizePGIdentifier(fk.RefSchema)
+	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)",
 		r.dialect.QualifyTable(targetSchema, tableName),
 		r.dialect.QuoteIdentifier(fkName),
 		strings.Join(cols, ", "),
-		r.dialect.QualifyTable(targetSchema, refTable),
+		r.dialect.QualifyTable(refSchema, refTable),
 		strings.Join(refCols, ", "))
 
 	if rule := pgReferentialAction(fk.OnDelete); rule != "" {
@@ -522,9 +526,9 @@ func rejectUnsupportedSQLServerExpression(expr string) error {
 
 func pgReferentialAction(rule string) string {
 	switch strings.ToUpper(strings.TrimSpace(rule)) {
-	case "", "NO ACTION":
+	case "":
 		return ""
-	case "CASCADE", "SET NULL", "SET DEFAULT", "RESTRICT":
+	case "NO ACTION", "CASCADE", "SET NULL", "SET DEFAULT", "RESTRICT":
 		return strings.ToUpper(strings.TrimSpace(rule))
 	default:
 		return ""

--- a/internal/ddl/postgres/renderer_test.go
+++ b/internal/ddl/postgres/renderer_test.go
@@ -73,14 +73,16 @@ func TestDeterministicFinalizationDDL(t *testing.T) {
 	fkDDL, err := renderer.createForeignKey(table, &driver.ForeignKey{
 		Name:       "FK_Votes_Posts",
 		Columns:    []string{"PostId"},
+		RefSchema:  "identity",
 		RefTable:   "Posts",
 		RefColumns: []string{"Id"},
 		OnDelete:   "NO ACTION",
+		OnUpdate:   "CASCADE",
 	}, "public")
 	if err != nil {
 		t.Fatalf("createForeignKey: %v", err)
 	}
-	assertContains(t, fkDDL, `ALTER TABLE "public"."votes" ADD CONSTRAINT "fk_votes_posts" FOREIGN KEY ("postid") REFERENCES "public"."posts" ("id")`)
+	assertContains(t, fkDDL, `ALTER TABLE "public"."votes" ADD CONSTRAINT "fk_votes_posts" FOREIGN KEY ("postid") REFERENCES "identity"."posts" ("id") ON DELETE NO ACTION ON UPDATE CASCADE`)
 
 	checkDDL, err := renderer.createCheckConstraint(table, &driver.CheckConstraint{
 		Name:       "CK_Votes_BountyAmount",

--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -69,7 +69,9 @@ import (
 // nullable PRIMARY KEY / ORDER BY columns instead of emitting invalid DDL.
 // "18": standalone schema side-object DDL adds deterministic index and
 // constraint rendering, including fail-closed cross-dialect index predicates.
-const RendererVersion = "18"
+// "19": foreign-key references honor an explicit referenced schema and emit
+// explicit NO ACTION clauses when callers request them.
+const RendererVersion = "19"
 
 // ClickHouseNullableCompositeError reports a nullable composite that ClickHouse
 // cannot represent as Nullable(T). Rewriting it to Array(Nullable(T)) would
@@ -639,7 +641,7 @@ func (r Renderer) CreateForeignKeyDDL(t *driver.Table, fk *driver.ForeignKey) (s
 		r.qualify(r.normalize(t.Name)),
 		r.quote(r.normalize(fk.Name)),
 		strings.Join(cols, ", "),
-		r.qualify(r.normalize(fk.RefTable)),
+		r.qualifyForeignKeyReference(fk.RefSchema, fk.RefTable),
 		strings.Join(refCols, ", "))
 	if action := referentialAction(fk.OnDelete); action != "" {
 		b.WriteString(" ON DELETE ")
@@ -1039,6 +1041,13 @@ func (r Renderer) qualify(table string) string {
 	return r.quote(r.schema) + "." + r.quote(table)
 }
 
+func (r Renderer) qualifyForeignKeyReference(schema, table string) string {
+	if strings.TrimSpace(schema) == "" {
+		return r.qualify(r.normalize(table))
+	}
+	return r.quote(r.normalize(schema)) + "." + r.quote(r.normalize(table))
+}
+
 func firstColumns(columns [][]driver.Column) []driver.Column {
 	if len(columns) == 0 {
 		return nil
@@ -1100,9 +1109,9 @@ func boolLiteral(target string, value bool) string {
 
 func referentialAction(rule string) string {
 	switch strings.ToUpper(strings.TrimSpace(rule)) {
-	case "", "NO ACTION":
+	case "":
 		return ""
-	case "CASCADE", "SET NULL", "SET DEFAULT", "RESTRICT":
+	case "NO ACTION", "CASCADE", "SET NULL", "SET DEFAULT", "RESTRICT":
 		return strings.ToUpper(strings.TrimSpace(rule))
 	default:
 		return ""

--- a/internal/ddl/renderer_test.go
+++ b/internal/ddl/renderer_test.go
@@ -181,6 +181,47 @@ func TestRenderer_FinalizationMySQL(t *testing.T) {
 	assertEqualSQL(t, checkSQL, "ALTER TABLE `crm`.`Companies` ADD CONSTRAINT `CK_Companies_Active` CHECK (`IsActive` = 1)")
 }
 
+func TestRenderer_ForeignKeyReferenceSchemaAndExplicitNoAction(t *testing.T) {
+	cases := []struct {
+		target string
+		schema string
+		want   string
+	}{
+		{
+			target: "mssql",
+			schema: "dbo",
+			want:   `ALTER TABLE [dbo].[OrderLines] ADD CONSTRAINT [FK_OrderLines_Orders] FOREIGN KEY ([TenantId], [OrderId]) REFERENCES [identity].[Orders] ([TenantId], [Id]) ON DELETE NO ACTION ON UPDATE CASCADE`,
+		},
+		{
+			target: "mysql",
+			schema: "crm",
+			want:   "ALTER TABLE `crm`.`OrderLines` ADD CONSTRAINT `FK_OrderLines_Orders` FOREIGN KEY (`TenantId`, `OrderId`) REFERENCES `identity`.`Orders` (`TenantId`, `Id`) ON DELETE NO ACTION ON UPDATE CASCADE",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.target, func(t *testing.T) {
+			renderer, err := NewRenderer(tc.target, tc.schema, "fail")
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			got, err := renderer.CreateForeignKeyDDL(&driver.Table{Name: "OrderLines"}, &driver.ForeignKey{
+				Name:       "FK_OrderLines_Orders",
+				Columns:    []string{"TenantId", "OrderId"},
+				RefSchema:  "identity",
+				RefTable:   "Orders",
+				RefColumns: []string{"TenantId", "Id"},
+				OnDelete:   "NO ACTION",
+				OnUpdate:   "CASCADE",
+			})
+			if err != nil {
+				t.Fatalf("CreateForeignKeyDDL: %v", err)
+			}
+			assertEqualSQL(t, got, tc.want)
+		})
+	}
+}
+
 func TestRenderer_DropIndexPostgresWithoutSchema(t *testing.T) {
 	renderer, err := NewRenderer("postgres", "", "fail")
 	if err != nil {

--- a/internal/schemadiff/testdata/golden/sync_mssql.sql
+++ b/internal/schemadiff/testdata/golden/sync_mssql.sql
@@ -56,11 +56,11 @@ ALTER TABLE [tgt].[audit_log] ADD CONSTRAINT [ck_audit_action] CHECK ([action] I
 
 -- [blocking] create foreign key fk_users_org
 -- note: foreign key validation can scan existing rows
-ALTER TABLE [tgt].[users] ADD CONSTRAINT [fk_users_org] FOREIGN KEY ([org_id]) REFERENCES [tgt].[orgs] ([id]) ON DELETE SET NULL;
+ALTER TABLE [tgt].[users] ADD CONSTRAINT [fk_users_org] FOREIGN KEY ([org_id]) REFERENCES [app].[orgs] ([id]) ON DELETE SET NULL;
 
 -- [blocking] create foreign key fk_audit_actor
 -- note: foreign key validation can scan existing rows
-ALTER TABLE [tgt].[audit_log] ADD CONSTRAINT [fk_audit_actor] FOREIGN KEY ([actor]) REFERENCES [tgt].[users] ([username]) ON DELETE CASCADE;
+ALTER TABLE [tgt].[audit_log] ADD CONSTRAINT [fk_audit_actor] FOREIGN KEY ([actor]) REFERENCES [app].[users] ([username]) ON DELETE CASCADE;
 
 -- [data-loss-risk] drop table line_items
 -- note: drops the table and its data

--- a/internal/schemadiff/testdata/golden/sync_mysql.sql
+++ b/internal/schemadiff/testdata/golden/sync_mysql.sql
@@ -53,11 +53,11 @@ ALTER TABLE `tgt`.`audit_log` ADD CONSTRAINT `ck_audit_action` CHECK (`action` I
 
 -- [blocking] create foreign key fk_users_org
 -- note: foreign key validation can scan existing rows
-ALTER TABLE `tgt`.`users` ADD CONSTRAINT `fk_users_org` FOREIGN KEY (`org_id`) REFERENCES `tgt`.`orgs` (`id`) ON DELETE SET NULL;
+ALTER TABLE `tgt`.`users` ADD CONSTRAINT `fk_users_org` FOREIGN KEY (`org_id`) REFERENCES `app`.`orgs` (`id`) ON DELETE SET NULL;
 
 -- [blocking] create foreign key fk_audit_actor
 -- note: foreign key validation can scan existing rows
-ALTER TABLE `tgt`.`audit_log` ADD CONSTRAINT `fk_audit_actor` FOREIGN KEY (`actor`) REFERENCES `tgt`.`users` (`username`) ON DELETE CASCADE;
+ALTER TABLE `tgt`.`audit_log` ADD CONSTRAINT `fk_audit_actor` FOREIGN KEY (`actor`) REFERENCES `app`.`users` (`username`) ON DELETE CASCADE;
 
 -- [data-loss-risk] drop table line_items
 -- note: drops the table and its data

--- a/internal/schemadiff/testdata/golden/sync_postgres.sql
+++ b/internal/schemadiff/testdata/golden/sync_postgres.sql
@@ -53,11 +53,11 @@ ALTER TABLE "tgt"."audit_log" ADD CONSTRAINT "ck_audit_action" CHECK ("action" I
 
 -- [blocking] create foreign key fk_users_org
 -- note: foreign key validation can scan existing rows
-ALTER TABLE "tgt"."users" ADD CONSTRAINT "fk_users_org" FOREIGN KEY ("org_id") REFERENCES "tgt"."orgs" ("id") ON DELETE SET NULL;
+ALTER TABLE "tgt"."users" ADD CONSTRAINT "fk_users_org" FOREIGN KEY ("org_id") REFERENCES "app"."orgs" ("id") ON DELETE SET NULL;
 
 -- [blocking] create foreign key fk_audit_actor
 -- note: foreign key validation can scan existing rows
-ALTER TABLE "tgt"."audit_log" ADD CONSTRAINT "fk_audit_actor" FOREIGN KEY ("actor") REFERENCES "tgt"."users" ("username") ON DELETE CASCADE;
+ALTER TABLE "tgt"."audit_log" ADD CONSTRAINT "fk_audit_actor" FOREIGN KEY ("actor") REFERENCES "app"."users" ("username") ON DELETE CASCADE;
 
 -- [data-loss-risk] drop table line_items
 -- note: drops the table and its data

--- a/schema/ddl.go
+++ b/schema/ddl.go
@@ -280,9 +280,19 @@ type SideObjectDialect interface {
 	Dialect
 	RenderIndex(Request, TableRef, Index) (Result, error)
 	RenderPrimaryKey(Request, TableRef, PrimaryKey) (Result, error)
-	RenderForeignKey(Request, TableRef, ForeignKey) (Result, error)
 	RenderUniqueConstraint(Request, TableRef, UniqueConstraint) (Result, error)
 	RenderCheckConstraint(Request, TableRef, CheckConstraint) (Result, error)
+}
+
+// ForeignKeyDialect is the optional extension for standalone foreign-key
+// rendering. It remains separate from SideObjectDialect so adding this API
+// does not break existing custom side-object implementations.
+//
+// A ForeignKeyDialect should set Capabilities.StandaloneForeignKeys to true.
+// Built-in dialects implement this interface.
+type ForeignKeyDialect interface {
+	Dialect
+	RenderForeignKey(Request, TableRef, ForeignKey) (Result, error)
 }
 
 var (
@@ -530,7 +540,7 @@ func (r Renderer) CreateForeignKey(table TableRef, foreignKey ForeignKey) (Resul
 	if err := validateForeignKeyActionSupport(r.Dialect(), foreignKey.OnUpdate); err != nil {
 		return Result{}, err
 	}
-	dialect, err := r.sideObjectDialect("standalone foreign keys")
+	dialect, err := r.foreignKeyDialect()
 	if err != nil {
 		return Result{}, err
 	}
@@ -676,6 +686,14 @@ func (r Renderer) sideObjectDialect(feature string) (SideObjectDialect, error) {
 	dialect, ok := r.dialect.(SideObjectDialect)
 	if !ok {
 		return nil, r.unsupported(feature)
+	}
+	return dialect, nil
+}
+
+func (r Renderer) foreignKeyDialect() (ForeignKeyDialect, error) {
+	dialect, ok := r.dialect.(ForeignKeyDialect)
+	if !ok {
+		return nil, r.unsupported("standalone foreign keys")
 	}
 	return dialect, nil
 }

--- a/schema/ddl.go
+++ b/schema/ddl.go
@@ -79,8 +79,9 @@ type Result struct {
 // StatementKind identifies the create artifact emitted by a Statement. The
 // public create plan contains schema and table statements only. Independent
 // side objects are rendered through Renderer.CreateIndex,
-// Renderer.CreatePrimaryKey, Renderer.CreateUniqueConstraint, and
-// Renderer.CreateCheckConstraint so callers retain their own schedule.
+// Renderer.CreatePrimaryKey, Renderer.CreateForeignKey,
+// Renderer.CreateUniqueConstraint, and Renderer.CreateCheckConstraint so
+// callers retain their own schedule.
 type StatementKind string
 
 const (

--- a/schema/ddl.go
+++ b/schema/ddl.go
@@ -41,6 +41,7 @@ type Capabilities struct {
 	ComputedColumns        bool
 	SecondaryIndexes       bool
 	StandalonePrimaryKeys  bool
+	StandaloneForeignKeys  bool
 	NamedUniqueConstraints bool
 	CheckConstraints       bool
 	IndexExpressionKeys    bool
@@ -212,6 +213,35 @@ type PrimaryKey struct {
 	Columns []string
 }
 
+// ReferentialAction controls the action a foreign key takes when its
+// referenced row is deleted or updated. The empty value omits the clause;
+// use ReferentialActionNoAction when an explicit NO ACTION clause is needed.
+type ReferentialAction string
+
+const (
+	ReferentialActionNoAction   ReferentialAction = "NO ACTION"
+	ReferentialActionRestrict   ReferentialAction = "RESTRICT"
+	ReferentialActionCascade    ReferentialAction = "CASCADE"
+	ReferentialActionSetNull    ReferentialAction = "SET NULL"
+	ReferentialActionSetDefault ReferentialAction = "SET DEFAULT"
+)
+
+// ForeignKey is a standalone, named foreign-key constraint. RefSchema is
+// optional: when empty, the renderer's configured schema is used for both
+// tables; when set, it explicitly qualifies RefTable.
+//
+// Columns and RefColumns are positionally aligned and must have the same
+// non-zero length. OnDelete and OnUpdate accept the ReferentialAction values.
+type ForeignKey struct {
+	Name       string
+	Columns    []string
+	RefSchema  string
+	RefTable   string
+	RefColumns []string
+	OnDelete   ReferentialAction
+	OnUpdate   ReferentialAction
+}
+
 // UniqueConstraint is a named UNIQUE constraint. It is deliberately separate
 // from Index with IsUnique so callers choose the database object they intend.
 type UniqueConstraint struct {
@@ -249,6 +279,7 @@ type SideObjectDialect interface {
 	Dialect
 	RenderIndex(Request, TableRef, Index) (Result, error)
 	RenderPrimaryKey(Request, TableRef, PrimaryKey) (Result, error)
+	RenderForeignKey(Request, TableRef, ForeignKey) (Result, error)
 	RenderUniqueConstraint(Request, TableRef, UniqueConstraint) (Result, error)
 	RenderCheckConstraint(Request, TableRef, CheckConstraint) (Result, error)
 }
@@ -482,6 +513,29 @@ func (r Renderer) CreatePrimaryKey(table TableRef, primaryKey PrimaryKey) (Resul
 	return dialect.RenderPrimaryKey(r.request, table, primaryKey)
 }
 
+// CreateForeignKey renders a standalone, named foreign-key constraint. The
+// local table uses the renderer's configured schema; ForeignKey.RefSchema
+// optionally selects a distinct schema or database for the referenced table.
+func (r Renderer) CreateForeignKey(table TableRef, foreignKey ForeignKey) (Result, error) {
+	if !r.Capabilities().StandaloneForeignKeys {
+		return Result{}, r.unsupported("standalone foreign keys")
+	}
+	if err := validateForeignKey(table, &foreignKey); err != nil {
+		return Result{}, err
+	}
+	if err := validateForeignKeyActionSupport(r.Dialect(), foreignKey.OnDelete); err != nil {
+		return Result{}, err
+	}
+	if err := validateForeignKeyActionSupport(r.Dialect(), foreignKey.OnUpdate); err != nil {
+		return Result{}, err
+	}
+	dialect, err := r.sideObjectDialect("standalone foreign keys")
+	if err != nil {
+		return Result{}, err
+	}
+	return dialect.RenderForeignKey(r.request, table, foreignKey)
+}
+
 // CreateUniqueConstraint renders a standalone, named UNIQUE constraint. Use
 // CreateIndex with Index.IsUnique for a unique index instead.
 func (r Renderer) CreateUniqueConstraint(table TableRef, unique UniqueConstraint) (Result, error) {
@@ -687,6 +741,65 @@ func validateKeyConstraint(kind string, table TableRef, name string, columns []s
 	return nil
 }
 
+func validateForeignKey(table TableRef, foreignKey *ForeignKey) error {
+	if err := validateTableRef("foreign key", table); err != nil {
+		return err
+	}
+	if strings.TrimSpace(foreignKey.Name) == "" {
+		return fmt.Errorf("render foreign key on table %q: empty constraint name", table.Name)
+	}
+	if strings.TrimSpace(foreignKey.RefTable) == "" {
+		return fmt.Errorf("render foreign key %q: empty referenced table", foreignKey.Name)
+	}
+	if len(foreignKey.Columns) == 0 {
+		return fmt.Errorf("render foreign key %q: no columns", foreignKey.Name)
+	}
+	if len(foreignKey.Columns) != len(foreignKey.RefColumns) {
+		return fmt.Errorf("render foreign key %q: %d columns but %d referenced columns", foreignKey.Name, len(foreignKey.Columns), len(foreignKey.RefColumns))
+	}
+	for i, column := range foreignKey.Columns {
+		if strings.TrimSpace(column) == "" {
+			return fmt.Errorf("render foreign key %q: column %d is empty", foreignKey.Name, i)
+		}
+	}
+	for i, column := range foreignKey.RefColumns {
+		if strings.TrimSpace(column) == "" {
+			return fmt.Errorf("render foreign key %q: referenced column %d is empty", foreignKey.Name, i)
+		}
+	}
+	var err error
+	if foreignKey.OnDelete, err = normalizeReferentialAction("ON DELETE", foreignKey.Name, foreignKey.OnDelete); err != nil {
+		return err
+	}
+	if foreignKey.OnUpdate, err = normalizeReferentialAction("ON UPDATE", foreignKey.Name, foreignKey.OnUpdate); err != nil {
+		return err
+	}
+	return nil
+}
+
+func normalizeReferentialAction(clause, name string, action ReferentialAction) (ReferentialAction, error) {
+	canonical := ReferentialAction(strings.ToUpper(strings.Join(strings.Fields(string(action)), " ")))
+	switch canonical {
+	case "", ReferentialActionNoAction, ReferentialActionRestrict, ReferentialActionCascade, ReferentialActionSetNull, ReferentialActionSetDefault:
+		return canonical, nil
+	default:
+		return "", fmt.Errorf("render foreign key %q: invalid %s action %q", name, clause, action)
+	}
+}
+
+func validateForeignKeyActionSupport(dialect string, action ReferentialAction) error {
+	if action == "" || action == ReferentialActionNoAction || action == ReferentialActionCascade || action == ReferentialActionSetNull {
+		return nil
+	}
+	if dialect == "mssql" && action == ReferentialActionRestrict {
+		return &UnsupportedFeatureError{Dialect: dialect, Feature: "foreign-key RESTRICT actions"}
+	}
+	if dialect == "mysql" && action == ReferentialActionSetDefault {
+		return &UnsupportedFeatureError{Dialect: dialect, Feature: "foreign-key SET DEFAULT actions"}
+	}
+	return nil
+}
+
 func hasTrue(values []bool) bool {
 	for _, value := range values {
 		if value {
@@ -715,7 +828,7 @@ func builtinDialects() []Dialect {
 	full := Capabilities{
 		CreateSchema: true, CreateTable: true, CreateColumn: true,
 		PrimaryKeys: true, IdentityColumns: true, Defaults: true, ComputedColumns: true,
-		SecondaryIndexes: true, StandalonePrimaryKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
+		SecondaryIndexes: true, StandalonePrimaryKeys: true, StandaloneForeignKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
 		IndexExpressionKeys: true, IndexIncludeColumns: true, FilteredIndexes: true,
 	}
 	return []Dialect{
@@ -725,7 +838,7 @@ func builtinDialects() []Dialect {
 			capabilities: Capabilities{
 				CreateSchema: true, CreateTable: true, CreateColumn: true,
 				PrimaryKeys: true, IdentityColumns: true, Defaults: true, ComputedColumns: true,
-				SecondaryIndexes: true, StandalonePrimaryKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
+				SecondaryIndexes: true, StandalonePrimaryKeys: true, StandaloneForeignKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
 				IndexIncludeColumns: true, FilteredIndexes: true,
 			},
 		},
@@ -734,7 +847,7 @@ func builtinDialects() []Dialect {
 			capabilities: Capabilities{
 				CreateSchema: true, CreateTable: true, CreateColumn: true,
 				PrimaryKeys: true, IdentityColumns: true, Defaults: true, ComputedColumns: true,
-				SecondaryIndexes: true, StandalonePrimaryKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
+				SecondaryIndexes: true, StandalonePrimaryKeys: true, StandaloneForeignKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
 				IndexExpressionKeys: true, IndexPrefixLengths: true,
 			},
 		},
@@ -841,6 +954,18 @@ func (d builtinDialect) RenderPrimaryKey(request Request, table TableRef, primar
 	return Result{SQL: sql}, nil
 }
 
+func (d builtinDialect) RenderForeignKey(request Request, table TableRef, foreignKey ForeignKey) (Result, error) {
+	renderer, err := d.renderer(request)
+	if err != nil {
+		return Result{}, err
+	}
+	sql, err := renderer.CreateForeignKeyDDL(toDriverTableRef(table), toDriverForeignKey(foreignKey))
+	if err != nil {
+		return Result{}, d.publicRenderError(err)
+	}
+	return Result{SQL: sql}, nil
+}
+
 func (d builtinDialect) RenderUniqueConstraint(request Request, table TableRef, unique UniqueConstraint) (Result, error) {
 	renderer, err := d.renderer(request)
 	if err != nil {
@@ -931,6 +1056,18 @@ func toDriverIndex(index Index) *driver.Index {
 		IsUnique:            index.IsUnique,
 		IncludeCols:         append([]string(nil), index.IncludeColumns...),
 		Filter:              index.Filter,
+	}
+}
+
+func toDriverForeignKey(foreignKey ForeignKey) *driver.ForeignKey {
+	return &driver.ForeignKey{
+		Name:       foreignKey.Name,
+		Columns:    append([]string(nil), foreignKey.Columns...),
+		RefSchema:  strings.TrimSpace(foreignKey.RefSchema),
+		RefTable:   foreignKey.RefTable,
+		RefColumns: append([]string(nil), foreignKey.RefColumns...),
+		OnDelete:   string(foreignKey.OnDelete),
+		OnUpdate:   string(foreignKey.OnUpdate),
 	}
 }
 

--- a/schema/ddl_public_test.go
+++ b/schema/ddl_public_test.go
@@ -628,6 +628,32 @@ type duplicateAliasesDialect struct {
 func (d duplicateAliasesDialect) Name() string      { return d.name }
 func (d duplicateAliasesDialect) Aliases() []string { return d.aliases }
 
+// legacySideObjectDialect intentionally implements the pre-ForeignKey
+// SideObjectDialect method set to pin source compatibility for custom users.
+type legacySideObjectDialect struct{ testDialect }
+
+func (legacySideObjectDialect) Name() string      { return "legacy-side-objects" }
+func (legacySideObjectDialect) Aliases() []string { return nil }
+func (legacySideObjectDialect) Capabilities() schema.Capabilities {
+	return schema.Capabilities{
+		CreateSchema: true, CreateTable: true, CreateColumn: true,
+		SecondaryIndexes: true, StandalonePrimaryKeys: true,
+		NamedUniqueConstraints: true, CheckConstraints: true,
+	}
+}
+func (legacySideObjectDialect) RenderIndex(schema.Request, schema.TableRef, schema.Index) (schema.Result, error) {
+	return schema.Result{SQL: "LEGACY INDEX"}, nil
+}
+func (legacySideObjectDialect) RenderPrimaryKey(schema.Request, schema.TableRef, schema.PrimaryKey) (schema.Result, error) {
+	return schema.Result{SQL: "LEGACY PRIMARY KEY"}, nil
+}
+func (legacySideObjectDialect) RenderUniqueConstraint(schema.Request, schema.TableRef, schema.UniqueConstraint) (schema.Result, error) {
+	return schema.Result{SQL: "LEGACY UNIQUE"}, nil
+}
+func (legacySideObjectDialect) RenderCheckConstraint(schema.Request, schema.TableRef, schema.CheckConstraint) (schema.Result, error) {
+	return schema.Result{SQL: "LEGACY CHECK"}, nil
+}
+
 func assertGolden(t *testing.T, got, name string) {
 	t.Helper()
 	wantBytes, err := os.ReadFile(filepath.Join("testdata", "ddl", name))

--- a/schema/ddl_side_objects_public_test.go
+++ b/schema/ddl_side_objects_public_test.go
@@ -517,6 +517,47 @@ func TestPublicDDLForeignKeyValidationAndActionCapabilities(t *testing.T) {
 	}
 }
 
+func TestPublicDDLLegacySideObjectDialectRemainsCompatible(t *testing.T) {
+	registry := schema.NewRegistry()
+	if err := registry.Register(legacySideObjectDialect{}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	renderer, err := registry.NewRenderer(schema.Options{TargetDialect: "legacy-side-objects"})
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	table := schema.TableRef{Name: "items"}
+
+	for _, tc := range []struct {
+		name string
+		call func() (schema.Result, error)
+		want string
+	}{
+		{name: "index", call: func() (schema.Result, error) {
+			return renderer.CreateIndex(table, schema.Index{Name: "ix_items_id", Columns: []string{"id"}})
+		}, want: "LEGACY INDEX"},
+		{name: "primary key", call: func() (schema.Result, error) {
+			return renderer.CreatePrimaryKey(table, schema.PrimaryKey{Name: "pk_items", Columns: []string{"id"}})
+		}, want: "LEGACY PRIMARY KEY"},
+		{name: "unique", call: func() (schema.Result, error) {
+			return renderer.CreateUniqueConstraint(table, schema.UniqueConstraint{Name: "uq_items_id", Columns: []string{"id"}})
+		}, want: "LEGACY UNIQUE"},
+		{name: "check", call: func() (schema.Result, error) {
+			return renderer.CreateCheckConstraint(table, schema.CheckConstraint{Name: "ck_items_id", Expression: "id > 0"})
+		}, want: "LEGACY CHECK"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := tc.call()
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			if result.SQL != tc.want {
+				t.Fatalf("SQL = %q, want %q", result.SQL, tc.want)
+			}
+		})
+	}
+}
+
 func TestPublicDDLSideObjectAdapterParity(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/schema/ddl_side_objects_public_test.go
+++ b/schema/ddl_side_objects_public_test.go
@@ -86,10 +86,18 @@ func TestPublicDDLSideObjectGoldens(t *testing.T) {
 				if err != nil {
 					t.Fatalf("CreateCheckConstraint: %v", err)
 				}
+				foreignKey, err := renderer.CreateForeignKey(tc.table, schema.ForeignKey{
+					Name: "FK_Orders_Accounts", Columns: []string{"ID"}, RefSchema: "identity", RefTable: "Accounts", RefColumns: []string{"ID"},
+					OnDelete: schema.ReferentialActionCascade, OnUpdate: schema.ReferentialActionSetNull,
+				})
+				if err != nil {
+					t.Fatalf("CreateForeignKey: %v", err)
+				}
 				statements = append(statements,
 					"create_primary_key\n"+primaryKey.SQL,
 					"create_unique_constraint\n"+unique.SQL,
 					"create_check_constraint\n"+check.SQL,
+					"create_foreign_key\n"+foreignKey.SQL,
 				)
 			}
 			assertGolden(t, strings.Join(statements, "\n\n"), tc.golden)
@@ -135,6 +143,13 @@ func TestPublicDDLClickHouseSideObjectErrorGolden(t *testing.T) {
 				return err
 			},
 		},
+		{
+			kind: "create_foreign_key",
+			call: func() error {
+				_, err := renderer.CreateForeignKey(table, schema.ForeignKey{Name: "fk_events_id", Columns: []string{"id"}, RefTable: "accounts", RefColumns: []string{"id"}})
+				return err
+			},
+		},
 	}
 
 	lines := make([]string, 0, len(cases))
@@ -174,6 +189,18 @@ func TestPublicDDLSideObjectsPreserveOrderAndIdentifierConvention(t *testing.T) 
 	const wantPrimaryKey = `ALTER TABLE "public"."order_lines" ADD CONSTRAINT "pk_order_lines" PRIMARY KEY ("tenant_id", "order_id")`
 	if primaryKey.SQL != wantPrimaryKey {
 		t.Fatalf("primary-key SQL = %q, want %q", primaryKey.SQL, wantPrimaryKey)
+	}
+
+	foreignKey, err := renderer.CreateForeignKey(table, schema.ForeignKey{
+		Name: "FK Order Lines Orders", Columns: []string{"Tenant ID", "Order ID"}, RefSchema: "Catalog Data", RefTable: "Orders", RefColumns: []string{"Tenant ID", "ID"},
+		OnDelete: schema.ReferentialActionNoAction, OnUpdate: schema.ReferentialActionCascade,
+	})
+	if err != nil {
+		t.Fatalf("CreateForeignKey: %v", err)
+	}
+	const wantForeignKey = `ALTER TABLE "public"."order_lines" ADD CONSTRAINT "fk_order_lines_orders" FOREIGN KEY ("tenant_id", "order_id") REFERENCES "catalog_data"."orders" ("tenant_id", "id") ON DELETE NO ACTION ON UPDATE CASCADE`
+	if foreignKey.SQL != wantForeignKey {
+		t.Fatalf("foreign-key SQL = %q, want %q", foreignKey.SQL, wantForeignKey)
 	}
 }
 
@@ -284,6 +311,7 @@ func TestPublicDDLSideObjectCapabilitiesAndUnsupportedErrors(t *testing.T) {
 		dialect                  string
 		secondaryIndexes         bool
 		standalonePrimaryKeys    bool
+		standaloneForeignKeys    bool
 		namedUniqueConstraints   bool
 		checkConstraints         bool
 		expressionKeys           bool
@@ -293,25 +321,25 @@ func TestPublicDDLSideObjectCapabilitiesAndUnsupportedErrors(t *testing.T) {
 		unsupportedSideArtifacts []string
 	}{
 		{
-			dialect: "postgres", secondaryIndexes: true, standalonePrimaryKeys: true, namedUniqueConstraints: true, checkConstraints: true,
+			dialect: "postgres", secondaryIndexes: true, standalonePrimaryKeys: true, standaloneForeignKeys: true, namedUniqueConstraints: true, checkConstraints: true,
 			expressionKeys: true, includeColumns: true, filteredIndexes: true,
 		},
 		{
-			dialect: "mssql", secondaryIndexes: true, standalonePrimaryKeys: true, namedUniqueConstraints: true, checkConstraints: true,
+			dialect: "mssql", secondaryIndexes: true, standalonePrimaryKeys: true, standaloneForeignKeys: true, namedUniqueConstraints: true, checkConstraints: true,
 			includeColumns: true, filteredIndexes: true,
 		},
 		{
-			dialect: "mysql", secondaryIndexes: true, standalonePrimaryKeys: true, namedUniqueConstraints: true, checkConstraints: true,
+			dialect: "mysql", secondaryIndexes: true, standalonePrimaryKeys: true, standaloneForeignKeys: true, namedUniqueConstraints: true, checkConstraints: true,
 			expressionKeys: true, prefixLengths: true,
 		},
 		{
 			dialect: "sqlite", secondaryIndexes: true,
 			filteredIndexes:          true,
-			unsupportedSideArtifacts: []string{"standalone primary keys", "named unique constraints", "check constraints"},
+			unsupportedSideArtifacts: []string{"standalone primary keys", "standalone foreign keys", "named unique constraints", "check constraints"},
 		},
 		{
 			dialect:                  "clickhouse",
-			unsupportedSideArtifacts: []string{"secondary indexes", "standalone primary keys", "named unique constraints", "check constraints"},
+			unsupportedSideArtifacts: []string{"secondary indexes", "standalone primary keys", "standalone foreign keys", "named unique constraints", "check constraints"},
 		},
 	}
 
@@ -323,7 +351,7 @@ func TestPublicDDLSideObjectCapabilitiesAndUnsupportedErrors(t *testing.T) {
 				t.Fatalf("NewRenderer: %v", err)
 			}
 			got := renderer.Capabilities()
-			if got.SecondaryIndexes != tc.secondaryIndexes || got.StandalonePrimaryKeys != tc.standalonePrimaryKeys ||
+			if got.SecondaryIndexes != tc.secondaryIndexes || got.StandalonePrimaryKeys != tc.standalonePrimaryKeys || got.StandaloneForeignKeys != tc.standaloneForeignKeys ||
 				got.NamedUniqueConstraints != tc.namedUniqueConstraints || got.CheckConstraints != tc.checkConstraints ||
 				got.IndexExpressionKeys != tc.expressionKeys || got.IndexPrefixLengths != tc.prefixLengths ||
 				got.IndexIncludeColumns != tc.includeColumns || got.FilteredIndexes != tc.filteredIndexes {
@@ -337,6 +365,8 @@ func TestPublicDDLSideObjectCapabilitiesAndUnsupportedErrors(t *testing.T) {
 					_, err = renderer.CreateIndex(table, schema.Index{Name: "ix_items_name", Columns: []string{"name"}})
 				case "standalone primary keys":
 					_, err = renderer.CreatePrimaryKey(table, schema.PrimaryKey{Columns: []string{"id"}})
+				case "standalone foreign keys":
+					_, err = renderer.CreateForeignKey(table, schema.ForeignKey{Name: "fk_items_parent", Columns: []string{"id"}, RefTable: "parent", RefColumns: []string{"id"}})
 				case "named unique constraints":
 					_, err = renderer.CreateUniqueConstraint(table, schema.UniqueConstraint{Name: "uq_items_name", Columns: []string{"name"}})
 				case "check constraints":
@@ -445,6 +475,48 @@ func TestPublicDDLSideObjectFeatureValidation(t *testing.T) {
 	}
 }
 
+func TestPublicDDLForeignKeyValidationAndActionCapabilities(t *testing.T) {
+	table := schema.TableRef{Name: "items"}
+	foreignKey := schema.ForeignKey{Name: "fk_items_parent", Columns: []string{"parent_id"}, RefTable: "parents", RefColumns: []string{"id"}}
+
+	postgres, err := schema.NewRenderer(schema.Options{TargetDialect: "postgres"})
+	if err != nil {
+		t.Fatalf("NewRenderer postgres: %v", err)
+	}
+	foreignKey.OnDelete = schema.ReferentialAction("rename")
+	if _, err := postgres.CreateForeignKey(table, foreignKey); err == nil || !strings.Contains(err.Error(), "invalid ON DELETE action") {
+		t.Fatalf("CreateForeignKey invalid action error = %v", err)
+	}
+	foreignKey.OnDelete = ""
+	foreignKey.RefColumns = nil
+	if _, err := postgres.CreateForeignKey(table, foreignKey); err == nil || !strings.Contains(err.Error(), "1 columns but 0 referenced columns") {
+		t.Fatalf("CreateForeignKey mismatched columns error = %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		dialect string
+		action  schema.ReferentialAction
+		feature string
+	}{
+		{name: "mssql restrict", dialect: "mssql", action: schema.ReferentialActionRestrict, feature: "foreign-key RESTRICT actions"},
+		{name: "mysql set default", dialect: "mysql", action: schema.ReferentialActionSetDefault, feature: "foreign-key SET DEFAULT actions"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			renderer, err := schema.NewRenderer(schema.Options{TargetDialect: tc.dialect})
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			fk := schema.ForeignKey{Name: "fk_items_parent", Columns: []string{"parent_id"}, RefTable: "parents", RefColumns: []string{"id"}, OnDelete: tc.action}
+			_, err = renderer.CreateForeignKey(table, fk)
+			var unsupported *schema.UnsupportedFeatureError
+			if !errors.As(err, &unsupported) || unsupported.Dialect != tc.dialect || unsupported.Feature != tc.feature {
+				t.Fatalf("CreateForeignKey error = %#v, want UnsupportedFeatureError for %q", err, tc.feature)
+			}
+		})
+	}
+}
+
 func TestPublicDDLSideObjectAdapterParity(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -518,6 +590,25 @@ func TestPublicDDLSideObjectAdapterParity(t *testing.T) {
 			}
 			if gotPrimaryKey.SQL != wantPrimaryKey {
 				t.Fatalf("primary-key adapter SQL = %q, want core SQL %q", gotPrimaryKey.SQL, wantPrimaryKey)
+			}
+
+			foreignKey := schema.ForeignKey{
+				Name: "FK_Orders_Accounts", Columns: []string{"ID"}, RefSchema: "identity", RefTable: "Accounts", RefColumns: []string{"ID"},
+				OnDelete: schema.ReferentialActionCascade, OnUpdate: schema.ReferentialActionSetNull,
+			}
+			gotForeignKey, err := public.CreateForeignKey(tc.table, foreignKey)
+			if err != nil {
+				t.Fatalf("CreateForeignKey: %v", err)
+			}
+			wantForeignKey, err := core.CreateForeignKeyDDL(coreTable, &driver.ForeignKey{
+				Name: foreignKey.Name, Columns: append([]string(nil), foreignKey.Columns...), RefSchema: foreignKey.RefSchema, RefTable: foreignKey.RefTable,
+				RefColumns: append([]string(nil), foreignKey.RefColumns...), OnDelete: string(foreignKey.OnDelete), OnUpdate: string(foreignKey.OnUpdate),
+			})
+			if err != nil {
+				t.Fatalf("core CreateForeignKeyDDL: %v", err)
+			}
+			if gotForeignKey.SQL != wantForeignKey {
+				t.Fatalf("foreign-key adapter SQL = %q, want core SQL %q", gotForeignKey.SQL, wantForeignKey)
 			}
 
 			gotUnique, err := public.CreateUniqueConstraint(tc.table, schema.UniqueConstraint{Name: "UQ_Orders_Email", Columns: []string{"Email"}})

--- a/schema/testdata/ddl/clickhouse_side_objects.error.golden
+++ b/schema/testdata/ddl/clickhouse_side_objects.error.golden
@@ -9,3 +9,6 @@ DDL dialect "clickhouse" does not support named unique constraints
 
 create_check_constraint
 DDL dialect "clickhouse" does not support check constraints
+
+create_foreign_key
+DDL dialect "clickhouse" does not support standalone foreign keys

--- a/schema/testdata/ddl/mssql_side_objects.sql.golden
+++ b/schema/testdata/ddl/mssql_side_objects.sql.golden
@@ -9,3 +9,6 @@ ALTER TABLE [dbo].[Orders] ADD CONSTRAINT [UQ_Orders_Email] UNIQUE ([Email])
 
 create_check_constraint
 ALTER TABLE [dbo].[Orders] ADD CONSTRAINT [CK_Orders_Total] CHECK ([Total] >= 0)
+
+create_foreign_key
+ALTER TABLE [dbo].[Orders] ADD CONSTRAINT [FK_Orders_Accounts] FOREIGN KEY ([ID]) REFERENCES [identity].[Accounts] ([ID]) ON DELETE CASCADE ON UPDATE SET NULL

--- a/schema/testdata/ddl/mysql_side_objects.sql.golden
+++ b/schema/testdata/ddl/mysql_side_objects.sql.golden
@@ -9,3 +9,6 @@ ALTER TABLE `crm`.`Orders` ADD CONSTRAINT `UQ_Orders_Email` UNIQUE (`Email`)
 
 create_check_constraint
 ALTER TABLE `crm`.`Orders` ADD CONSTRAINT `CK_Orders_Total` CHECK (`Total` >= 0)
+
+create_foreign_key
+ALTER TABLE `crm`.`Orders` ADD CONSTRAINT `FK_Orders_Accounts` FOREIGN KEY (`ID`) REFERENCES `identity`.`Accounts` (`ID`) ON DELETE CASCADE ON UPDATE SET NULL

--- a/schema/testdata/ddl/postgres_side_objects.sql.golden
+++ b/schema/testdata/ddl/postgres_side_objects.sql.golden
@@ -9,3 +9,6 @@ ALTER TABLE "public"."orders" ADD CONSTRAINT "uq_orders_email" UNIQUE ("email")
 
 create_check_constraint
 ALTER TABLE "public"."orders" ADD CONSTRAINT "ck_orders_total" CHECK ("total" >= 0)
+
+create_foreign_key
+ALTER TABLE "public"."orders" ADD CONSTRAINT "fk_orders_accounts" FOREIGN KEY ("id") REFERENCES "identity"."accounts" ("id") ON DELETE CASCADE ON UPDATE SET NULL


### PR DESCRIPTION
## Summary

- add public `ForeignKey` and typed `ReferentialAction` values, plus `Renderer.CreateForeignKey`
- expose standalone-FK capabilities and typed unsupported errors across PostgreSQL, SQL Server, MySQL, SQLite, and ClickHouse
- adapt the existing internal renderer with deterministic identifier/schema qualification, composite-key validation, and explicit referential-action handling
- add public external-package tests, dialect goldens, adapter parity coverage, and referenced-schema schemadiff goldens

`RefSchema` explicitly qualifies the referenced table. Empty action values omit the clause; explicit `NO ACTION` is preserved. SQL Server rejects `RESTRICT` and MySQL rejects `SET DEFAULT` as typed unsupported features rather than emitting invalid SQL.

## Validation

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `make lint`
- `go vet ./...`
- `go build -trimpath -o /private/tmp/smt-fk-check ./cmd/smt`
- `go mod tidy` (no module diff)
- `git diff --check`