### PR TITLE
feat(schema): expose evolution DDL API

### DIFF
--- a/internal/ddl/renderer.go
+++ b/internal/ddl/renderer.go
@@ -71,7 +71,10 @@ import (
 // constraint rendering, including fail-closed cross-dialect index predicates.
 // "19": foreign-key references honor an explicit referenced schema and emit
 // explicit NO ACTION clauses when callers request them.
-const RendererVersion = "19"
+// "20": public schema-evolution rendering adds deterministic drop, ALTER,
+// default, and truncate operations, including explicit session-affinity
+// batches for destructive MySQL and SQLite paths.
+const RendererVersion = "20"
 
 // ClickHouseNullableCompositeError reports a nullable composite that ClickHouse
 // cannot represent as Nullable(T). Rewriting it to Array(Nullable(T)) would
@@ -688,6 +691,8 @@ func (r Renderer) DropIndexDDL(tableName, indexName string) string {
 		return fmt.Sprintf("DROP INDEX %s ON %s", r.quote(r.normalize(indexName)), r.qualify(r.normalize(tableName)))
 	case "mysql":
 		return fmt.Sprintf("DROP INDEX %s ON %s", r.quote(r.normalize(indexName)), r.qualify(r.normalize(tableName)))
+	case "sqlite":
+		return fmt.Sprintf("DROP INDEX IF EXISTS %s", r.quote(r.normalize(indexName)))
 	default:
 		return ""
 	}
@@ -707,9 +712,74 @@ func (r Renderer) DropCheckDDL(tableName, chkName string) string {
 }
 
 func (r Renderer) DropTableDDL(tableName string) string {
-	// IF EXISTS is supported by all three targets (MSSQL since 2016, and SMT
-	// requires compatibility level 140+).
-	return fmt.Sprintf("DROP TABLE IF EXISTS %s", r.qualify(r.normalize(tableName)))
+	sql, _ := r.DropTableWithOptionsDDL(tableName, false)
+	return sql
+}
+
+// DropSchemaDDL renders a dialect-safe, idempotent schema/database drop. A
+// cascade is intentionally explicit: only PostgreSQL accepts it, and callers
+// must opt in before a schema drop may remove dependent objects.
+func (r Renderer) DropSchemaDDL(cascade bool) (string, error) {
+	schema := strings.TrimSpace(r.schema)
+	if schema == "" {
+		return "", nil
+	}
+	if cascade && r.target != "postgres" {
+		return "", fmt.Errorf("%s does not support schema-drop CASCADE", r.target)
+	}
+	switch r.target {
+	case "postgres":
+		sql := fmt.Sprintf("DROP SCHEMA IF EXISTS %s", r.quote(schema))
+		if cascade {
+			sql += " CASCADE"
+		}
+		return sql, nil
+	case "mssql":
+		escapedName := strings.ReplaceAll(schema, "'", "''")
+		escapedDDL := strings.ReplaceAll(fmt.Sprintf("DROP SCHEMA %s", r.quote(schema)), "'", "''")
+		return fmt.Sprintf("IF SCHEMA_ID(N'%s') IS NOT NULL EXEC(N'%s')", escapedName, escapedDDL), nil
+	case "mysql", "clickhouse":
+		return fmt.Sprintf("DROP DATABASE IF EXISTS %s", r.quote(schema)), nil
+	default:
+		return "", fmt.Errorf("%s does not support dropping named schemas", r.target)
+	}
+}
+
+// DropTableWithOptionsDDL renders a dialect-safe, idempotent table drop.
+// PostgreSQL CASCADE is explicit so callers can preserve dependency policy in
+// their own scheduling layer.
+func (r Renderer) DropTableWithOptionsDDL(tableName string, cascade bool) (string, error) {
+	if cascade && r.target != "postgres" {
+		return "", fmt.Errorf("%s does not support table-drop CASCADE", r.target)
+	}
+	sql := fmt.Sprintf("DROP TABLE IF EXISTS %s", r.qualify(r.normalize(tableName)))
+	if cascade {
+		sql += " CASCADE"
+	}
+	return sql, nil
+}
+
+// TruncateTableDDL renders the data-clearing command for one table. SQLite
+// deliberately uses DELETE because it has no TRUNCATE statement.
+func (r Renderer) TruncateTableDDL(tableName string, cascade bool) (string, error) {
+	if cascade && r.target != "postgres" {
+		return "", fmt.Errorf("%s does not support truncate CASCADE", r.target)
+	}
+	table := r.qualify(r.normalize(tableName))
+	switch r.target {
+	case "postgres":
+		sql := "TRUNCATE TABLE " + table
+		if cascade {
+			sql += " CASCADE"
+		}
+		return sql, nil
+	case "mssql", "mysql", "clickhouse":
+		return "TRUNCATE TABLE " + table, nil
+	case "sqlite":
+		return "DELETE FROM " + table, nil
+	default:
+		return "", fmt.Errorf("unsupported deterministic DDL target %q", r.target)
+	}
 }
 
 func (r Renderer) AddColumnDDL(tableName string, col driver.Column, tableColumns []driver.Column) (string, error) {
@@ -725,7 +795,38 @@ func (r Renderer) AddColumnDDL(tableName string, col driver.Column, tableColumns
 }
 
 func (r Renderer) DropColumnDDL(tableName, colName string) string {
+	if r.target == "clickhouse" {
+		return fmt.Sprintf("ALTER TABLE %s DROP COLUMN IF EXISTS %s", r.qualify(r.normalize(tableName)), r.quote(r.normalize(colName)))
+	}
 	return fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", r.qualify(r.normalize(tableName)), r.quote(r.normalize(colName)))
+}
+
+// DropConstraintDDL renders a named relational-constraint drop. MySQL uses
+// different syntax for each constraint kind, while PostgreSQL and SQL Server
+// share ALTER TABLE ... DROP CONSTRAINT. Supported kinds are primary_key,
+// unique, foreign_key, and check.
+func (r Renderer) DropConstraintDDL(tableName, name, kind string) (string, error) {
+	table := r.qualify(r.normalize(tableName))
+	constraint := r.quote(r.normalize(name))
+	switch r.target {
+	case "postgres", "mssql":
+		return fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", table, constraint), nil
+	case "mysql":
+		switch kind {
+		case "primary_key":
+			return fmt.Sprintf("ALTER TABLE %s DROP PRIMARY KEY", table), nil
+		case "unique":
+			return fmt.Sprintf("ALTER TABLE %s DROP INDEX %s", table, constraint), nil
+		case "foreign_key":
+			return fmt.Sprintf("ALTER TABLE %s DROP FOREIGN KEY %s", table, constraint), nil
+		case "check":
+			return fmt.Sprintf("ALTER TABLE %s DROP CHECK %s", table, constraint), nil
+		default:
+			return "", fmt.Errorf("unsupported MySQL constraint kind %q", kind)
+		}
+	default:
+		return "", fmt.Errorf("%s does not support dropping named constraints", r.target)
+	}
 }
 
 func (r Renderer) AlterColumnTypeDDL(tableName string, col driver.Column) (string, error) {

--- a/schema/ddl.go
+++ b/schema/ddl.go
@@ -35,6 +35,20 @@ type Capabilities struct {
 	CreateSchema           bool
 	CreateTable            bool
 	CreateColumn           bool
+	DropSchemas            bool
+	DropSchemaCascade      bool
+	DropTables             bool
+	DropTableCascade       bool
+	DropIndexes            bool
+	DropConstraints        bool
+	AddColumns             bool
+	DropColumns            bool
+	AlterColumnTypes       bool
+	AlterColumnNullability bool
+	SetColumnDefaults      bool
+	DropColumnDefaults     bool
+	TruncateTables         bool
+	TruncateTableCascade   bool
 	PrimaryKeys            bool
 	IdentityColumns        bool
 	Defaults               bool
@@ -92,16 +106,20 @@ const (
 	StatementCreateTable StatementKind = "create_table"
 )
 
-// Statement is one deterministic executable DDL artifact. SQL is exactly one
-// statement; callers retain execution, retry, and scheduling policy.
+// Statement is one deterministic executable SQL unit. It is normally one DDL
+// statement; a dialect may use a single multi-statement SQL batch where that
+// is required for atomic scope (for example SQL Server default-constraint
+// discovery). Callers retain execution, retry, and scheduling policy.
 //
 // Warnings apply only to this artifact. They are advisory and never change
 // SQL, which keeps plans deterministic and safe to persist or inspect before
-// execution.
+// execution. BestEffort means an executor should record, but not fail the
+// containing operation for, an error from this cleanup statement.
 type Statement struct {
-	Kind     StatementKind
-	SQL      string
-	Warnings []Warning
+	Kind       StatementKind
+	SQL        string
+	Warnings   []Warning
+	BestEffort bool
 }
 
 // Plan is an ordered, deterministic set of CREATE statements. It owns no
@@ -846,6 +864,10 @@ type builtinDialect struct {
 func builtinDialects() []Dialect {
 	full := Capabilities{
 		CreateSchema: true, CreateTable: true, CreateColumn: true,
+		DropSchemas: true, DropSchemaCascade: true,
+		DropTables: true, DropTableCascade: true, DropIndexes: true, DropConstraints: true,
+		AddColumns: true, DropColumns: true, AlterColumnTypes: true, AlterColumnNullability: true,
+		SetColumnDefaults: true, DropColumnDefaults: true, TruncateTables: true, TruncateTableCascade: true,
 		PrimaryKeys: true, IdentityColumns: true, Defaults: true, ComputedColumns: true,
 		SecondaryIndexes: true, StandalonePrimaryKeys: true, StandaloneForeignKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
 		IndexExpressionKeys: true, IndexIncludeColumns: true, FilteredIndexes: true,
@@ -856,6 +878,9 @@ func builtinDialects() []Dialect {
 			name: "mssql", aliases: []string{"sqlserver", "sql-server", "sql_server"},
 			capabilities: Capabilities{
 				CreateSchema: true, CreateTable: true, CreateColumn: true,
+				DropSchemas: true, DropTables: true, DropIndexes: true, DropConstraints: true,
+				AddColumns: true, DropColumns: true, AlterColumnTypes: true, AlterColumnNullability: true,
+				SetColumnDefaults: true, DropColumnDefaults: true, TruncateTables: true,
 				PrimaryKeys: true, IdentityColumns: true, Defaults: true, ComputedColumns: true,
 				SecondaryIndexes: true, StandalonePrimaryKeys: true, StandaloneForeignKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
 				IndexIncludeColumns: true, FilteredIndexes: true,
@@ -865,6 +890,9 @@ func builtinDialects() []Dialect {
 			name: "mysql", aliases: []string{"mariadb", "maria"},
 			capabilities: Capabilities{
 				CreateSchema: true, CreateTable: true, CreateColumn: true,
+				DropSchemas: true, DropTables: true, DropIndexes: true, DropConstraints: true,
+				AddColumns: true, DropColumns: true, AlterColumnTypes: true, AlterColumnNullability: true,
+				SetColumnDefaults: true, DropColumnDefaults: true, TruncateTables: true,
 				PrimaryKeys: true, IdentityColumns: true, Defaults: true, ComputedColumns: true,
 				SecondaryIndexes: true, StandalonePrimaryKeys: true, StandaloneForeignKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
 				IndexExpressionKeys: true, IndexPrefixLengths: true,
@@ -874,12 +902,17 @@ func builtinDialects() []Dialect {
 			name: "sqlite", aliases: []string{"sqlite3"},
 			capabilities: Capabilities{
 				CreateTable: true, CreateColumn: true, PrimaryKeys: true, IdentityColumns: true, Defaults: true,
+				DropTables: true, DropIndexes: true, AddColumns: true, DropColumns: true, TruncateTables: true,
 				SecondaryIndexes: true, FilteredIndexes: true,
 			},
 		},
 		builtinDialect{
 			name: "clickhouse", aliases: []string{"click-house"},
-			capabilities: Capabilities{CreateSchema: true, CreateTable: true, CreateColumn: true, PrimaryKeys: true},
+			capabilities: Capabilities{
+				CreateSchema: true, CreateTable: true, CreateColumn: true,
+				DropSchemas: true, DropTables: true, AddColumns: true, DropColumns: true, TruncateTables: true,
+				PrimaryKeys: true,
+			},
 		},
 	}
 }

--- a/schema/ddl.go
+++ b/schema/ddl.go
@@ -35,20 +35,6 @@ type Capabilities struct {
 	CreateSchema           bool
 	CreateTable            bool
 	CreateColumn           bool
-	DropSchemas            bool
-	DropSchemaCascade      bool
-	DropTables             bool
-	DropTableCascade       bool
-	DropIndexes            bool
-	DropConstraints        bool
-	AddColumns             bool
-	DropColumns            bool
-	AlterColumnTypes       bool
-	AlterColumnNullability bool
-	SetColumnDefaults      bool
-	DropColumnDefaults     bool
-	TruncateTables         bool
-	TruncateTableCascade   bool
 	PrimaryKeys            bool
 	IdentityColumns        bool
 	Defaults               bool
@@ -106,20 +92,16 @@ const (
 	StatementCreateTable StatementKind = "create_table"
 )
 
-// Statement is one deterministic executable SQL unit. It is normally one DDL
-// statement; a dialect may use a single multi-statement SQL batch where that
-// is required for atomic scope (for example SQL Server default-constraint
-// discovery). Callers retain execution, retry, and scheduling policy.
+// Statement is one deterministic executable DDL artifact. SQL is exactly one
+// statement; callers retain execution, retry, and scheduling policy.
 //
 // Warnings apply only to this artifact. They are advisory and never change
 // SQL, which keeps plans deterministic and safe to persist or inspect before
-// execution. BestEffort means an executor should record, but not fail the
-// containing operation for, an error from this cleanup statement.
+// execution.
 type Statement struct {
-	Kind       StatementKind
-	SQL        string
-	Warnings   []Warning
-	BestEffort bool
+	Kind     StatementKind
+	SQL      string
+	Warnings []Warning
 }
 
 // Plan is an ordered, deterministic set of CREATE statements. It owns no
@@ -856,62 +838,107 @@ func hasPositive(values []int) bool {
 }
 
 type builtinDialect struct {
-	name         string
-	aliases      []string
-	capabilities Capabilities
+	name                  string
+	aliases               []string
+	capabilities          Capabilities
+	evolutionCapabilities EvolutionCapabilities
 }
 
 func builtinDialects() []Dialect {
 	full := Capabilities{
 		CreateSchema: true, CreateTable: true, CreateColumn: true,
-		DropSchemas: true, DropSchemaCascade: true,
-		DropTables: true, DropTableCascade: true, DropIndexes: true, DropConstraints: true,
-		AddColumns: true, DropColumns: true, AlterColumnTypes: true, AlterColumnNullability: true,
-		SetColumnDefaults: true, DropColumnDefaults: true, TruncateTables: true, TruncateTableCascade: true,
 		PrimaryKeys: true, IdentityColumns: true, Defaults: true, ComputedColumns: true,
 		SecondaryIndexes: true, StandalonePrimaryKeys: true, StandaloneForeignKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
 		IndexExpressionKeys: true, IndexIncludeColumns: true, FilteredIndexes: true,
 	}
+	fullEvolution := EvolutionCapabilities{
+		EvolutionCapabilityDropSchema,
+		EvolutionCapabilityDropSchemaCascade,
+		EvolutionCapabilityDropTable,
+		EvolutionCapabilityDropTableCascade,
+		EvolutionCapabilityDropIndex,
+		EvolutionCapabilityDropConstraint,
+		EvolutionCapabilityAddColumn,
+		EvolutionCapabilityDropColumn,
+		EvolutionCapabilityAlterColumnType,
+		EvolutionCapabilityAlterColumnNullability,
+		EvolutionCapabilitySetColumnDefault,
+		EvolutionCapabilityDropColumnDefault,
+		EvolutionCapabilityTruncateTable,
+		EvolutionCapabilityTruncateTableCascade,
+	}
 	return []Dialect{
-		builtinDialect{name: "postgres", aliases: []string{"postgresql", "pg"}, capabilities: full},
+		builtinDialect{name: "postgres", aliases: []string{"postgresql", "pg"}, capabilities: full, evolutionCapabilities: fullEvolution},
 		builtinDialect{
 			name: "mssql", aliases: []string{"sqlserver", "sql-server", "sql_server"},
 			capabilities: Capabilities{
 				CreateSchema: true, CreateTable: true, CreateColumn: true,
-				DropSchemas: true, DropTables: true, DropIndexes: true, DropConstraints: true,
-				AddColumns: true, DropColumns: true, AlterColumnTypes: true, AlterColumnNullability: true,
-				SetColumnDefaults: true, DropColumnDefaults: true, TruncateTables: true,
 				PrimaryKeys: true, IdentityColumns: true, Defaults: true, ComputedColumns: true,
 				SecondaryIndexes: true, StandalonePrimaryKeys: true, StandaloneForeignKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
 				IndexIncludeColumns: true, FilteredIndexes: true,
+			},
+			evolutionCapabilities: EvolutionCapabilities{
+				EvolutionCapabilityDropSchema,
+				EvolutionCapabilityDropTable,
+				EvolutionCapabilityDropIndex,
+				EvolutionCapabilityDropConstraint,
+				EvolutionCapabilityAddColumn,
+				EvolutionCapabilityDropColumn,
+				EvolutionCapabilityAlterColumnType,
+				EvolutionCapabilityAlterColumnNullability,
+				EvolutionCapabilitySetColumnDefault,
+				EvolutionCapabilityDropColumnDefault,
+				EvolutionCapabilityTruncateTable,
 			},
 		},
 		builtinDialect{
 			name: "mysql", aliases: []string{"mariadb", "maria"},
 			capabilities: Capabilities{
 				CreateSchema: true, CreateTable: true, CreateColumn: true,
-				DropSchemas: true, DropTables: true, DropIndexes: true, DropConstraints: true,
-				AddColumns: true, DropColumns: true, AlterColumnTypes: true, AlterColumnNullability: true,
-				SetColumnDefaults: true, DropColumnDefaults: true, TruncateTables: true,
 				PrimaryKeys: true, IdentityColumns: true, Defaults: true, ComputedColumns: true,
 				SecondaryIndexes: true, StandalonePrimaryKeys: true, StandaloneForeignKeys: true, NamedUniqueConstraints: true, CheckConstraints: true,
 				IndexExpressionKeys: true, IndexPrefixLengths: true,
+			},
+			evolutionCapabilities: EvolutionCapabilities{
+				EvolutionCapabilityDropSchema,
+				EvolutionCapabilityDropTable,
+				EvolutionCapabilityDropIndex,
+				EvolutionCapabilityDropConstraint,
+				EvolutionCapabilityAddColumn,
+				EvolutionCapabilityDropColumn,
+				EvolutionCapabilityAlterColumnType,
+				EvolutionCapabilityAlterColumnNullability,
+				EvolutionCapabilitySetColumnDefault,
+				EvolutionCapabilityDropColumnDefault,
+				EvolutionCapabilityTruncateTable,
 			},
 		},
 		builtinDialect{
 			name: "sqlite", aliases: []string{"sqlite3"},
 			capabilities: Capabilities{
 				CreateTable: true, CreateColumn: true, PrimaryKeys: true, IdentityColumns: true, Defaults: true,
-				DropTables: true, DropIndexes: true, AddColumns: true, DropColumns: true, TruncateTables: true,
 				SecondaryIndexes: true, FilteredIndexes: true,
+			},
+			evolutionCapabilities: EvolutionCapabilities{
+				EvolutionCapabilityDropTable,
+				EvolutionCapabilityDropIndex,
+				EvolutionCapabilityAddColumn,
+				EvolutionCapabilityDropColumn,
+				EvolutionCapabilityTruncateTable,
 			},
 		},
 		builtinDialect{
 			name: "clickhouse", aliases: []string{"click-house"},
 			capabilities: Capabilities{
 				CreateSchema: true, CreateTable: true, CreateColumn: true,
-				DropSchemas: true, DropTables: true, AddColumns: true, DropColumns: true, TruncateTables: true,
 				PrimaryKeys: true,
+			},
+			evolutionCapabilities: EvolutionCapabilities{
+				EvolutionCapabilityDropSchema,
+				EvolutionCapabilityDropTable,
+				EvolutionCapabilityAddColumn,
+				EvolutionCapabilityDropColumn,
+				EvolutionCapabilityTruncateTable,
 			},
 		},
 	}
@@ -920,6 +947,9 @@ func builtinDialects() []Dialect {
 func (d builtinDialect) Name() string               { return d.name }
 func (d builtinDialect) Aliases() []string          { return append([]string(nil), d.aliases...) }
 func (d builtinDialect) Capabilities() Capabilities { return d.capabilities }
+func (d builtinDialect) EvolutionCapabilities() EvolutionCapabilities {
+	return append(EvolutionCapabilities(nil), d.evolutionCapabilities...)
+}
 
 func (d builtinDialect) RenderSchema(request Request) (Result, error) {
 	renderer, err := d.renderer(request)

--- a/schema/ddl_compatibility_test.go
+++ b/schema/ddl_compatibility_test.go
@@ -1,0 +1,22 @@
+package schema_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestLegacyUnkeyedStructLiteralsCompile pins the public struct layouts that
+// existed in v1.3.0. The fixture is an external package so it catches a
+// source-incompatible field addition that keyed literals would miss.
+func TestLegacyUnkeyedStructLiteralsCompile(t *testing.T) {
+	repositoryRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("repository root: %v", err)
+	}
+	command := exec.Command("go", "test", "./schema/testdata/legacy_struct_literals")
+	command.Dir = repositoryRoot
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("legacy public struct-literal fixture failed: %v\n%s", err, output)
+	}
+}

--- a/schema/ddl_evolution_public_test.go
+++ b/schema/ddl_evolution_public_test.go
@@ -70,7 +70,7 @@ func TestPublicDDLEvolutionGoldens(t *testing.T) {
 func renderEvolutionArtifacts(t *testing.T, renderer schema.Renderer, column, alter schema.Column) string {
 	t.Helper()
 	table := schema.TableRef{Name: "Orders", Columns: []schema.Column{{Name: "id", DataType: column.DataType}, column}}
-	caps := renderer.Capabilities()
+	caps := renderer.EvolutionCapabilities()
 	var artifacts []string
 	appendBatch := func(name string, render func() (schema.Batch, error)) {
 		t.Helper()
@@ -81,44 +81,44 @@ func renderEvolutionArtifacts(t *testing.T, renderer schema.Renderer, column, al
 		artifacts = append(artifacts, name+"\n"+formatBatch(batch))
 	}
 
-	if caps.DropSchemas {
+	if caps.Supports(schema.EvolutionCapabilityDropSchema) {
 		appendBatch("drop_schema", func() (schema.Batch, error) {
-			return renderer.DropSchema(schema.DropOptions{Cascade: caps.DropSchemaCascade})
+			return renderer.DropSchema(schema.DropOptions{Cascade: caps.Supports(schema.EvolutionCapabilityDropSchemaCascade)})
 		})
 	}
 	appendBatch("drop_table", func() (schema.Batch, error) {
-		return renderer.DropTable(table, schema.DropOptions{Cascade: caps.DropTableCascade})
+		return renderer.DropTable(table, schema.DropOptions{Cascade: caps.Supports(schema.EvolutionCapabilityDropTableCascade)})
 	})
-	if caps.DropIndexes {
+	if caps.Supports(schema.EvolutionCapabilityDropIndex) {
 		appendBatch("drop_index", func() (schema.Batch, error) {
 			return renderer.DropIndex(table, "IX Orders Subtotal")
 		})
 	}
-	if caps.DropConstraints {
+	if caps.Supports(schema.EvolutionCapabilityDropConstraint) {
 		appendBatch("drop_foreign_key", func() (schema.Batch, error) {
 			return renderer.DropConstraint(table, schema.ConstraintRef{Name: "FK Orders Account", Kind: schema.ConstraintForeignKey})
 		})
 	}
 	appendBatch("add_column", func() (schema.Batch, error) { return renderer.AddColumn(table, column) })
 	appendBatch("drop_column", func() (schema.Batch, error) { return renderer.DropColumn(table, column.Name) })
-	if caps.AlterColumnTypes {
+	if caps.Supports(schema.EvolutionCapabilityAlterColumnType) {
 		appendBatch("alter_column_type", func() (schema.Batch, error) { return renderer.AlterColumnType(table, alter) })
 	}
-	if caps.AlterColumnNullability {
+	if caps.Supports(schema.EvolutionCapabilityAlterColumnNullability) {
 		appendBatch("alter_column_nullability", func() (schema.Batch, error) {
 			return renderer.AlterColumnNullability(table, alter)
 		})
 	}
-	if caps.SetColumnDefaults {
+	if caps.Supports(schema.EvolutionCapabilitySetColumnDefault) {
 		appendBatch("set_column_default", func() (schema.Batch, error) { return renderer.SetColumnDefault(table, column) })
 	}
-	if caps.DropColumnDefaults {
+	if caps.Supports(schema.EvolutionCapabilityDropColumnDefault) {
 		appendBatch("drop_column_default", func() (schema.Batch, error) {
 			return renderer.DropColumnDefault(table, column.Name)
 		})
 	}
 	appendBatch("truncate_table", func() (schema.Batch, error) {
-		return renderer.TruncateTable(table, schema.TruncateOptions{Cascade: caps.TruncateTableCascade})
+		return renderer.TruncateTable(table, schema.TruncateOptions{Cascade: caps.Supports(schema.EvolutionCapabilityTruncateTableCascade)})
 	})
 	return strings.Join(artifacts, "\n\n")
 }
@@ -128,8 +128,8 @@ func formatBatch(batch schema.Batch) string {
 	if batch.RequiresSingleConnection {
 		lines = append(lines, "requires_single_connection")
 	}
-	for _, statement := range batch.Statements {
-		if statement.BestEffort {
+	for i, statement := range batch.Statements {
+		if batch.IsBestEffort(i) {
 			lines = append(lines, "best_effort")
 		}
 		lines = append(lines, string(statement.Kind), statement.SQL)
@@ -161,15 +161,49 @@ func TestPublicDDLEvolutionCapabilitiesAndUnsupportedErrors(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewRenderer: %v", err)
 			}
-			got := renderer.Capabilities()
-			if got.DropSchemas != tc.want.dropSchemas || got.DropSchemaCascade != tc.want.dropSchemaCascade ||
-				got.DropTables != tc.want.dropTables || got.DropTableCascade != tc.want.dropTableCascade ||
-				got.DropIndexes != tc.want.dropIndexes || got.DropConstraints != tc.want.dropConstraints ||
-				got.AddColumns != tc.want.addColumns || got.DropColumns != tc.want.dropColumns ||
-				got.AlterColumnTypes != tc.want.alterTypes || got.AlterColumnNullability != tc.want.alterNullability ||
-				got.SetColumnDefaults != tc.want.setDefaults || got.DropColumnDefaults != tc.want.dropDefaults ||
-				got.TruncateTables != tc.want.truncate || got.TruncateTableCascade != tc.want.truncateCascade {
+			got := renderer.EvolutionCapabilities()
+			if got.Supports(schema.EvolutionCapabilityDropSchema) != tc.want.dropSchemas ||
+				got.Supports(schema.EvolutionCapabilityDropSchemaCascade) != tc.want.dropSchemaCascade ||
+				got.Supports(schema.EvolutionCapabilityDropTable) != tc.want.dropTables ||
+				got.Supports(schema.EvolutionCapabilityDropTableCascade) != tc.want.dropTableCascade ||
+				got.Supports(schema.EvolutionCapabilityDropIndex) != tc.want.dropIndexes ||
+				got.Supports(schema.EvolutionCapabilityDropConstraint) != tc.want.dropConstraints ||
+				got.Supports(schema.EvolutionCapabilityAddColumn) != tc.want.addColumns ||
+				got.Supports(schema.EvolutionCapabilityDropColumn) != tc.want.dropColumns ||
+				got.Supports(schema.EvolutionCapabilityAlterColumnType) != tc.want.alterTypes ||
+				got.Supports(schema.EvolutionCapabilityAlterColumnNullability) != tc.want.alterNullability ||
+				got.Supports(schema.EvolutionCapabilitySetColumnDefault) != tc.want.setDefaults ||
+				got.Supports(schema.EvolutionCapabilityDropColumnDefault) != tc.want.dropDefaults ||
+				got.Supports(schema.EvolutionCapabilityTruncateTable) != tc.want.truncate ||
+				got.Supports(schema.EvolutionCapabilityTruncateTableCascade) != tc.want.truncateCascade {
 				t.Fatalf("evolution capabilities = %+v, want %+v", got, tc.want)
+			}
+			for _, capability := range []schema.EvolutionCapability{
+				schema.EvolutionCapabilityDropSchema,
+				schema.EvolutionCapabilityDropSchemaCascade,
+				schema.EvolutionCapabilityDropTable,
+				schema.EvolutionCapabilityDropTableCascade,
+				schema.EvolutionCapabilityDropIndex,
+				schema.EvolutionCapabilityDropConstraint,
+				schema.EvolutionCapabilityAddColumn,
+				schema.EvolutionCapabilityDropColumn,
+				schema.EvolutionCapabilityAlterColumnType,
+				schema.EvolutionCapabilityAlterColumnNullability,
+				schema.EvolutionCapabilitySetColumnDefault,
+				schema.EvolutionCapabilityDropColumnDefault,
+				schema.EvolutionCapabilityTruncateTable,
+				schema.EvolutionCapabilityTruncateTableCascade,
+			} {
+				if renderer.SupportsEvolution(capability) != got.Supports(capability) {
+					t.Fatalf("SupportsEvolution(%q) differs from EvolutionCapabilities", capability)
+				}
+			}
+			if len(got) > 0 {
+				first := got[0]
+				got[0] = ""
+				if !renderer.SupportsEvolution(first) {
+					t.Fatalf("EvolutionCapabilities returned an aliased slice")
+				}
 			}
 		})
 	}
@@ -366,7 +400,7 @@ func TestPublicDDLEvolutionConstraintKindsAndCleanupContracts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TruncateTable(sqlite): %v", err)
 	}
-	if len(batch.Statements) != 2 || !batch.Statements[1].BestEffort || batch.Statements[1].Kind != schema.StatementBestEffortCleanup || batch.Statements[1].SQL != "DELETE FROM sqlite_sequence WHERE name = 'O''Reilly'" {
+	if len(batch.Statements) != 2 || !batch.IsBestEffort(1) || batch.IsBestEffort(0) || batch.IsBestEffort(2) || batch.Statements[1].Kind != schema.StatementBestEffortCleanup || batch.Statements[1].SQL != "DELETE FROM sqlite_sequence WHERE name = 'O''Reilly'" {
 		t.Fatalf("sqlite truncate cleanup = %+v, want quoted best-effort sqlite_sequence cleanup", batch)
 	}
 }
@@ -485,8 +519,8 @@ func TestPublicDDLEvolutionAdapterParity(t *testing.T) {
 				t.Fatalf("add SQL = %q, want %q", gotAdd.Statements[0].SQL, wantAdd)
 			}
 
-			caps := public.Capabilities()
-			if caps.DropSchemas {
+			caps := public.EvolutionCapabilities()
+			if caps.Supports(schema.EvolutionCapabilityDropSchema) {
 				gotSchema, err := public.DropSchema(schema.DropOptions{})
 				if err != nil {
 					t.Fatalf("DropSchema: %v", err)
@@ -499,7 +533,7 @@ func TestPublicDDLEvolutionAdapterParity(t *testing.T) {
 					t.Fatalf("drop schema SQL = %q, want %q", gotSchema.Statements[0].SQL, wantSchema)
 				}
 			}
-			if caps.DropIndexes {
+			if caps.Supports(schema.EvolutionCapabilityDropIndex) {
 				gotIndex, err := public.DropIndex(table, "ix_orders_extra")
 				if err != nil {
 					t.Fatalf("DropIndex: %v", err)
@@ -508,7 +542,7 @@ func TestPublicDDLEvolutionAdapterParity(t *testing.T) {
 					t.Fatalf("drop index SQL = %q, want %q", gotIndex.Statements[0].SQL, want)
 				}
 			}
-			if caps.DropConstraints {
+			if caps.Supports(schema.EvolutionCapabilityDropConstraint) {
 				gotConstraint, err := public.DropConstraint(table, schema.ConstraintRef{Name: "fk_orders_parent", Kind: schema.ConstraintForeignKey})
 				if err != nil {
 					t.Fatalf("DropConstraint: %v", err)
@@ -521,7 +555,7 @@ func TestPublicDDLEvolutionAdapterParity(t *testing.T) {
 					t.Fatalf("drop constraint SQL = %q, want %q", gotConstraint.Statements[0].SQL, wantConstraint)
 				}
 			}
-			if caps.DropColumns {
+			if caps.Supports(schema.EvolutionCapabilityDropColumn) {
 				gotColumn, err := public.DropColumn(table, column.Name)
 				if err != nil {
 					t.Fatalf("DropColumn: %v", err)
@@ -530,7 +564,7 @@ func TestPublicDDLEvolutionAdapterParity(t *testing.T) {
 					t.Fatalf("drop column SQL = %q, want %q", gotColumn.Statements[0].SQL, want)
 				}
 			}
-			if caps.AlterColumnTypes {
+			if caps.Supports(schema.EvolutionCapabilityAlterColumnType) {
 				gotType, err := public.AlterColumnType(table, column)
 				if err != nil {
 					t.Fatalf("AlterColumnType: %v", err)
@@ -543,7 +577,7 @@ func TestPublicDDLEvolutionAdapterParity(t *testing.T) {
 					t.Fatalf("alter type SQL = %q, want %q", gotType.Statements[0].SQL, wantType)
 				}
 			}
-			if caps.AlterColumnNullability {
+			if caps.Supports(schema.EvolutionCapabilityAlterColumnNullability) {
 				gotNullability, err := public.AlterColumnNullability(table, column)
 				if err != nil {
 					t.Fatalf("AlterColumnNullability: %v", err)
@@ -556,7 +590,7 @@ func TestPublicDDLEvolutionAdapterParity(t *testing.T) {
 					t.Fatalf("alter nullability SQL = %q, want %q", gotNullability.Statements[0].SQL, wantNullability)
 				}
 			}
-			if caps.SetColumnDefaults {
+			if caps.Supports(schema.EvolutionCapabilitySetColumnDefault) {
 				defaultColumn := column
 				defaultColumn.DefaultExpression = "0"
 				gotDefault, err := public.SetColumnDefault(table, defaultColumn)
@@ -579,7 +613,7 @@ func TestPublicDDLEvolutionAdapterParity(t *testing.T) {
 					}
 				}
 			}
-			if caps.DropColumnDefaults {
+			if caps.Supports(schema.EvolutionCapabilityDropColumnDefault) {
 				gotDefault, err := public.DropColumnDefault(table, column.Name)
 				if err != nil {
 					t.Fatalf("DropColumnDefault: %v", err)
@@ -615,7 +649,10 @@ type nullableOnlyEvolutionDialect struct{ testDialect }
 func (nullableOnlyEvolutionDialect) Name() string      { return "nullable-only" }
 func (nullableOnlyEvolutionDialect) Aliases() []string { return nil }
 func (nullableOnlyEvolutionDialect) Capabilities() schema.Capabilities {
-	return schema.Capabilities{AlterColumnNullability: true}
+	return schema.Capabilities{}
+}
+func (nullableOnlyEvolutionDialect) EvolutionCapabilities() schema.EvolutionCapabilities {
+	return schema.EvolutionCapabilities{schema.EvolutionCapabilityAlterColumnNullability}
 }
 func (nullableOnlyEvolutionDialect) RenderEvolution(_ schema.Request, operation schema.Evolution) (schema.Batch, error) {
 	if operation.Kind != schema.EvolutionAlterColumnNullability {

--- a/schema/ddl_evolution_public_test.go
+++ b/schema/ddl_evolution_public_test.go
@@ -371,6 +371,41 @@ func TestPublicDDLEvolutionConstraintKindsAndCleanupContracts(t *testing.T) {
 	}
 }
 
+func TestPublicDDLMSSQLSetColumnDefaultReplacesCatalogNamedConstraint(t *testing.T) {
+	renderer, err := schema.NewRenderer(schema.Options{TargetDialect: "mssql", Schema: "dbo", SourceDialect: "mssql"})
+	if err != nil {
+		t.Fatalf("NewRenderer(mssql): %v", err)
+	}
+	batch, err := renderer.SetColumnDefault(
+		schema.TableRef{Name: "Orders"},
+		schema.Column{Name: "Status", DataType: "int", DefaultExpression: "42"},
+	)
+	if err != nil {
+		t.Fatalf("SetColumnDefault: %v", err)
+	}
+	if !batch.RequiresSingleConnection || len(batch.Statements) != 2 {
+		t.Fatalf("replacement batch = %+v, want same-connection drop then add", batch)
+	}
+	drop, set := batch.Statements[0], batch.Statements[1]
+	if drop.Kind != schema.StatementDropColumnDefault || set.Kind != schema.StatementSetColumnDefault {
+		t.Fatalf("replacement statement kinds = %q, %q", drop.Kind, set.Kind)
+	}
+	for _, want := range []string{
+		"sys.default_constraints",
+		"t.name = N'Orders'",
+		"c.name = N'Status'",
+		"IF @constraintName IS NOT NULL",
+		"QUOTENAME(@constraintName)",
+	} {
+		if !strings.Contains(drop.SQL, want) {
+			t.Fatalf("replacement drop SQL missing %q:\n%s", want, drop.SQL)
+		}
+	}
+	if want := "ALTER TABLE [dbo].[Orders] ADD CONSTRAINT [df_Orders_Status] DEFAULT 42 FOR [Status]"; set.SQL != want {
+		t.Fatalf("replacement add SQL = %q, want %q", set.SQL, want)
+	}
+}
+
 func TestPublicDDLEvolutionPreservesConfiguredSchemaName(t *testing.T) {
 	for _, tc := range []struct {
 		dialect string
@@ -532,8 +567,16 @@ func TestPublicDDLEvolutionAdapterParity(t *testing.T) {
 				if err != nil {
 					t.Fatalf("internal SetColumnDefault: %v", err)
 				}
-				if gotDefault.Statements[0].SQL != wantDefault {
-					t.Fatalf("set default SQL = %q, want %q", gotDefault.Statements[0].SQL, wantDefault)
+				if !batchContainsSQL(gotDefault, wantDefault) {
+					t.Fatalf("set default SQL = %+v, want %q", gotDefault.Statements, wantDefault)
+				}
+				if tc.dialect == "mssql" {
+					if !gotDefault.RequiresSingleConnection || len(gotDefault.Statements) != 2 {
+						t.Fatalf("MSSQL default replacement batch = %+v, want same-connection drop then add", gotDefault)
+					}
+					if wantDrop := internal.DropColumnDefaultDDL(table.Name, column.Name); gotDefault.Statements[0].SQL != wantDrop {
+						t.Fatalf("MSSQL default replacement drop = %q, want %q", gotDefault.Statements[0].SQL, wantDrop)
+					}
 				}
 			}
 			if caps.DropColumnDefaults {

--- a/schema/ddl_evolution_public_test.go
+++ b/schema/ddl_evolution_public_test.go
@@ -271,6 +271,23 @@ func TestPublicDDLEvolutionNullabilityUsesOperationSpecificValidation(t *testing
 	}
 }
 
+func TestPublicDDLEvolutionSetDefaultUsesOperationSpecificValidation(t *testing.T) {
+	table := schema.TableRef{Name: "accounts"}
+	// Column.DataType is intentionally omitted; no builtin dialect restates
+	// the type in a SET DEFAULT statement.
+	column := schema.Column{Name: "status", DefaultExpression: "0"}
+
+	for _, dialect := range []string{"postgres", "mssql", "mysql"} {
+		renderer, err := schema.NewRenderer(schema.Options{TargetDialect: dialect})
+		if err != nil {
+			t.Fatalf("NewRenderer(%s): %v", dialect, err)
+		}
+		if _, err := renderer.SetColumnDefault(table, column); err != nil {
+			t.Fatalf("%s SetColumnDefault without DataType: %v", dialect, err)
+		}
+	}
+}
+
 func TestBuiltinEvolutionDialectReturnsTypedUnsupportedErrorsDirectly(t *testing.T) {
 	dialect, err := schema.NewRegistry().Resolve("sqlite")
 	if err != nil {

--- a/schema/ddl_evolution_public_test.go
+++ b/schema/ddl_evolution_public_test.go
@@ -231,6 +231,65 @@ func TestPublicDDLEvolutionCapabilitiesAndUnsupportedErrors(t *testing.T) {
 	}
 }
 
+func TestPublicDDLEvolutionNullabilityUsesOperationSpecificValidation(t *testing.T) {
+	table := schema.TableRef{Name: "accounts"}
+	column := schema.Column{Name: "status", IsNullable: true}
+
+	postgres, err := schema.NewRenderer(schema.Options{TargetDialect: "postgres", Schema: "public"})
+	if err != nil {
+		t.Fatalf("NewRenderer(postgres): %v", err)
+	}
+	batch, err := postgres.AlterColumnNullability(table, column)
+	if err != nil {
+		t.Fatalf("PostgreSQL nullability without DataType: %v", err)
+	}
+	if got, want := batch.Statements[0].SQL, `ALTER TABLE "public"."accounts" ALTER COLUMN "status" DROP NOT NULL`; got != want {
+		t.Fatalf("PostgreSQL nullability SQL = %q, want %q", got, want)
+	}
+
+	registry := schema.NewRegistry()
+	if err := registry.Register(nullableOnlyEvolutionDialect{}); err != nil {
+		t.Fatalf("Register custom evolution dialect: %v", err)
+	}
+	custom, err := registry.NewRenderer(schema.Options{TargetDialect: "nullable-only"})
+	if err != nil {
+		t.Fatalf("NewRenderer(custom): %v", err)
+	}
+	if _, err := custom.AlterColumnNullability(table, column); err != nil {
+		t.Fatalf("custom nullability without DataType: %v", err)
+	}
+
+	for _, dialect := range []string{"mssql", "mysql"} {
+		renderer, err := schema.NewRenderer(schema.Options{TargetDialect: dialect})
+		if err != nil {
+			t.Fatalf("NewRenderer(%s): %v", dialect, err)
+		}
+		if _, err := renderer.AlterColumnNullability(table, column); err == nil ||
+			!strings.Contains(err.Error(), "empty source data type") {
+			t.Fatalf("%s nullability error = %v, want empty source data type", dialect, err)
+		}
+	}
+}
+
+func TestBuiltinEvolutionDialectReturnsTypedUnsupportedErrorsDirectly(t *testing.T) {
+	dialect, err := schema.NewRegistry().Resolve("sqlite")
+	if err != nil {
+		t.Fatalf("Resolve(sqlite): %v", err)
+	}
+	evolution := dialect.(schema.EvolutionDialect)
+	_, err = evolution.RenderEvolution(
+		schema.Request{Schema: "named"},
+		schema.Evolution{Kind: schema.EvolutionDropSchema},
+	)
+	var unsupported *schema.UnsupportedFeatureError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("RenderEvolution error = %v, want UnsupportedFeatureError", err)
+	}
+	if unsupported.Feature != "schema drops" {
+		t.Fatalf("Unsupported feature = %q, want %q", unsupported.Feature, "schema drops")
+	}
+}
+
 func TestPublicDDLEvolutionConstraintKindsAndCleanupContracts(t *testing.T) {
 	mysql, err := schema.NewRenderer(schema.Options{TargetDialect: "mysql", Schema: "crm"})
 	if err != nil {
@@ -488,6 +547,26 @@ func TestPublicDDLEvolutionAdapterParity(t *testing.T) {
 			}
 		})
 	}
+}
+
+type nullableOnlyEvolutionDialect struct{ testDialect }
+
+func (nullableOnlyEvolutionDialect) Name() string      { return "nullable-only" }
+func (nullableOnlyEvolutionDialect) Aliases() []string { return nil }
+func (nullableOnlyEvolutionDialect) Capabilities() schema.Capabilities {
+	return schema.Capabilities{AlterColumnNullability: true}
+}
+func (nullableOnlyEvolutionDialect) RenderEvolution(_ schema.Request, operation schema.Evolution) (schema.Batch, error) {
+	if operation.Kind != schema.EvolutionAlterColumnNullability {
+		return schema.Batch{}, errors.New("unexpected evolution kind")
+	}
+	if operation.Column.DataType != "" {
+		return schema.Batch{}, errors.New("unexpected column data type")
+	}
+	return schema.Batch{Statements: []schema.Statement{{
+		Kind: schema.StatementAlterColumnNullability,
+		SQL:  "ALTER NULLABILITY",
+	}}}, nil
 }
 
 func batchContainsSQL(batch schema.Batch, want string) bool {

--- a/schema/ddl_evolution_public_test.go
+++ b/schema/ddl_evolution_public_test.go
@@ -1,0 +1,526 @@
+package schema_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/johndauphine/smt/internal/ddl"
+	"github.com/johndauphine/smt/internal/driver"
+	"github.com/johndauphine/smt/schema"
+)
+
+func TestPublicDDLEvolutionGoldens(t *testing.T) {
+	cases := []struct {
+		name   string
+		opts   schema.Options
+		column schema.Column
+		alter  schema.Column
+		golden string
+	}{
+		{
+			name:   "postgres",
+			opts:   schema.Options{TargetDialect: "postgres", Schema: "public", SourceDialect: "postgres"},
+			column: schema.Column{Name: "subtotal", DataType: "int4", IsNullable: true, DefaultExpression: "0"},
+			alter:  schema.Column{Name: "subtotal", DataType: "int8", IsNullable: true},
+			golden: "postgres_evolution.sql.golden",
+		},
+		{
+			name:   "mssql",
+			opts:   schema.Options{TargetDialect: "mssql", Schema: "dbo", SourceDialect: "mssql"},
+			column: schema.Column{Name: "subtotal", DataType: "int", IsNullable: true, DefaultExpression: "0"},
+			alter:  schema.Column{Name: "subtotal", DataType: "bigint", IsNullable: true},
+			golden: "mssql_evolution.sql.golden",
+		},
+		{
+			name:   "mysql",
+			opts:   schema.Options{TargetDialect: "mysql", Schema: "crm", SourceDialect: "mysql"},
+			column: schema.Column{Name: "subtotal", DataType: "int", IsNullable: true, DefaultExpression: "0"},
+			alter:  schema.Column{Name: "subtotal", DataType: "bigint", IsNullable: true},
+			golden: "mysql_evolution.sql.golden",
+		},
+		{
+			name:   "sqlite",
+			opts:   schema.Options{TargetDialect: "sqlite", Schema: "ignored_by_sqlite", SourceDialect: "sqlite"},
+			column: schema.Column{Name: "subtotal", DataType: "integer", IsNullable: true, DefaultExpression: "0"},
+			alter:  schema.Column{Name: "subtotal", DataType: "integer", IsNullable: true},
+			golden: "sqlite_evolution.sql.golden",
+		},
+		{
+			name:   "clickhouse",
+			opts:   schema.Options{TargetDialect: "clickhouse", Schema: "analytics", SourceDialect: "clickhouse"},
+			column: schema.Column{Name: "subtotal", DataType: "Int64", IsNullable: true},
+			alter:  schema.Column{Name: "subtotal", DataType: "Int64", IsNullable: true},
+			golden: "clickhouse_evolution.sql.golden",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			renderer, err := schema.NewRenderer(tc.opts)
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			got := renderEvolutionArtifacts(t, renderer, tc.column, tc.alter)
+			assertGolden(t, got, tc.golden)
+		})
+	}
+}
+
+func renderEvolutionArtifacts(t *testing.T, renderer schema.Renderer, column, alter schema.Column) string {
+	t.Helper()
+	table := schema.TableRef{Name: "Orders", Columns: []schema.Column{{Name: "id", DataType: column.DataType}, column}}
+	caps := renderer.Capabilities()
+	var artifacts []string
+	appendBatch := func(name string, render func() (schema.Batch, error)) {
+		t.Helper()
+		batch, err := render()
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		artifacts = append(artifacts, name+"\n"+formatBatch(batch))
+	}
+
+	if caps.DropSchemas {
+		appendBatch("drop_schema", func() (schema.Batch, error) {
+			return renderer.DropSchema(schema.DropOptions{Cascade: caps.DropSchemaCascade})
+		})
+	}
+	appendBatch("drop_table", func() (schema.Batch, error) {
+		return renderer.DropTable(table, schema.DropOptions{Cascade: caps.DropTableCascade})
+	})
+	if caps.DropIndexes {
+		appendBatch("drop_index", func() (schema.Batch, error) {
+			return renderer.DropIndex(table, "IX Orders Subtotal")
+		})
+	}
+	if caps.DropConstraints {
+		appendBatch("drop_foreign_key", func() (schema.Batch, error) {
+			return renderer.DropConstraint(table, schema.ConstraintRef{Name: "FK Orders Account", Kind: schema.ConstraintForeignKey})
+		})
+	}
+	appendBatch("add_column", func() (schema.Batch, error) { return renderer.AddColumn(table, column) })
+	appendBatch("drop_column", func() (schema.Batch, error) { return renderer.DropColumn(table, column.Name) })
+	if caps.AlterColumnTypes {
+		appendBatch("alter_column_type", func() (schema.Batch, error) { return renderer.AlterColumnType(table, alter) })
+	}
+	if caps.AlterColumnNullability {
+		appendBatch("alter_column_nullability", func() (schema.Batch, error) {
+			return renderer.AlterColumnNullability(table, alter)
+		})
+	}
+	if caps.SetColumnDefaults {
+		appendBatch("set_column_default", func() (schema.Batch, error) { return renderer.SetColumnDefault(table, column) })
+	}
+	if caps.DropColumnDefaults {
+		appendBatch("drop_column_default", func() (schema.Batch, error) {
+			return renderer.DropColumnDefault(table, column.Name)
+		})
+	}
+	appendBatch("truncate_table", func() (schema.Batch, error) {
+		return renderer.TruncateTable(table, schema.TruncateOptions{Cascade: caps.TruncateTableCascade})
+	})
+	return strings.Join(artifacts, "\n\n")
+}
+
+func formatBatch(batch schema.Batch) string {
+	var lines []string
+	if batch.RequiresSingleConnection {
+		lines = append(lines, "requires_single_connection")
+	}
+	for _, statement := range batch.Statements {
+		if statement.BestEffort {
+			lines = append(lines, "best_effort")
+		}
+		lines = append(lines, string(statement.Kind), statement.SQL)
+	}
+	for _, statement := range batch.Cleanup {
+		lines = append(lines, "on_failure_"+string(statement.Kind), statement.SQL)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func TestPublicDDLEvolutionCapabilitiesAndUnsupportedErrors(t *testing.T) {
+	type expected struct {
+		dropSchemas, dropSchemaCascade, dropTables, dropTableCascade, dropIndexes, dropConstraints                  bool
+		addColumns, dropColumns, alterTypes, alterNullability, setDefaults, dropDefaults, truncate, truncateCascade bool
+	}
+	cases := []struct {
+		dialect string
+		want    expected
+	}{
+		{"postgres", expected{true, true, true, true, true, true, true, true, true, true, true, true, true, true}},
+		{"mssql", expected{true, false, true, false, true, true, true, true, true, true, true, true, true, false}},
+		{"mysql", expected{true, false, true, false, true, true, true, true, true, true, true, true, true, false}},
+		{"sqlite", expected{false, false, true, false, true, false, true, true, false, false, false, false, true, false}},
+		{"clickhouse", expected{true, false, true, false, false, false, true, true, false, false, false, false, true, false}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.dialect, func(t *testing.T) {
+			renderer, err := schema.NewRenderer(schema.Options{TargetDialect: tc.dialect, Schema: "scope"})
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			got := renderer.Capabilities()
+			if got.DropSchemas != tc.want.dropSchemas || got.DropSchemaCascade != tc.want.dropSchemaCascade ||
+				got.DropTables != tc.want.dropTables || got.DropTableCascade != tc.want.dropTableCascade ||
+				got.DropIndexes != tc.want.dropIndexes || got.DropConstraints != tc.want.dropConstraints ||
+				got.AddColumns != tc.want.addColumns || got.DropColumns != tc.want.dropColumns ||
+				got.AlterColumnTypes != tc.want.alterTypes || got.AlterColumnNullability != tc.want.alterNullability ||
+				got.SetColumnDefaults != tc.want.setDefaults || got.DropColumnDefaults != tc.want.dropDefaults ||
+				got.TruncateTables != tc.want.truncate || got.TruncateTableCascade != tc.want.truncateCascade {
+				t.Fatalf("evolution capabilities = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+
+	table := schema.TableRef{Name: "events"}
+	casesUnsupported := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "sqlite drop schema",
+			call: func() error {
+				r, _ := schema.NewRenderer(schema.Options{TargetDialect: "sqlite", Schema: "main"})
+				_, err := r.DropSchema(schema.DropOptions{})
+				return err
+			},
+		},
+		{
+			name: "sqlite constraint drop",
+			call: func() error {
+				r, _ := schema.NewRenderer(schema.Options{TargetDialect: "sqlite"})
+				_, err := r.DropConstraint(table, schema.ConstraintRef{Name: "fk_events_parent", Kind: schema.ConstraintForeignKey})
+				return err
+			},
+		},
+		{
+			name: "sqlite alter type",
+			call: func() error {
+				r, _ := schema.NewRenderer(schema.Options{TargetDialect: "sqlite"})
+				_, err := r.AlterColumnType(table, schema.Column{Name: "id", DataType: "integer"})
+				return err
+			},
+		},
+		{
+			name: "clickhouse index drop",
+			call: func() error {
+				r, _ := schema.NewRenderer(schema.Options{TargetDialect: "clickhouse"})
+				_, err := r.DropIndex(table, "ix_events_id")
+				return err
+			},
+		},
+		{
+			name: "mssql table cascade",
+			call: func() error {
+				r, _ := schema.NewRenderer(schema.Options{TargetDialect: "mssql"})
+				_, err := r.DropTable(table, schema.DropOptions{Cascade: true})
+				return err
+			},
+		},
+	}
+	for _, tc := range casesUnsupported {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			var unsupported *schema.UnsupportedFeatureError
+			if !errors.As(err, &unsupported) {
+				t.Fatalf("error = %v, want UnsupportedFeatureError", err)
+			}
+		})
+	}
+}
+
+func TestPublicDDLEvolutionConstraintKindsAndCleanupContracts(t *testing.T) {
+	mysql, err := schema.NewRenderer(schema.Options{TargetDialect: "mysql", Schema: "crm"})
+	if err != nil {
+		t.Fatalf("NewRenderer(mysql): %v", err)
+	}
+	table := schema.TableRef{Name: "orders"}
+	for _, tc := range []struct {
+		kind schema.ConstraintKind
+		want string
+	}{
+		{schema.ConstraintPrimaryKey, "ALTER TABLE `crm`.`orders` DROP PRIMARY KEY"},
+		{schema.ConstraintUnique, "ALTER TABLE `crm`.`orders` DROP INDEX `uq_orders_code`"},
+		{schema.ConstraintForeignKey, "ALTER TABLE `crm`.`orders` DROP FOREIGN KEY `uq_orders_code`"},
+		{schema.ConstraintCheck, "ALTER TABLE `crm`.`orders` DROP CHECK `uq_orders_code`"},
+	} {
+		batch, err := mysql.DropConstraint(table, schema.ConstraintRef{Name: "uq_orders_code", Kind: tc.kind})
+		if err != nil {
+			t.Fatalf("DropConstraint(%s): %v", tc.kind, err)
+		}
+		if got := batch.Statements[0].SQL; got != tc.want {
+			t.Fatalf("DropConstraint(%s) = %q, want %q", tc.kind, got, tc.want)
+		}
+	}
+
+	for _, tc := range []struct {
+		dialect string
+		setup   string
+		cleanup string
+	}{
+		{"mysql", "SET FOREIGN_KEY_CHECKS = 0", "SET FOREIGN_KEY_CHECKS = 1"},
+		{"sqlite", "PRAGMA foreign_keys = OFF", "PRAGMA foreign_keys = ON"},
+	} {
+		t.Run(tc.dialect+" drop batch", func(t *testing.T) {
+			renderer, err := schema.NewRenderer(schema.Options{TargetDialect: tc.dialect})
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			batch, err := renderer.DropTable(schema.TableRef{Name: "events"}, schema.DropOptions{})
+			if err != nil {
+				t.Fatalf("DropTable: %v", err)
+			}
+			if !batch.RequiresSingleConnection || len(batch.Statements) != 3 || len(batch.Cleanup) != 1 {
+				t.Fatalf("drop batch contract = %+v, want same-connection setup/DDL/cleanup plus failure cleanup", batch)
+			}
+			if batch.Statements[0].SQL != tc.setup || batch.Statements[2].SQL != tc.cleanup || batch.Cleanup[0].SQL != tc.cleanup {
+				t.Fatalf("drop batch SQL = %+v, want setup=%q cleanup=%q", batch, tc.setup, tc.cleanup)
+			}
+		})
+	}
+
+	sqlite, err := schema.NewRenderer(schema.Options{TargetDialect: "sqlite"})
+	if err != nil {
+		t.Fatalf("NewRenderer(sqlite): %v", err)
+	}
+	batch, err := sqlite.TruncateTable(schema.TableRef{Name: "O'Reilly"}, schema.TruncateOptions{})
+	if err != nil {
+		t.Fatalf("TruncateTable(sqlite): %v", err)
+	}
+	if len(batch.Statements) != 2 || !batch.Statements[1].BestEffort || batch.Statements[1].Kind != schema.StatementBestEffortCleanup || batch.Statements[1].SQL != "DELETE FROM sqlite_sequence WHERE name = 'O''Reilly'" {
+		t.Fatalf("sqlite truncate cleanup = %+v, want quoted best-effort sqlite_sequence cleanup", batch)
+	}
+}
+
+func TestPublicDDLEvolutionPreservesConfiguredSchemaName(t *testing.T) {
+	for _, tc := range []struct {
+		dialect string
+		want    string
+	}{
+		{"postgres", `DROP SCHEMA IF EXISTS "Tenant Space"`},
+		{"mssql", `IF SCHEMA_ID(N'Tenant Space') IS NOT NULL EXEC(N'DROP SCHEMA [Tenant Space]')`},
+		{"mysql", "DROP DATABASE IF EXISTS `Tenant Space`"},
+		{"clickhouse", "DROP DATABASE IF EXISTS `Tenant Space`"},
+	} {
+		t.Run(tc.dialect, func(t *testing.T) {
+			renderer, err := schema.NewRenderer(schema.Options{TargetDialect: tc.dialect, Schema: "Tenant Space"})
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			batch, err := renderer.DropSchema(schema.DropOptions{})
+			if err != nil {
+				t.Fatalf("DropSchema: %v", err)
+			}
+			if got := batch.Statements[0].SQL; got != tc.want {
+				t.Fatalf("DropSchema = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPublicDDLEvolutionAdapterParity(t *testing.T) {
+	cases := []struct {
+		dialect, targetSchema, source, dataType string
+		cascade                                 bool
+	}{
+		{"postgres", "public", "postgres", "int4", true},
+		{"mssql", "dbo", "mssql", "int", false},
+		{"mysql", "crm", "mysql", "int", false},
+		{"sqlite", "ignored", "sqlite", "integer", false},
+		{"clickhouse", "analytics", "clickhouse", "Int64", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.dialect, func(t *testing.T) {
+			public, err := schema.NewRenderer(schema.Options{TargetDialect: tc.dialect, Schema: tc.targetSchema, SourceDialect: tc.source})
+			if err != nil {
+				t.Fatalf("NewRenderer: %v", err)
+			}
+			internalSchema := tc.targetSchema
+			if tc.dialect == "sqlite" {
+				internalSchema = ""
+			}
+			internal, err := ddl.NewRenderer(tc.dialect, internalSchema, "fail")
+			if err != nil {
+				t.Fatalf("ddl.NewRenderer: %v", err)
+			}
+			internal = internal.WithSource(tc.source)
+			table := schema.TableRef{Name: "Orders"}
+			column := schema.Column{Name: "extra", DataType: tc.dataType, IsNullable: true}
+
+			gotDrop, err := public.DropTable(table, schema.DropOptions{Cascade: tc.cascade})
+			if err != nil {
+				t.Fatalf("DropTable: %v", err)
+			}
+			wantDrop, err := internal.DropTableWithOptionsDDL(table.Name, tc.cascade)
+			if err != nil {
+				t.Fatalf("internal DropTable: %v", err)
+			}
+			if !batchContainsSQL(gotDrop, wantDrop) {
+				t.Fatalf("drop core SQL = %+v, want %q", gotDrop.Statements, wantDrop)
+			}
+
+			gotAdd, err := public.AddColumn(table, column)
+			if err != nil {
+				t.Fatalf("AddColumn: %v", err)
+			}
+			wantAdd, err := internal.AddColumnDDL(table.Name, toInternalColumn(column), nil)
+			if err != nil {
+				t.Fatalf("internal AddColumn: %v", err)
+			}
+			if gotAdd.Statements[0].SQL != wantAdd {
+				t.Fatalf("add SQL = %q, want %q", gotAdd.Statements[0].SQL, wantAdd)
+			}
+
+			caps := public.Capabilities()
+			if caps.DropSchemas {
+				gotSchema, err := public.DropSchema(schema.DropOptions{})
+				if err != nil {
+					t.Fatalf("DropSchema: %v", err)
+				}
+				wantSchema, err := internal.DropSchemaDDL(false)
+				if err != nil {
+					t.Fatalf("internal DropSchema: %v", err)
+				}
+				if gotSchema.Statements[0].SQL != wantSchema {
+					t.Fatalf("drop schema SQL = %q, want %q", gotSchema.Statements[0].SQL, wantSchema)
+				}
+			}
+			if caps.DropIndexes {
+				gotIndex, err := public.DropIndex(table, "ix_orders_extra")
+				if err != nil {
+					t.Fatalf("DropIndex: %v", err)
+				}
+				if want := internal.DropIndexDDL(table.Name, "ix_orders_extra"); gotIndex.Statements[0].SQL != want {
+					t.Fatalf("drop index SQL = %q, want %q", gotIndex.Statements[0].SQL, want)
+				}
+			}
+			if caps.DropConstraints {
+				gotConstraint, err := public.DropConstraint(table, schema.ConstraintRef{Name: "fk_orders_parent", Kind: schema.ConstraintForeignKey})
+				if err != nil {
+					t.Fatalf("DropConstraint: %v", err)
+				}
+				wantConstraint, err := internal.DropConstraintDDL(table.Name, "fk_orders_parent", string(schema.ConstraintForeignKey))
+				if err != nil {
+					t.Fatalf("internal DropConstraint: %v", err)
+				}
+				if gotConstraint.Statements[0].SQL != wantConstraint {
+					t.Fatalf("drop constraint SQL = %q, want %q", gotConstraint.Statements[0].SQL, wantConstraint)
+				}
+			}
+			if caps.DropColumns {
+				gotColumn, err := public.DropColumn(table, column.Name)
+				if err != nil {
+					t.Fatalf("DropColumn: %v", err)
+				}
+				if want := internal.DropColumnDDL(table.Name, column.Name); gotColumn.Statements[0].SQL != want {
+					t.Fatalf("drop column SQL = %q, want %q", gotColumn.Statements[0].SQL, want)
+				}
+			}
+			if caps.AlterColumnTypes {
+				gotType, err := public.AlterColumnType(table, column)
+				if err != nil {
+					t.Fatalf("AlterColumnType: %v", err)
+				}
+				wantType, err := internal.AlterColumnTypeDDL(table.Name, toInternalColumn(column))
+				if err != nil {
+					t.Fatalf("internal AlterColumnType: %v", err)
+				}
+				if gotType.Statements[0].SQL != wantType {
+					t.Fatalf("alter type SQL = %q, want %q", gotType.Statements[0].SQL, wantType)
+				}
+			}
+			if caps.AlterColumnNullability {
+				gotNullability, err := public.AlterColumnNullability(table, column)
+				if err != nil {
+					t.Fatalf("AlterColumnNullability: %v", err)
+				}
+				wantNullability, err := internal.AlterColumnNullabilityDDL(table.Name, toInternalColumn(column))
+				if err != nil {
+					t.Fatalf("internal AlterColumnNullability: %v", err)
+				}
+				if gotNullability.Statements[0].SQL != wantNullability {
+					t.Fatalf("alter nullability SQL = %q, want %q", gotNullability.Statements[0].SQL, wantNullability)
+				}
+			}
+			if caps.SetColumnDefaults {
+				defaultColumn := column
+				defaultColumn.DefaultExpression = "0"
+				gotDefault, err := public.SetColumnDefault(table, defaultColumn)
+				if err != nil {
+					t.Fatalf("SetColumnDefault: %v", err)
+				}
+				wantDefault, err := internal.SetColumnDefaultDDL(table.Name, toInternalColumn(defaultColumn))
+				if err != nil {
+					t.Fatalf("internal SetColumnDefault: %v", err)
+				}
+				if gotDefault.Statements[0].SQL != wantDefault {
+					t.Fatalf("set default SQL = %q, want %q", gotDefault.Statements[0].SQL, wantDefault)
+				}
+			}
+			if caps.DropColumnDefaults {
+				gotDefault, err := public.DropColumnDefault(table, column.Name)
+				if err != nil {
+					t.Fatalf("DropColumnDefault: %v", err)
+				}
+				if want := internal.DropColumnDefaultDDL(table.Name, column.Name); gotDefault.Statements[0].SQL != want {
+					t.Fatalf("drop default SQL = %q, want %q", gotDefault.Statements[0].SQL, want)
+				}
+			}
+
+			gotTruncate, err := public.TruncateTable(table, schema.TruncateOptions{Cascade: tc.cascade})
+			if err != nil {
+				t.Fatalf("TruncateTable: %v", err)
+			}
+			wantTruncate, err := internal.TruncateTableDDL(table.Name, tc.cascade)
+			if err != nil {
+				t.Fatalf("internal TruncateTable: %v", err)
+			}
+			if !batchContainsSQL(gotTruncate, wantTruncate) {
+				t.Fatalf("truncate core SQL = %+v, want %q", gotTruncate.Statements, wantTruncate)
+			}
+			if want := tc.dialect == "mysql" || tc.dialect == "sqlite"; gotDrop.RequiresSingleConnection != want {
+				t.Fatalf("drop affinity = %t, want %t", gotDrop.RequiresSingleConnection, want)
+			}
+			if want := tc.dialect == "mysql"; gotTruncate.RequiresSingleConnection != want {
+				t.Fatalf("truncate affinity = %t, want %t", gotTruncate.RequiresSingleConnection, want)
+			}
+		})
+	}
+}
+
+func batchContainsSQL(batch schema.Batch, want string) bool {
+	for _, statement := range batch.Statements {
+		if statement.SQL == want {
+			return true
+		}
+	}
+	return false
+}
+
+// toInternalColumn keeps the parity assertion intentionally public-value
+// driven while accepting the internal test helper's exact type.
+func toInternalColumn(column schema.Column) driver.Column {
+	return driver.Column{
+		Name:               column.Name,
+		DataType:           column.DataType,
+		MaxLength:          column.MaxLength,
+		Precision:          column.Precision,
+		Scale:              column.Scale,
+		DatetimePrecision:  column.DatetimePrecision,
+		IsNullable:         column.IsNullable,
+		IsIdentity:         column.IsIdentity,
+		IsUnsigned:         column.IsUnsigned,
+		DisplayWidth:       column.DisplayWidth,
+		DefaultExpression:  column.DefaultExpression,
+		HasDefault:         column.HasDefault,
+		OnUpdateExpression: column.OnUpdateExpression,
+		IsComputed:         column.IsComputed,
+		ComputedExpression: column.ComputedExpression,
+		ComputedPersisted:  column.ComputedPersisted,
+		EnumValues:         append([]string(nil), column.EnumValues...),
+		SRID:               column.SRID,
+		SpatialSubType:     column.SpatialSubType,
+	}
+}

--- a/schema/ddl_evolution_public_test.go
+++ b/schema/ddl_evolution_public_test.go
@@ -273,8 +273,9 @@ func TestPublicDDLEvolutionNullabilityUsesOperationSpecificValidation(t *testing
 
 func TestPublicDDLEvolutionSetDefaultUsesOperationSpecificValidation(t *testing.T) {
 	table := schema.TableRef{Name: "accounts"}
-	// Column.DataType is intentionally omitted; no builtin dialect restates
-	// the type in a SET DEFAULT statement.
+	// Column.DataType is intentionally omitted to assert that no builtin
+	// dialect requires it for SET DEFAULT. Column.DefaultExpression satisfies
+	// the required non-empty default check.
 	column := schema.Column{Name: "status", DefaultExpression: "0"}
 
 	for _, dialect := range []string{"postgres", "mssql", "mysql"} {

--- a/schema/evolution.go
+++ b/schema/evolution.go
@@ -307,6 +307,10 @@ func (r Renderer) validateNullabilityColumn(column Column) error {
 	return nil
 }
 
+// validateSetDefaultColumn validates that column has the minimum fields required
+// for SET DEFAULT operations. Only column.Name is required: no builtin dialect
+// restates the column type in a SET DEFAULT statement. Custom dialects that
+// need DataType should validate it inside RenderEvolution.
 func validateSetDefaultColumn(column Column) error {
 	if strings.TrimSpace(column.Name) == "" {
 		return fmt.Errorf("render column: empty column name")

--- a/schema/evolution.go
+++ b/schema/evolution.go
@@ -20,10 +20,26 @@ type Batch struct {
 	Statements               []Statement
 	Cleanup                  []Statement
 	RequiresSingleConnection bool
+	// BestEffortStatementIndexes identifies zero-based entries in Statements
+	// whose execution errors are advisory. An executor should record those
+	// errors but continue the containing batch. Entries not listed are
+	// required. The built-in renderers emit sorted, unique, in-range indexes.
+	BestEffortStatementIndexes []int
 }
 
 // IsEmpty reports whether b contains no executable statements.
 func (b Batch) IsEmpty() bool { return len(b.Statements) == 0 }
+
+// IsBestEffort reports whether the Statement at index has advisory failure
+// semantics. Out-of-range indexes are never best effort.
+func (b Batch) IsBestEffort(index int) bool {
+	for _, bestEffort := range b.BestEffortStatementIndexes {
+		if bestEffort == index {
+			return true
+		}
+	}
+	return false
+}
 
 // EvolutionKind identifies an operation supplied to an EvolutionDialect.
 // Applications normally use the corresponding Renderer method; this type is
@@ -43,6 +59,43 @@ const (
 	EvolutionDropColumnDefault      EvolutionKind = "drop_column_default"
 	EvolutionTruncateTable          EvolutionKind = "truncate_table"
 )
+
+// EvolutionCapability identifies one public schema-evolution feature. The
+// corresponding Renderer method returns UnsupportedFeatureError when the
+// selected dialect does not advertise the feature.
+type EvolutionCapability string
+
+const (
+	EvolutionCapabilityDropSchema             EvolutionCapability = "drop_schema"
+	EvolutionCapabilityDropSchemaCascade      EvolutionCapability = "drop_schema_cascade"
+	EvolutionCapabilityDropTable              EvolutionCapability = "drop_table"
+	EvolutionCapabilityDropTableCascade       EvolutionCapability = "drop_table_cascade"
+	EvolutionCapabilityDropIndex              EvolutionCapability = "drop_index"
+	EvolutionCapabilityDropConstraint         EvolutionCapability = "drop_constraint"
+	EvolutionCapabilityAddColumn              EvolutionCapability = "add_column"
+	EvolutionCapabilityDropColumn             EvolutionCapability = "drop_column"
+	EvolutionCapabilityAlterColumnType        EvolutionCapability = "alter_column_type"
+	EvolutionCapabilityAlterColumnNullability EvolutionCapability = "alter_column_nullability"
+	EvolutionCapabilitySetColumnDefault       EvolutionCapability = "set_column_default"
+	EvolutionCapabilityDropColumnDefault      EvolutionCapability = "drop_column_default"
+	EvolutionCapabilityTruncateTable          EvolutionCapability = "truncate_table"
+	EvolutionCapabilityTruncateTableCascade   EvolutionCapability = "truncate_table_cascade"
+)
+
+// EvolutionCapabilities is the feature set advertised by an EvolutionDialect.
+// It is a slice rather than another fixed-width struct so future capabilities
+// can be added without changing existing composite-literal layouts.
+type EvolutionCapabilities []EvolutionCapability
+
+// Supports reports whether c advertises capability.
+func (c EvolutionCapabilities) Supports(capability EvolutionCapability) bool {
+	for _, available := range c {
+		if available == capability {
+			return true
+		}
+	}
+	return false
+}
 
 // DropOptions selects explicit destructive-drop behavior. Cascade is never
 // inferred: callers must request it and the target dialect must advertise the
@@ -95,7 +148,25 @@ type Evolution struct {
 // side-object implementations remain source compatible.
 type EvolutionDialect interface {
 	Dialect
+	EvolutionCapabilities() EvolutionCapabilities
 	RenderEvolution(Request, Evolution) (Batch, error)
+}
+
+// EvolutionCapabilities reports the schema-evolution features supported by
+// the selected dialect. The returned slice is a copy and may be safely
+// modified by the caller. A dialect without EvolutionDialect support returns
+// no evolution capabilities.
+func (r Renderer) EvolutionCapabilities() EvolutionCapabilities {
+	dialect, ok := r.dialect.(EvolutionDialect)
+	if !ok {
+		return nil
+	}
+	return append(EvolutionCapabilities(nil), dialect.EvolutionCapabilities()...)
+}
+
+// SupportsEvolution reports whether the selected dialect supports capability.
+func (r Renderer) SupportsEvolution(capability EvolutionCapability) bool {
+	return r.EvolutionCapabilities().Supports(capability)
 }
 
 const (
@@ -124,10 +195,10 @@ func (r Renderer) DropSchema(options DropOptions) (Batch, error) {
 	if strings.TrimSpace(r.request.Schema) == "" {
 		return Batch{}, nil
 	}
-	if !r.Capabilities().DropSchemas {
+	if !r.SupportsEvolution(EvolutionCapabilityDropSchema) {
 		return Batch{}, r.unsupported("schema drops")
 	}
-	if options.Cascade && !r.Capabilities().DropSchemaCascade {
+	if options.Cascade && !r.SupportsEvolution(EvolutionCapabilityDropSchemaCascade) {
 		return Batch{}, r.unsupported("schema-drop CASCADE")
 	}
 	return r.renderEvolution(Evolution{Kind: EvolutionDropSchema, DropOptions: options})
@@ -136,10 +207,10 @@ func (r Renderer) DropSchema(options DropOptions) (Batch, error) {
 // DropTable renders an idempotent table drop. Cascade is an explicit option
 // because it may remove dependent objects.
 func (r Renderer) DropTable(table TableRef, options DropOptions) (Batch, error) {
-	if !r.Capabilities().DropTables {
+	if !r.SupportsEvolution(EvolutionCapabilityDropTable) {
 		return Batch{}, r.unsupported("table drops")
 	}
-	if options.Cascade && !r.Capabilities().DropTableCascade {
+	if options.Cascade && !r.SupportsEvolution(EvolutionCapabilityDropTableCascade) {
 		return Batch{}, r.unsupported("table-drop CASCADE")
 	}
 	if err := validateTableRef("table drop", table); err != nil {
@@ -150,7 +221,7 @@ func (r Renderer) DropTable(table TableRef, options DropOptions) (Batch, error) 
 
 // DropIndex renders a named-index drop for a table.
 func (r Renderer) DropIndex(table TableRef, name string) (Batch, error) {
-	if !r.Capabilities().DropIndexes {
+	if !r.SupportsEvolution(EvolutionCapabilityDropIndex) {
 		return Batch{}, r.unsupported("index drops")
 	}
 	if err := validateTableRef("index drop", table); err != nil {
@@ -166,7 +237,7 @@ func (r Renderer) DropIndex(table TableRef, name string) (Batch, error) {
 // constraint drop. SQLite and ClickHouse report a typed unsupported error
 // rather than silently proposing a table rebuild.
 func (r Renderer) DropConstraint(table TableRef, constraint ConstraintRef) (Batch, error) {
-	if !r.Capabilities().DropConstraints {
+	if !r.SupportsEvolution(EvolutionCapabilityDropConstraint) {
 		return Batch{}, r.unsupported("constraint drops")
 	}
 	if err := validateTableRef("constraint drop", table); err != nil {
@@ -185,7 +256,7 @@ func (r Renderer) DropConstraint(table TableRef, constraint ConstraintRef) (Batc
 
 // AddColumn renders a complete ALTER TABLE add-column operation.
 func (r Renderer) AddColumn(table TableRef, column Column) (Batch, error) {
-	if !r.Capabilities().AddColumns {
+	if !r.SupportsEvolution(EvolutionCapabilityAddColumn) {
 		return Batch{}, r.unsupported("adding columns")
 	}
 	if err := validateTableRef("add column", table); err != nil {
@@ -199,7 +270,7 @@ func (r Renderer) AddColumn(table TableRef, column Column) (Batch, error) {
 
 // DropColumn renders a data-destructive column drop.
 func (r Renderer) DropColumn(table TableRef, name string) (Batch, error) {
-	if !r.Capabilities().DropColumns {
+	if !r.SupportsEvolution(EvolutionCapabilityDropColumn) {
 		return Batch{}, r.unsupported("dropping columns")
 	}
 	if err := validateTableRef("column drop", table); err != nil {
@@ -214,7 +285,7 @@ func (r Renderer) DropColumn(table TableRef, name string) (Batch, error) {
 // AlterColumnType renders an in-place type change when the dialect supports
 // one. SQLite and ClickHouse report a typed rebuild-required capability error.
 func (r Renderer) AlterColumnType(table TableRef, column Column) (Batch, error) {
-	if !r.Capabilities().AlterColumnTypes {
+	if !r.SupportsEvolution(EvolutionCapabilityAlterColumnType) {
 		return Batch{}, r.unsupported("altering column types without rebuilding the table")
 	}
 	if err := validateTableRef("column type change", table); err != nil {
@@ -231,7 +302,7 @@ func (r Renderer) AlterColumnType(table TableRef, column Column) (Batch, error) 
 // dialects may omit Column.DataType; SQL Server and MySQL require it because
 // their ALTER syntax restates the column type.
 func (r Renderer) AlterColumnNullability(table TableRef, column Column) (Batch, error) {
-	if !r.Capabilities().AlterColumnNullability {
+	if !r.SupportsEvolution(EvolutionCapabilityAlterColumnNullability) {
 		return Batch{}, r.unsupported("altering column nullability without rebuilding the table")
 	}
 	if err := validateTableRef("column nullability change", table); err != nil {
@@ -250,7 +321,7 @@ func (r Renderer) AlterColumnNullability(table TableRef, column Column) (Batch, 
 // statement. Custom dialects that need DataType should validate it inside
 // RenderEvolution.
 func (r Renderer) SetColumnDefault(table TableRef, column Column) (Batch, error) {
-	if !r.Capabilities().SetColumnDefaults {
+	if !r.SupportsEvolution(EvolutionCapabilitySetColumnDefault) {
 		return Batch{}, r.unsupported("setting column defaults")
 	}
 	if err := validateTableRef("set column default", table); err != nil {
@@ -267,7 +338,7 @@ func (r Renderer) SetColumnDefault(table TableRef, column Column) (Batch, error)
 
 // DropColumnDefault renders a deterministic default removal.
 func (r Renderer) DropColumnDefault(table TableRef, name string) (Batch, error) {
-	if !r.Capabilities().DropColumnDefaults {
+	if !r.SupportsEvolution(EvolutionCapabilityDropColumnDefault) {
 		return Batch{}, r.unsupported("dropping column defaults")
 	}
 	if err := validateTableRef("drop column default", table); err != nil {
@@ -283,10 +354,10 @@ func (r Renderer) DropColumnDefault(table TableRef, name string) (Batch, error) 
 // deterministic sqlite_sequence cleanup; MySQL additionally declares the
 // required same-connection foreign-key-check sequence.
 func (r Renderer) TruncateTable(table TableRef, options TruncateOptions) (Batch, error) {
-	if !r.Capabilities().TruncateTables {
+	if !r.SupportsEvolution(EvolutionCapabilityTruncateTable) {
 		return Batch{}, r.unsupported("truncating tables")
 	}
-	if options.Cascade && !r.Capabilities().TruncateTableCascade {
+	if options.Cascade && !r.SupportsEvolution(EvolutionCapabilityTruncateTableCascade) {
 		return Batch{}, r.unsupported("truncate CASCADE")
 	}
 	if err := validateTableRef("truncate table", table); err != nil {
@@ -438,8 +509,8 @@ func (d builtinDialect) RenderEvolution(request Request, operation Evolution) (B
 			cleanup := fmt.Sprintf("DELETE FROM sqlite_sequence WHERE name = '%s'", strings.ReplaceAll(driver.NormalizeIdentifier(d.name, operation.Table.Name), "'", "''"))
 			return Batch{Statements: []Statement{
 				{Kind: StatementTruncateTable, SQL: sql},
-				{Kind: StatementBestEffortCleanup, SQL: cleanup, BestEffort: true},
-			}}, nil
+				{Kind: StatementBestEffortCleanup, SQL: cleanup},
+			}, BestEffortStatementIndexes: []int{1}}, nil
 		default:
 			return batch(StatementTruncateTable, sql), nil
 		}
@@ -449,59 +520,59 @@ func (d builtinDialect) RenderEvolution(request Request, operation Evolution) (B
 }
 
 func (d builtinDialect) unsupportedEvolutionFeature(operation Evolution) string {
-	caps := d.capabilities
+	caps := d.EvolutionCapabilities()
 	switch operation.Kind {
 	case EvolutionDropSchema:
-		if !caps.DropSchemas {
+		if !caps.Supports(EvolutionCapabilityDropSchema) {
 			return "schema drops"
 		}
-		if operation.DropOptions.Cascade && !caps.DropSchemaCascade {
+		if operation.DropOptions.Cascade && !caps.Supports(EvolutionCapabilityDropSchemaCascade) {
 			return "schema-drop CASCADE"
 		}
 	case EvolutionDropTable:
-		if !caps.DropTables {
+		if !caps.Supports(EvolutionCapabilityDropTable) {
 			return "table drops"
 		}
-		if operation.DropOptions.Cascade && !caps.DropTableCascade {
+		if operation.DropOptions.Cascade && !caps.Supports(EvolutionCapabilityDropTableCascade) {
 			return "table-drop CASCADE"
 		}
 	case EvolutionDropIndex:
-		if !caps.DropIndexes {
+		if !caps.Supports(EvolutionCapabilityDropIndex) {
 			return "index drops"
 		}
 	case EvolutionDropConstraint:
-		if !caps.DropConstraints {
+		if !caps.Supports(EvolutionCapabilityDropConstraint) {
 			return "constraint drops"
 		}
 	case EvolutionAddColumn:
-		if !caps.AddColumns {
+		if !caps.Supports(EvolutionCapabilityAddColumn) {
 			return "adding columns"
 		}
 	case EvolutionDropColumn:
-		if !caps.DropColumns {
+		if !caps.Supports(EvolutionCapabilityDropColumn) {
 			return "dropping columns"
 		}
 	case EvolutionAlterColumnType:
-		if !caps.AlterColumnTypes {
+		if !caps.Supports(EvolutionCapabilityAlterColumnType) {
 			return "altering column types without rebuilding the table"
 		}
 	case EvolutionAlterColumnNullability:
-		if !caps.AlterColumnNullability {
+		if !caps.Supports(EvolutionCapabilityAlterColumnNullability) {
 			return "altering column nullability without rebuilding the table"
 		}
 	case EvolutionSetColumnDefault:
-		if !caps.SetColumnDefaults {
+		if !caps.Supports(EvolutionCapabilitySetColumnDefault) {
 			return "setting column defaults"
 		}
 	case EvolutionDropColumnDefault:
-		if !caps.DropColumnDefaults {
+		if !caps.Supports(EvolutionCapabilityDropColumnDefault) {
 			return "dropping column defaults"
 		}
 	case EvolutionTruncateTable:
-		if !caps.TruncateTables {
+		if !caps.Supports(EvolutionCapabilityTruncateTable) {
 			return "truncating tables"
 		}
-		if operation.TruncateOptions.Cascade && !caps.TruncateTableCascade {
+		if operation.TruncateOptions.Cascade && !caps.Supports(EvolutionCapabilityTruncateTableCascade) {
 			return "truncate CASCADE"
 		}
 	}

--- a/schema/evolution.go
+++ b/schema/evolution.go
@@ -245,7 +245,10 @@ func (r Renderer) AlterColumnNullability(table TableRef, column Column) (Batch, 
 
 // SetColumnDefault renders a deterministic default assignment. The column
 // must explicitly carry a default, including HasDefault for an intentional
-// empty-string default.
+// empty-string default. Column.Name is always required; Column.DataType is
+// optional because no builtin dialect restates the type in a SET DEFAULT
+// statement. Custom dialects that need DataType should validate it inside
+// RenderEvolution.
 func (r Renderer) SetColumnDefault(table TableRef, column Column) (Batch, error) {
 	if !r.Capabilities().SetColumnDefaults {
 		return Batch{}, r.unsupported("setting column defaults")
@@ -253,7 +256,7 @@ func (r Renderer) SetColumnDefault(table TableRef, column Column) (Batch, error)
 	if err := validateTableRef("set column default", table); err != nil {
 		return Batch{}, err
 	}
-	if err := r.validateColumn(column); err != nil {
+	if err := validateSetDefaultColumn(column); err != nil {
 		return Batch{}, err
 	}
 	if !column.HasDefault && strings.TrimSpace(column.DefaultExpression) == "" {
@@ -300,6 +303,13 @@ func (r Renderer) validateNullabilityColumn(column Column) error {
 		(dialect.name == "mssql" || dialect.name == "mysql") &&
 		strings.TrimSpace(column.DataType) == "" {
 		return fmt.Errorf("render column %q: empty source data type", column.Name)
+	}
+	return nil
+}
+
+func validateSetDefaultColumn(column Column) error {
+	if strings.TrimSpace(column.Name) == "" {
+		return fmt.Errorf("render column: empty column name")
 	}
 	return nil
 }

--- a/schema/evolution.go
+++ b/schema/evolution.go
@@ -1,0 +1,419 @@
+package schema
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/johndauphine/smt/internal/driver"
+)
+
+// Batch is an ordered, executable schema-evolution artifact. Statements must
+// be executed in order. When RequiresSingleConnection is true, every
+// Statement and, on an error, every Cleanup statement must execute on the
+// same physical connection. Cleanup restores session state when a preceding
+// statement did not complete (for example MySQL FOREIGN_KEY_CHECKS).
+//
+// SMT does not execute SQL: the caller owns transactions, retries, and error
+// policy. Batch makes the otherwise easy-to-miss connection-affinity contract
+// explicit without exposing database-driver types.
+type Batch struct {
+	Statements               []Statement
+	Cleanup                  []Statement
+	RequiresSingleConnection bool
+}
+
+// IsEmpty reports whether b contains no executable statements.
+func (b Batch) IsEmpty() bool { return len(b.Statements) == 0 }
+
+// EvolutionKind identifies an operation supplied to an EvolutionDialect.
+// Applications normally use the corresponding Renderer method; this type is
+// public so custom dialect adapters can implement the optional extension.
+type EvolutionKind string
+
+const (
+	EvolutionDropSchema             EvolutionKind = "drop_schema"
+	EvolutionDropTable              EvolutionKind = "drop_table"
+	EvolutionDropIndex              EvolutionKind = "drop_index"
+	EvolutionDropConstraint         EvolutionKind = "drop_constraint"
+	EvolutionAddColumn              EvolutionKind = "add_column"
+	EvolutionDropColumn             EvolutionKind = "drop_column"
+	EvolutionAlterColumnType        EvolutionKind = "alter_column_type"
+	EvolutionAlterColumnNullability EvolutionKind = "alter_column_nullability"
+	EvolutionSetColumnDefault       EvolutionKind = "set_column_default"
+	EvolutionDropColumnDefault      EvolutionKind = "drop_column_default"
+	EvolutionTruncateTable          EvolutionKind = "truncate_table"
+)
+
+// DropOptions selects explicit destructive-drop behavior. Cascade is never
+// inferred: callers must request it and the target dialect must advertise the
+// matching capability.
+type DropOptions struct {
+	Cascade bool
+}
+
+// TruncateOptions selects explicit truncate behavior. Cascade is supported
+// only where the selected dialect advertises TruncateTableCascade.
+type TruncateOptions struct {
+	Cascade bool
+}
+
+// ConstraintKind selects the dialect-specific form used to drop a named
+// table constraint. A primary-key name is retained for deterministic input
+// validation even though MySQL's DROP PRIMARY KEY syntax does not use it.
+type ConstraintKind string
+
+const (
+	ConstraintPrimaryKey ConstraintKind = "primary_key"
+	ConstraintUnique     ConstraintKind = "unique"
+	ConstraintForeignKey ConstraintKind = "foreign_key"
+	ConstraintCheck      ConstraintKind = "check"
+)
+
+// ConstraintRef identifies a named relational constraint on a table.
+type ConstraintRef struct {
+	Name string
+	Kind ConstraintKind
+}
+
+// Evolution is the typed public value received by a custom EvolutionDialect.
+// Renderer validates all fields before invoking the dialect; fields not used
+// by Kind are zero. No SMT internal driver value appears in this contract.
+type Evolution struct {
+	Kind            EvolutionKind
+	Table           TableRef
+	Column          Column
+	Name            string
+	Constraint      ConstraintRef
+	DropOptions     DropOptions
+	TruncateOptions TruncateOptions
+}
+
+// EvolutionDialect is the optional public extension for schema mutation DDL.
+// It remains separate from Dialect so existing custom create-only and
+// side-object implementations remain source compatible.
+type EvolutionDialect interface {
+	Dialect
+	RenderEvolution(Request, Evolution) (Batch, error)
+}
+
+const (
+	// StatementSessionSetup changes connection-local state before an operation.
+	StatementSessionSetup StatementKind = "session_setup"
+	// StatementSessionCleanup restores connection-local state after an operation.
+	StatementSessionCleanup StatementKind = "session_cleanup"
+	// StatementBestEffortCleanup performs non-critical post-operation cleanup.
+	StatementBestEffortCleanup      StatementKind = "best_effort_cleanup"
+	StatementDropSchema             StatementKind = "drop_schema"
+	StatementDropTable              StatementKind = "drop_table"
+	StatementDropIndex              StatementKind = "drop_index"
+	StatementDropConstraint         StatementKind = "drop_constraint"
+	StatementAddColumn              StatementKind = "add_column"
+	StatementDropColumn             StatementKind = "drop_column"
+	StatementAlterColumnType        StatementKind = "alter_column_type"
+	StatementAlterColumnNullability StatementKind = "alter_column_nullability"
+	StatementSetColumnDefault       StatementKind = "set_column_default"
+	StatementDropColumnDefault      StatementKind = "drop_column_default"
+	StatementTruncateTable          StatementKind = "truncate_table"
+)
+
+// DropSchema renders an idempotent drop of Options.Schema. An empty schema is
+// a no-op, matching CreateSchema.
+func (r Renderer) DropSchema(options DropOptions) (Batch, error) {
+	if strings.TrimSpace(r.request.Schema) == "" {
+		return Batch{}, nil
+	}
+	if !r.Capabilities().DropSchemas {
+		return Batch{}, r.unsupported("schema drops")
+	}
+	if options.Cascade && !r.Capabilities().DropSchemaCascade {
+		return Batch{}, r.unsupported("schema-drop CASCADE")
+	}
+	return r.renderEvolution(Evolution{Kind: EvolutionDropSchema, DropOptions: options})
+}
+
+// DropTable renders an idempotent table drop. Cascade is an explicit option
+// because it may remove dependent objects.
+func (r Renderer) DropTable(table TableRef, options DropOptions) (Batch, error) {
+	if !r.Capabilities().DropTables {
+		return Batch{}, r.unsupported("table drops")
+	}
+	if options.Cascade && !r.Capabilities().DropTableCascade {
+		return Batch{}, r.unsupported("table-drop CASCADE")
+	}
+	if err := validateTableRef("table drop", table); err != nil {
+		return Batch{}, err
+	}
+	return r.renderEvolution(Evolution{Kind: EvolutionDropTable, Table: table, DropOptions: options})
+}
+
+// DropIndex renders a named-index drop for a table.
+func (r Renderer) DropIndex(table TableRef, name string) (Batch, error) {
+	if !r.Capabilities().DropIndexes {
+		return Batch{}, r.unsupported("index drops")
+	}
+	if err := validateTableRef("index drop", table); err != nil {
+		return Batch{}, err
+	}
+	if strings.TrimSpace(name) == "" {
+		return Batch{}, fmt.Errorf("render index drop on table %q: empty index name", table.Name)
+	}
+	return r.renderEvolution(Evolution{Kind: EvolutionDropIndex, Table: table, Name: name})
+}
+
+// DropConstraint renders a named primary-key, unique, foreign-key, or check
+// constraint drop. SQLite and ClickHouse report a typed unsupported error
+// rather than silently proposing a table rebuild.
+func (r Renderer) DropConstraint(table TableRef, constraint ConstraintRef) (Batch, error) {
+	if !r.Capabilities().DropConstraints {
+		return Batch{}, r.unsupported("constraint drops")
+	}
+	if err := validateTableRef("constraint drop", table); err != nil {
+		return Batch{}, err
+	}
+	if strings.TrimSpace(constraint.Name) == "" {
+		return Batch{}, fmt.Errorf("render constraint drop on table %q: empty constraint name", table.Name)
+	}
+	switch constraint.Kind {
+	case ConstraintPrimaryKey, ConstraintUnique, ConstraintForeignKey, ConstraintCheck:
+	default:
+		return Batch{}, fmt.Errorf("render constraint drop %q: invalid constraint kind %q", constraint.Name, constraint.Kind)
+	}
+	return r.renderEvolution(Evolution{Kind: EvolutionDropConstraint, Table: table, Constraint: constraint})
+}
+
+// AddColumn renders a complete ALTER TABLE add-column operation.
+func (r Renderer) AddColumn(table TableRef, column Column) (Batch, error) {
+	if !r.Capabilities().AddColumns {
+		return Batch{}, r.unsupported("adding columns")
+	}
+	if err := validateTableRef("add column", table); err != nil {
+		return Batch{}, err
+	}
+	if err := r.validateColumn(column); err != nil {
+		return Batch{}, err
+	}
+	return r.renderEvolution(Evolution{Kind: EvolutionAddColumn, Table: table, Column: column})
+}
+
+// DropColumn renders a data-destructive column drop.
+func (r Renderer) DropColumn(table TableRef, name string) (Batch, error) {
+	if !r.Capabilities().DropColumns {
+		return Batch{}, r.unsupported("dropping columns")
+	}
+	if err := validateTableRef("column drop", table); err != nil {
+		return Batch{}, err
+	}
+	if strings.TrimSpace(name) == "" {
+		return Batch{}, fmt.Errorf("render column drop on table %q: empty column name", table.Name)
+	}
+	return r.renderEvolution(Evolution{Kind: EvolutionDropColumn, Table: table, Name: name})
+}
+
+// AlterColumnType renders an in-place type change when the dialect supports
+// one. SQLite and ClickHouse report a typed rebuild-required capability error.
+func (r Renderer) AlterColumnType(table TableRef, column Column) (Batch, error) {
+	if !r.Capabilities().AlterColumnTypes {
+		return Batch{}, r.unsupported("altering column types without rebuilding the table")
+	}
+	if err := validateTableRef("column type change", table); err != nil {
+		return Batch{}, err
+	}
+	if err := r.validateColumn(column); err != nil {
+		return Batch{}, err
+	}
+	return r.renderEvolution(Evolution{Kind: EvolutionAlterColumnType, Table: table, Column: column})
+}
+
+// AlterColumnNullability renders an in-place NULL/NOT NULL transition.
+func (r Renderer) AlterColumnNullability(table TableRef, column Column) (Batch, error) {
+	if !r.Capabilities().AlterColumnNullability {
+		return Batch{}, r.unsupported("altering column nullability without rebuilding the table")
+	}
+	if err := validateTableRef("column nullability change", table); err != nil {
+		return Batch{}, err
+	}
+	if err := r.validateColumn(column); err != nil {
+		return Batch{}, err
+	}
+	return r.renderEvolution(Evolution{Kind: EvolutionAlterColumnNullability, Table: table, Column: column})
+}
+
+// SetColumnDefault renders a deterministic default assignment. The column
+// must explicitly carry a default, including HasDefault for an intentional
+// empty-string default.
+func (r Renderer) SetColumnDefault(table TableRef, column Column) (Batch, error) {
+	if !r.Capabilities().SetColumnDefaults {
+		return Batch{}, r.unsupported("setting column defaults")
+	}
+	if err := validateTableRef("set column default", table); err != nil {
+		return Batch{}, err
+	}
+	if err := r.validateColumn(column); err != nil {
+		return Batch{}, err
+	}
+	if !column.HasDefault && strings.TrimSpace(column.DefaultExpression) == "" {
+		return Batch{}, fmt.Errorf("render column default %q: no default expression", column.Name)
+	}
+	return r.renderEvolution(Evolution{Kind: EvolutionSetColumnDefault, Table: table, Column: column})
+}
+
+// DropColumnDefault renders a deterministic default removal.
+func (r Renderer) DropColumnDefault(table TableRef, name string) (Batch, error) {
+	if !r.Capabilities().DropColumnDefaults {
+		return Batch{}, r.unsupported("dropping column defaults")
+	}
+	if err := validateTableRef("drop column default", table); err != nil {
+		return Batch{}, err
+	}
+	if strings.TrimSpace(name) == "" {
+		return Batch{}, fmt.Errorf("render column default drop on table %q: empty column name", table.Name)
+	}
+	return r.renderEvolution(Evolution{Kind: EvolutionDropColumnDefault, Table: table, Name: name})
+}
+
+// TruncateTable renders a data-clearing operation. SQLite uses DELETE and a
+// deterministic sqlite_sequence cleanup; MySQL additionally declares the
+// required same-connection foreign-key-check sequence.
+func (r Renderer) TruncateTable(table TableRef, options TruncateOptions) (Batch, error) {
+	if !r.Capabilities().TruncateTables {
+		return Batch{}, r.unsupported("truncating tables")
+	}
+	if options.Cascade && !r.Capabilities().TruncateTableCascade {
+		return Batch{}, r.unsupported("truncate CASCADE")
+	}
+	if err := validateTableRef("truncate table", table); err != nil {
+		return Batch{}, err
+	}
+	return r.renderEvolution(Evolution{Kind: EvolutionTruncateTable, Table: table, TruncateOptions: options})
+}
+
+func (r Renderer) renderEvolution(operation Evolution) (Batch, error) {
+	dialect, ok := r.dialect.(EvolutionDialect)
+	if !ok {
+		return Batch{}, r.unsupported(string(operation.Kind))
+	}
+	return dialect.RenderEvolution(r.request, operation)
+}
+
+func (d builtinDialect) RenderEvolution(request Request, operation Evolution) (Batch, error) {
+	renderer, err := d.renderer(request)
+	if err != nil {
+		return Batch{}, err
+	}
+	batch := func(kind StatementKind, sql string) Batch {
+		if strings.TrimSpace(sql) == "" {
+			return Batch{}
+		}
+		return Batch{Statements: []Statement{{Kind: kind, SQL: sql}}}
+	}
+	sessionBatch := func(kind StatementKind, sql, setup, cleanup string) Batch {
+		return Batch{
+			Statements: []Statement{
+				{Kind: StatementSessionSetup, SQL: setup},
+				{Kind: kind, SQL: sql},
+				{Kind: StatementSessionCleanup, SQL: cleanup},
+			},
+			Cleanup:                  []Statement{{Kind: StatementSessionCleanup, SQL: cleanup}},
+			RequiresSingleConnection: true,
+		}
+	}
+
+	switch operation.Kind {
+	case EvolutionDropSchema:
+		sql, err := renderer.DropSchemaDDL(operation.DropOptions.Cascade)
+		if err != nil {
+			return Batch{}, d.publicEvolutionError(err)
+		}
+		return batch(StatementDropSchema, sql), nil
+	case EvolutionDropTable:
+		sql, err := renderer.DropTableWithOptionsDDL(operation.Table.Name, operation.DropOptions.Cascade)
+		if err != nil {
+			return Batch{}, d.publicEvolutionError(err)
+		}
+		switch d.name {
+		case "mysql":
+			return sessionBatch(StatementDropTable, sql, "SET FOREIGN_KEY_CHECKS = 0", "SET FOREIGN_KEY_CHECKS = 1"), nil
+		case "sqlite":
+			return sessionBatch(StatementDropTable, sql, "PRAGMA foreign_keys = OFF", "PRAGMA foreign_keys = ON"), nil
+		default:
+			return batch(StatementDropTable, sql), nil
+		}
+	case EvolutionDropIndex:
+		return batch(StatementDropIndex, renderer.DropIndexDDL(operation.Table.Name, operation.Name)), nil
+	case EvolutionDropConstraint:
+		sql, err := renderer.DropConstraintDDL(operation.Table.Name, operation.Constraint.Name, string(operation.Constraint.Kind))
+		if err != nil {
+			return Batch{}, d.publicEvolutionError(err)
+		}
+		return batch(StatementDropConstraint, sql), nil
+	case EvolutionAddColumn:
+		sql, err := renderer.AddColumnDDL(operation.Table.Name, toDriverColumn(operation.Column), toDriverColumns(operation.Table.Columns))
+		if err != nil {
+			return Batch{}, d.publicEvolutionError(err)
+		}
+		return Batch{Statements: []Statement{{
+			Kind: StatementAddColumn, SQL: sql,
+			Warnings: mappingWarnings(d.name, request, operation.Table.Name, []Column{operation.Column}),
+		}}}, nil
+	case EvolutionDropColumn:
+		return batch(StatementDropColumn, renderer.DropColumnDDL(operation.Table.Name, operation.Name)), nil
+	case EvolutionAlterColumnType:
+		sql, err := renderer.AlterColumnTypeDDL(operation.Table.Name, toDriverColumn(operation.Column))
+		if err != nil {
+			return Batch{}, d.publicEvolutionError(err)
+		}
+		return Batch{Statements: []Statement{{
+			Kind: StatementAlterColumnType, SQL: sql,
+			Warnings: mappingWarnings(d.name, request, operation.Table.Name, []Column{operation.Column}),
+		}}}, nil
+	case EvolutionAlterColumnNullability:
+		sql, err := renderer.AlterColumnNullabilityDDL(operation.Table.Name, toDriverColumn(operation.Column))
+		if err != nil {
+			return Batch{}, d.publicEvolutionError(err)
+		}
+		return batch(StatementAlterColumnNullability, sql), nil
+	case EvolutionSetColumnDefault:
+		sql, err := renderer.SetColumnDefaultDDL(operation.Table.Name, toDriverColumn(operation.Column))
+		if err != nil {
+			return Batch{}, d.publicEvolutionError(err)
+		}
+		return batch(StatementSetColumnDefault, sql), nil
+	case EvolutionDropColumnDefault:
+		return batch(StatementDropColumnDefault, renderer.DropColumnDefaultDDL(operation.Table.Name, operation.Name)), nil
+	case EvolutionTruncateTable:
+		sql, err := renderer.TruncateTableDDL(operation.Table.Name, operation.TruncateOptions.Cascade)
+		if err != nil {
+			return Batch{}, d.publicEvolutionError(err)
+		}
+		switch d.name {
+		case "mysql":
+			return sessionBatch(StatementTruncateTable, sql, "SET FOREIGN_KEY_CHECKS = 0", "SET FOREIGN_KEY_CHECKS = 1"), nil
+		case "sqlite":
+			cleanup := fmt.Sprintf("DELETE FROM sqlite_sequence WHERE name = '%s'", strings.ReplaceAll(driver.NormalizeIdentifier(d.name, operation.Table.Name), "'", "''"))
+			return Batch{Statements: []Statement{
+				{Kind: StatementTruncateTable, SQL: sql},
+				{Kind: StatementBestEffortCleanup, SQL: cleanup, BestEffort: true},
+			}}, nil
+		default:
+			return batch(StatementTruncateTable, sql), nil
+		}
+	default:
+		return Batch{}, fmt.Errorf("render evolution: unknown operation %q", operation.Kind)
+	}
+}
+
+func (d builtinDialect) publicEvolutionError(err error) error {
+	message := err.Error()
+	switch {
+	case strings.Contains(message, "schema-drop CASCADE"):
+		return &UnsupportedFeatureError{Dialect: d.name, Feature: "schema-drop CASCADE"}
+	case strings.Contains(message, "table-drop CASCADE"):
+		return &UnsupportedFeatureError{Dialect: d.name, Feature: "table-drop CASCADE"}
+	case strings.Contains(message, "truncate CASCADE"):
+		return &UnsupportedFeatureError{Dialect: d.name, Feature: "truncate CASCADE"}
+	case strings.Contains(message, "does not support dropping named constraints"):
+		return &UnsupportedFeatureError{Dialect: d.name, Feature: "constraint drops"}
+	default:
+		return err
+	}
+}

--- a/schema/evolution.go
+++ b/schema/evolution.go
@@ -411,6 +411,18 @@ func (d builtinDialect) RenderEvolution(request Request, operation Evolution) (B
 		if err != nil {
 			return Batch{}, err
 		}
+		if d.name == "mssql" {
+			// SQL Server permits only one DEFAULT constraint per column. The
+			// existing constraint is catalog-named, so drop it first on the
+			// same connection before adding this renderer's deterministic name.
+			return Batch{
+				Statements: []Statement{
+					{Kind: StatementDropColumnDefault, SQL: renderer.DropColumnDefaultDDL(operation.Table.Name, operation.Column.Name)},
+					{Kind: StatementSetColumnDefault, SQL: sql},
+				},
+				RequiresSingleConnection: true,
+			}, nil
+		}
 		return batch(StatementSetColumnDefault, sql), nil
 	case EvolutionDropColumnDefault:
 		return batch(StatementDropColumnDefault, renderer.DropColumnDefaultDDL(operation.Table.Name, operation.Name)), nil

--- a/schema/evolution.go
+++ b/schema/evolution.go
@@ -76,8 +76,10 @@ type ConstraintRef struct {
 }
 
 // Evolution is the typed public value received by a custom EvolutionDialect.
-// Renderer validates all fields before invoking the dialect; fields not used
-// by Kind are zero. No SMT internal driver value appears in this contract.
+// Renderer performs operation-specific validation before invoking the
+// dialect. Top-level fields not used by Kind are zero; Column contains the
+// caller's input, including any optional fields. No SMT internal driver value
+// appears in this contract.
 type Evolution struct {
 	Kind            EvolutionKind
 	Table           TableRef
@@ -225,6 +227,9 @@ func (r Renderer) AlterColumnType(table TableRef, column Column) (Batch, error) 
 }
 
 // AlterColumnNullability renders an in-place NULL/NOT NULL transition.
+// Column.Name and Column.IsNullable are always used. PostgreSQL and custom
+// dialects may omit Column.DataType; SQL Server and MySQL require it because
+// their ALTER syntax restates the column type.
 func (r Renderer) AlterColumnNullability(table TableRef, column Column) (Batch, error) {
 	if !r.Capabilities().AlterColumnNullability {
 		return Batch{}, r.unsupported("altering column nullability without rebuilding the table")
@@ -232,7 +237,7 @@ func (r Renderer) AlterColumnNullability(table TableRef, column Column) (Batch, 
 	if err := validateTableRef("column nullability change", table); err != nil {
 		return Batch{}, err
 	}
-	if err := r.validateColumn(column); err != nil {
+	if err := r.validateNullabilityColumn(column); err != nil {
 		return Batch{}, err
 	}
 	return r.renderEvolution(Evolution{Kind: EvolutionAlterColumnNullability, Table: table, Column: column})
@@ -287,6 +292,18 @@ func (r Renderer) TruncateTable(table TableRef, options TruncateOptions) (Batch,
 	return r.renderEvolution(Evolution{Kind: EvolutionTruncateTable, Table: table, TruncateOptions: options})
 }
 
+func (r Renderer) validateNullabilityColumn(column Column) error {
+	if strings.TrimSpace(column.Name) == "" {
+		return fmt.Errorf("render column: empty column name")
+	}
+	if dialect, ok := r.dialect.(builtinDialect); ok &&
+		(dialect.name == "mssql" || dialect.name == "mysql") &&
+		strings.TrimSpace(column.DataType) == "" {
+		return fmt.Errorf("render column %q: empty source data type", column.Name)
+	}
+	return nil
+}
+
 func (r Renderer) renderEvolution(operation Evolution) (Batch, error) {
 	dialect, ok := r.dialect.(EvolutionDialect)
 	if !ok {
@@ -296,6 +313,9 @@ func (r Renderer) renderEvolution(operation Evolution) (Batch, error) {
 }
 
 func (d builtinDialect) RenderEvolution(request Request, operation Evolution) (Batch, error) {
+	if feature := d.unsupportedEvolutionFeature(operation); feature != "" {
+		return Batch{}, &UnsupportedFeatureError{Dialect: d.name, Feature: feature}
+	}
 	renderer, err := d.renderer(request)
 	if err != nil {
 		return Batch{}, err
@@ -322,13 +342,13 @@ func (d builtinDialect) RenderEvolution(request Request, operation Evolution) (B
 	case EvolutionDropSchema:
 		sql, err := renderer.DropSchemaDDL(operation.DropOptions.Cascade)
 		if err != nil {
-			return Batch{}, d.publicEvolutionError(err)
+			return Batch{}, err
 		}
 		return batch(StatementDropSchema, sql), nil
 	case EvolutionDropTable:
 		sql, err := renderer.DropTableWithOptionsDDL(operation.Table.Name, operation.DropOptions.Cascade)
 		if err != nil {
-			return Batch{}, d.publicEvolutionError(err)
+			return Batch{}, err
 		}
 		switch d.name {
 		case "mysql":
@@ -343,13 +363,13 @@ func (d builtinDialect) RenderEvolution(request Request, operation Evolution) (B
 	case EvolutionDropConstraint:
 		sql, err := renderer.DropConstraintDDL(operation.Table.Name, operation.Constraint.Name, string(operation.Constraint.Kind))
 		if err != nil {
-			return Batch{}, d.publicEvolutionError(err)
+			return Batch{}, err
 		}
 		return batch(StatementDropConstraint, sql), nil
 	case EvolutionAddColumn:
 		sql, err := renderer.AddColumnDDL(operation.Table.Name, toDriverColumn(operation.Column), toDriverColumns(operation.Table.Columns))
 		if err != nil {
-			return Batch{}, d.publicEvolutionError(err)
+			return Batch{}, err
 		}
 		return Batch{Statements: []Statement{{
 			Kind: StatementAddColumn, SQL: sql,
@@ -360,7 +380,7 @@ func (d builtinDialect) RenderEvolution(request Request, operation Evolution) (B
 	case EvolutionAlterColumnType:
 		sql, err := renderer.AlterColumnTypeDDL(operation.Table.Name, toDriverColumn(operation.Column))
 		if err != nil {
-			return Batch{}, d.publicEvolutionError(err)
+			return Batch{}, err
 		}
 		return Batch{Statements: []Statement{{
 			Kind: StatementAlterColumnType, SQL: sql,
@@ -369,13 +389,13 @@ func (d builtinDialect) RenderEvolution(request Request, operation Evolution) (B
 	case EvolutionAlterColumnNullability:
 		sql, err := renderer.AlterColumnNullabilityDDL(operation.Table.Name, toDriverColumn(operation.Column))
 		if err != nil {
-			return Batch{}, d.publicEvolutionError(err)
+			return Batch{}, err
 		}
 		return batch(StatementAlterColumnNullability, sql), nil
 	case EvolutionSetColumnDefault:
 		sql, err := renderer.SetColumnDefaultDDL(operation.Table.Name, toDriverColumn(operation.Column))
 		if err != nil {
-			return Batch{}, d.publicEvolutionError(err)
+			return Batch{}, err
 		}
 		return batch(StatementSetColumnDefault, sql), nil
 	case EvolutionDropColumnDefault:
@@ -383,7 +403,7 @@ func (d builtinDialect) RenderEvolution(request Request, operation Evolution) (B
 	case EvolutionTruncateTable:
 		sql, err := renderer.TruncateTableDDL(operation.Table.Name, operation.TruncateOptions.Cascade)
 		if err != nil {
-			return Batch{}, d.publicEvolutionError(err)
+			return Batch{}, err
 		}
 		switch d.name {
 		case "mysql":
@@ -402,18 +422,62 @@ func (d builtinDialect) RenderEvolution(request Request, operation Evolution) (B
 	}
 }
 
-func (d builtinDialect) publicEvolutionError(err error) error {
-	message := err.Error()
-	switch {
-	case strings.Contains(message, "schema-drop CASCADE"):
-		return &UnsupportedFeatureError{Dialect: d.name, Feature: "schema-drop CASCADE"}
-	case strings.Contains(message, "table-drop CASCADE"):
-		return &UnsupportedFeatureError{Dialect: d.name, Feature: "table-drop CASCADE"}
-	case strings.Contains(message, "truncate CASCADE"):
-		return &UnsupportedFeatureError{Dialect: d.name, Feature: "truncate CASCADE"}
-	case strings.Contains(message, "does not support dropping named constraints"):
-		return &UnsupportedFeatureError{Dialect: d.name, Feature: "constraint drops"}
-	default:
-		return err
+func (d builtinDialect) unsupportedEvolutionFeature(operation Evolution) string {
+	caps := d.capabilities
+	switch operation.Kind {
+	case EvolutionDropSchema:
+		if !caps.DropSchemas {
+			return "schema drops"
+		}
+		if operation.DropOptions.Cascade && !caps.DropSchemaCascade {
+			return "schema-drop CASCADE"
+		}
+	case EvolutionDropTable:
+		if !caps.DropTables {
+			return "table drops"
+		}
+		if operation.DropOptions.Cascade && !caps.DropTableCascade {
+			return "table-drop CASCADE"
+		}
+	case EvolutionDropIndex:
+		if !caps.DropIndexes {
+			return "index drops"
+		}
+	case EvolutionDropConstraint:
+		if !caps.DropConstraints {
+			return "constraint drops"
+		}
+	case EvolutionAddColumn:
+		if !caps.AddColumns {
+			return "adding columns"
+		}
+	case EvolutionDropColumn:
+		if !caps.DropColumns {
+			return "dropping columns"
+		}
+	case EvolutionAlterColumnType:
+		if !caps.AlterColumnTypes {
+			return "altering column types without rebuilding the table"
+		}
+	case EvolutionAlterColumnNullability:
+		if !caps.AlterColumnNullability {
+			return "altering column nullability without rebuilding the table"
+		}
+	case EvolutionSetColumnDefault:
+		if !caps.SetColumnDefaults {
+			return "setting column defaults"
+		}
+	case EvolutionDropColumnDefault:
+		if !caps.DropColumnDefaults {
+			return "dropping column defaults"
+		}
+	case EvolutionTruncateTable:
+		if !caps.TruncateTables {
+			return "truncating tables"
+		}
+		if operation.TruncateOptions.Cascade && !caps.TruncateTableCascade {
+			return "truncate CASCADE"
+		}
 	}
+	return ""
 }

--- a/schema/testdata/ddl/clickhouse_evolution.sql.golden
+++ b/schema/testdata/ddl/clickhouse_evolution.sql.golden
@@ -1,0 +1,19 @@
+drop_schema
+drop_schema
+DROP DATABASE IF EXISTS `analytics`
+
+drop_table
+drop_table
+DROP TABLE IF EXISTS `analytics`.`Orders`
+
+add_column
+add_column
+ALTER TABLE `analytics`.`Orders` ADD COLUMN `subtotal` Nullable(Int64)
+
+drop_column
+drop_column
+ALTER TABLE `analytics`.`Orders` DROP COLUMN IF EXISTS `subtotal`
+
+truncate_table
+truncate_table
+TRUNCATE TABLE `analytics`.`Orders`

--- a/schema/testdata/ddl/mssql_evolution.sql.golden
+++ b/schema/testdata/ddl/mssql_evolution.sql.golden
@@ -31,6 +31,9 @@ alter_column_nullability
 ALTER TABLE [dbo].[Orders] ALTER COLUMN [subtotal] BIGINT NULL
 
 set_column_default
+requires_single_connection
+drop_column_default
+DECLARE @constraintName sysname; SELECT @constraintName = dc.name FROM sys.default_constraints dc JOIN sys.columns c ON c.default_object_id = dc.object_id JOIN sys.tables t ON t.object_id = c.object_id JOIN sys.schemas s ON s.schema_id = t.schema_id WHERE s.name = N'dbo' AND t.name = N'Orders' AND c.name = N'subtotal'; IF @constraintName IS NOT NULL EXEC(N'ALTER TABLE [dbo].[Orders] DROP CONSTRAINT ' + QUOTENAME(@constraintName))
 set_column_default
 ALTER TABLE [dbo].[Orders] ADD CONSTRAINT [df_Orders_subtotal] DEFAULT 0 FOR [subtotal]
 

--- a/schema/testdata/ddl/mssql_evolution.sql.golden
+++ b/schema/testdata/ddl/mssql_evolution.sql.golden
@@ -1,0 +1,43 @@
+drop_schema
+drop_schema
+IF SCHEMA_ID(N'dbo') IS NOT NULL EXEC(N'DROP SCHEMA [dbo]')
+
+drop_table
+drop_table
+DROP TABLE IF EXISTS [dbo].[Orders]
+
+drop_index
+drop_index
+DROP INDEX [IX Orders Subtotal] ON [dbo].[Orders]
+
+drop_foreign_key
+drop_constraint
+ALTER TABLE [dbo].[Orders] DROP CONSTRAINT [FK Orders Account]
+
+add_column
+add_column
+ALTER TABLE [dbo].[Orders] ADD [subtotal] INT DEFAULT 0
+
+drop_column
+drop_column
+ALTER TABLE [dbo].[Orders] DROP COLUMN [subtotal]
+
+alter_column_type
+alter_column_type
+ALTER TABLE [dbo].[Orders] ALTER COLUMN [subtotal] BIGINT NULL
+
+alter_column_nullability
+alter_column_nullability
+ALTER TABLE [dbo].[Orders] ALTER COLUMN [subtotal] BIGINT NULL
+
+set_column_default
+set_column_default
+ALTER TABLE [dbo].[Orders] ADD CONSTRAINT [df_Orders_subtotal] DEFAULT 0 FOR [subtotal]
+
+drop_column_default
+drop_column_default
+DECLARE @constraintName sysname; SELECT @constraintName = dc.name FROM sys.default_constraints dc JOIN sys.columns c ON c.default_object_id = dc.object_id JOIN sys.tables t ON t.object_id = c.object_id JOIN sys.schemas s ON s.schema_id = t.schema_id WHERE s.name = N'dbo' AND t.name = N'Orders' AND c.name = N'subtotal'; IF @constraintName IS NOT NULL EXEC(N'ALTER TABLE [dbo].[Orders] DROP CONSTRAINT ' + QUOTENAME(@constraintName))
+
+truncate_table
+truncate_table
+TRUNCATE TABLE [dbo].[Orders]

--- a/schema/testdata/ddl/mysql_evolution.sql.golden
+++ b/schema/testdata/ddl/mysql_evolution.sql.golden
@@ -1,0 +1,57 @@
+drop_schema
+drop_schema
+DROP DATABASE IF EXISTS `crm`
+
+drop_table
+requires_single_connection
+session_setup
+SET FOREIGN_KEY_CHECKS = 0
+drop_table
+DROP TABLE IF EXISTS `crm`.`Orders`
+session_cleanup
+SET FOREIGN_KEY_CHECKS = 1
+on_failure_session_cleanup
+SET FOREIGN_KEY_CHECKS = 1
+
+drop_index
+drop_index
+DROP INDEX `IX Orders Subtotal` ON `crm`.`Orders`
+
+drop_foreign_key
+drop_constraint
+ALTER TABLE `crm`.`Orders` DROP FOREIGN KEY `FK Orders Account`
+
+add_column
+add_column
+ALTER TABLE `crm`.`Orders` ADD COLUMN `subtotal` INT DEFAULT 0
+
+drop_column
+drop_column
+ALTER TABLE `crm`.`Orders` DROP COLUMN `subtotal`
+
+alter_column_type
+alter_column_type
+ALTER TABLE `crm`.`Orders` MODIFY COLUMN `subtotal` BIGINT
+
+alter_column_nullability
+alter_column_nullability
+ALTER TABLE `crm`.`Orders` MODIFY COLUMN `subtotal` BIGINT
+
+set_column_default
+set_column_default
+ALTER TABLE `crm`.`Orders` ALTER COLUMN `subtotal` SET DEFAULT 0
+
+drop_column_default
+drop_column_default
+ALTER TABLE `crm`.`Orders` ALTER COLUMN `subtotal` DROP DEFAULT
+
+truncate_table
+requires_single_connection
+session_setup
+SET FOREIGN_KEY_CHECKS = 0
+truncate_table
+TRUNCATE TABLE `crm`.`Orders`
+session_cleanup
+SET FOREIGN_KEY_CHECKS = 1
+on_failure_session_cleanup
+SET FOREIGN_KEY_CHECKS = 1

--- a/schema/testdata/ddl/postgres_evolution.sql.golden
+++ b/schema/testdata/ddl/postgres_evolution.sql.golden
@@ -1,0 +1,43 @@
+drop_schema
+drop_schema
+DROP SCHEMA IF EXISTS "public" CASCADE
+
+drop_table
+drop_table
+DROP TABLE IF EXISTS "public"."orders" CASCADE
+
+drop_index
+drop_index
+DROP INDEX "public"."ix_orders_subtotal"
+
+drop_foreign_key
+drop_constraint
+ALTER TABLE "public"."orders" DROP CONSTRAINT "fk_orders_account"
+
+add_column
+add_column
+ALTER TABLE "public"."orders" ADD COLUMN "subtotal" integer DEFAULT 0
+
+drop_column
+drop_column
+ALTER TABLE "public"."orders" DROP COLUMN "subtotal"
+
+alter_column_type
+alter_column_type
+ALTER TABLE "public"."orders" ALTER COLUMN "subtotal" TYPE bigint
+
+alter_column_nullability
+alter_column_nullability
+ALTER TABLE "public"."orders" ALTER COLUMN "subtotal" DROP NOT NULL
+
+set_column_default
+set_column_default
+ALTER TABLE "public"."orders" ALTER COLUMN "subtotal" SET DEFAULT 0
+
+drop_column_default
+drop_column_default
+ALTER TABLE "public"."orders" ALTER COLUMN "subtotal" DROP DEFAULT
+
+truncate_table
+truncate_table
+TRUNCATE TABLE "public"."orders" CASCADE

--- a/schema/testdata/ddl/sqlite_evolution.sql.golden
+++ b/schema/testdata/ddl/sqlite_evolution.sql.golden
@@ -1,0 +1,29 @@
+drop_table
+requires_single_connection
+session_setup
+PRAGMA foreign_keys = OFF
+drop_table
+DROP TABLE IF EXISTS "Orders"
+session_cleanup
+PRAGMA foreign_keys = ON
+on_failure_session_cleanup
+PRAGMA foreign_keys = ON
+
+drop_index
+drop_index
+DROP INDEX IF EXISTS "IX Orders Subtotal"
+
+add_column
+add_column
+ALTER TABLE "Orders" ADD COLUMN "subtotal" INTEGER DEFAULT 0
+
+drop_column
+drop_column
+ALTER TABLE "Orders" DROP COLUMN "subtotal"
+
+truncate_table
+truncate_table
+DELETE FROM "Orders"
+best_effort
+best_effort_cleanup
+DELETE FROM sqlite_sequence WHERE name = 'Orders'

--- a/schema/testdata/legacy_struct_literals/legacy_struct_literals.go
+++ b/schema/testdata/legacy_struct_literals/legacy_struct_literals.go
@@ -1,0 +1,18 @@
+// Package legacystructliterals intentionally uses the v1.3.0 unkeyed public
+// struct literals. It is built by TestLegacyUnkeyedStructLiteralsCompile.
+package legacystructliterals
+
+import "github.com/johndauphine/smt/schema"
+
+var LegacyCapabilities = schema.Capabilities{
+	true, false, true,
+	false, true, false, true,
+	false, true, false, true, false,
+	true, false, true, false,
+}
+
+var LegacyStatement = schema.Statement{
+	schema.StatementCreateTable,
+	"CREATE TABLE legacy ()",
+	nil,
+}

--- a/schema/testdata/legacy_struct_literals/legacy_struct_literals_test.go
+++ b/schema/testdata/legacy_struct_literals/legacy_struct_literals_test.go
@@ -1,0 +1,16 @@
+package legacystructliterals
+
+import "testing"
+
+func TestLegacyCapabilitiesFieldOrder(t *testing.T) {
+	if !LegacyCapabilities.CreateSchema || LegacyCapabilities.CreateTable ||
+		!LegacyCapabilities.CreateColumn || LegacyCapabilities.PrimaryKeys ||
+		!LegacyCapabilities.IdentityColumns || LegacyCapabilities.Defaults ||
+		!LegacyCapabilities.ComputedColumns || LegacyCapabilities.SecondaryIndexes ||
+		!LegacyCapabilities.StandalonePrimaryKeys || LegacyCapabilities.StandaloneForeignKeys ||
+		!LegacyCapabilities.NamedUniqueConstraints || LegacyCapabilities.CheckConstraints ||
+		!LegacyCapabilities.IndexExpressionKeys || LegacyCapabilities.IndexPrefixLengths ||
+		!LegacyCapabilities.IndexIncludeColumns || LegacyCapabilities.FilteredIndexes {
+		t.Fatalf("legacy Capabilities literal field order changed: %+v", LegacyCapabilities)
+	}
+}


### PR DESCRIPTION
## Summary

- expose a public, stdlib-only schema-evolution DDL API for drops, column evolution, defaults, and truncate operations
- add explicit per-dialect capability contracts and typed unsupported-feature errors across PostgreSQL, MSSQL, MySQL, SQLite, and ClickHouse
- model ordered same-connection cleanup for destructive MySQL and SQLite paths, including SQLite's best-effort sequence reset

## DMT adoption

DMT remains unchanged in this PR. Its later adoption can retain scheduling and execution while delegating the remaining target-schema SQL to SMT.

## Validation

- `go test ./...`
- `go test -race ./...`
- `make lint`
- `go vet ./...`
- `make build`
- `go mod tidy` with no module diff
- `git diff --check`