### PR TITLE
chore: prepare SMT v1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-26
+
 ### Added
 
 - **Public schema-evolution DDL API** ([#247]) — `schema.Renderer` now
@@ -301,6 +303,7 @@ Releases before 0.10.0 are listed on the
 history since v0.9.0:
 [`v0.9.0...v0.10.0`](https://github.com/johndauphine/smt/compare/v0.9.0...v0.10.0).
 
+[1.4.0]: https://github.com/johndauphine/smt/releases/tag/v1.4.0
 [1.0.0]: https://github.com/johndauphine/smt/releases/tag/v1.0.0
 [0.12.1]: https://github.com/johndauphine/smt/releases/tag/v0.12.1
 [0.12.0]: https://github.com/johndauphine/smt/releases/tag/v0.12.0

--- a/README.md
+++ b/README.md
@@ -6,23 +6,27 @@ SMT is the schema-only counterpart to [DMT](https://github.com/johndauphine/dmt)
 
 ## Release Status
 
-SMT v1.0.0 is published as a stable GitHub Release:
-[SMT v1.0.0](https://github.com/johndauphine/smt/releases/tag/v1.0.0).
-The release tag points at commit
-`b08be2c1fcf22ced8e38e7137420e5d81b8e8ec0`, and downloadable Linux, macOS,
-and Windows artifacts are available with SHA-256 checksums. See
+SMT v1.4.0 is the release target for this source tree. The release publishes
+Linux, macOS, and Windows artifacts with SHA-256 checksums after the documented
+validation gates pass. See
 [docs/release-checklist.md](docs/release-checklist.md#current-release-status)
-for the current release status, validation gates, and asset list.
+for the target status, validation gates, and asset list, and
+[CHANGELOG.md](CHANGELOG.md#140---2026-07-26) for the release notes.
 
 ## Supported databases
 
 PostgreSQL, SQL Server, MySQL — both as source and target. New engines are added by dropping a package under `internal/driver/foo/` that implements `driver.Driver`/`Reader`/`Writer` and registers itself in `init()`.
 
 For applications that need deterministic schema DDL without using the SMT CLI,
-the public [`github.com/johndauphine/smt/schema`](docs/public-ddl-api.md) package exposes a registry,
-public schema values, explicit capability checks, and structured mapping
-warnings. It currently renders PostgreSQL, SQL Server, MySQL, SQLite, and
-ClickHouse DDL at schema/table/column scope.
+the public
+[`github.com/johndauphine/smt/schema`](docs/public-ddl-api.md) package exposes
+deterministic create and schema-evolution DDL. The create surface covers
+schemas/databases, tables, columns, indexes, and standalone primary-key,
+foreign-key, named-unique, and check constraints. The evolution surface covers
+schema/table/index/constraint drops, column add/drop/type/nullability/default
+changes, and table truncation as ordered batches. PostgreSQL, SQL Server,
+MySQL, SQLite, and ClickHouse advertise their exact supported subsets through
+capability APIs; unsupported requests fail explicitly.
 
 ## Quick start
 
@@ -33,6 +37,7 @@ make build
 ./smt health-check
 ./smt create                        # write target DDL to schema.sql
 ./smt create --apply                # execute DDL against the configured target
+./smt drift                         # report source-derived vs live-target drift
 ./smt snapshot                      # capture source schema as a baseline
 # ...time passes, source schema evolves...
 ./smt sync                          # diff source vs live target, render ALTERs to migration.sql
@@ -40,7 +45,8 @@ make build
 ./smt sync --apply                  # execute the ALTERs against the target
 ```
 
-Run `./smt` with no arguments to launch the TUI. See `./smt --help` for command help and [docs/cli.md](docs/cli.md) for the v1 CLI surface contract.
+Run `./smt` with no arguments to launch the TUI. See `./smt --help` for command
+help and [docs/cli.md](docs/cli.md) for the v1.4 CLI surface contract.
 
 ## Commands
 
@@ -49,6 +55,7 @@ Run `./smt` with no arguments to launch the TUI. See `./smt --help` for command 
 | `smt init` | build a `config.yaml` with a guided wizard (`--non-interactive` + per-field flags for scripting; `--print` to stdout) |
 | `smt create` | extract source schema and emit CREATE TABLE / CREATE INDEX / etc to `schema.sql` |
 | `smt create --apply` | also execute the generated DDL against the configured target |
+| `smt drift` | report read-only drift between the source-derived schema and the live target |
 | `smt snapshot` | save the current source schema as a baseline for future diffing |
 | `smt snapshot list` | list stored snapshots (id, source, schema, table count, captured-at); `--limit N` |
 | `smt sync` | diff source against the live target schema; generate target-dialect SQL; emit to `migration.sql` for review |

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,19 +1,40 @@
-# SMT v1.0.0 Release Checklist
+# SMT v1.4.0 Release Checklist
 
 ## Current Release Status
 
-SMT v1.0.0 is published as a stable GitHub Release:
-[SMT v1.0.0](https://github.com/johndauphine/smt/releases/tag/v1.0.0).
+SMT v1.4.0 is the current release target. Treat it as published only after the
+annotated tag, release assets, checksums, and stable GitHub Release are present.
 
 | Item | Status |
 |------|--------|
-| Release | Published on 2026-06-23 at 02:10 UTC; not a draft or prerelease |
-| Tag | Annotated tag `v1.0.0`, targeting `b08be2c1fcf22ced8e38e7137420e5d81b8e8ec0` |
-| CI | Passing on `main` for Unit Tests, Race Tests, Lint, and Build CLI at the release commit |
-| Release blockers | No open `v1` or `release-blocker` issues; release readiness tracker [#144](https://github.com/johndauphine/smt/issues/144) is closed |
+| Release | Target: stable GitHub Release `v1.4.0`; not complete until published |
+| Tag | Create annotated tag `v1.4.0` at the commit that passed every release gate |
+| CI | Unit Tests, Race Tests, Lint, and Build CLI must pass on the release commit |
+| Release blockers | Confirm there are no open release-blocking issues before tagging |
 | Assets | `smt-linux-amd64`, `smt-darwin-arm64`, `smt-windows-amd64.exe`, `checksums.txt` |
-| Checksums | Local release checksums passed before upload; the published `checksums.txt` matches the local file |
-| Acceptance artifacts | `so2010_verification.json`, `crm_acceptance_matrix.json`, and `live_ai_smoke.json` were generated under `.acceptance-artifacts/` during release validation |
+| Checksums | Generate locally, verify before upload, then verify the published `checksums.txt` |
+| Acceptance artifacts | Generate `so2010_verification.json`, `crm_acceptance_matrix.json`, and `live_ai_smoke.json` under `.acceptance-artifacts/` during release validation |
+
+## v1.4 Scope
+
+The stable CLI surface is `init`, `create`, `sync`, `drift`, `snapshot`,
+`snapshot list`, `health-check`, `profile`, `init-secrets`, and `history`.
+Preview remains the default for create and sync; applying DDL is explicit. See
+[`docs/cli.md`](cli.md) for the command and flag contract.
+
+The public [`schema`](public-ddl-api.md) package covers deterministic creation
+of schemas/databases, tables, columns, indexes, standalone primary keys,
+foreign keys, named unique constraints, and check constraints. `PlanCreate`
+orders schema and table statements; callers render and order standalone side
+objects explicitly.
+
+The public evolution API renders typed, ordered batches for
+schema/table/index/constraint drops, column add/drop/type/nullability/default
+changes, and table truncation. PostgreSQL supports the complete current
+evolution surface including explicit cascade; SQL Server and MySQL support the
+non-cascade surface. SQLite and ClickHouse advertise their supported subsets.
+Every unsupported request returns `*schema.UnsupportedFeatureError` rather
+than silently dropping behavior or proposing a rebuild.
 
 ## Supported Artifacts
 
@@ -26,7 +47,7 @@ SMT v1.0.0 is published as a stable GitHub Release:
 `make release-checksums` writes `dist/checksums.txt` with SHA-256 checksums for
 the built artifacts.
 
-Other platforms can build from source with Go 1.23+:
+Other platforms can build from source with Go 1.25.7 or later:
 
 ```bash
 go build -trimpath -o smt ./cmd/smt
@@ -100,7 +121,7 @@ make test-live-ai
 Build artifacts and checksums:
 
 ```bash
-VERSION=v1.0.0 make release-checksums
+VERSION=v1.4.0 make release-checksums
 ```
 
 Archive:
@@ -112,6 +133,6 @@ Archive:
 
 ## GitHub Release Notes
 
-Use the `CHANGELOG.md` `1.0.0` section as the release body. It includes the v1
-support contract, compatibility notes, release gates, and breaking config
-changes needed to publish without reconstructing notes manually.
+Use the `CHANGELOG.md` `1.4.0` section as the release body. It records the
+public schema-evolution API and the deterministic CLI/rendering changes shipped
+since v1.0.0 without reconstructing notes manually.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version is the current version of smt.
 // Can be overridden at build time with -ldflags "-X ...version.Version=..."
-var Version = "1.0.0"
+var Version = "1.4.0"
 
 // Name is the application name.
 const Name = "smt"


### PR DESCRIPTION
## Summary

- cut the accumulated schema-evolution work into a dated v1.4.0 changelog section
- update the source version and release documentation for the complete public create/constraint/evolution DDL surface
- document exact release assets, Go requirement, and validation workflow

## Validation

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `golangci-lint run`
- `go mod tidy -diff`
- `make test-so2010` (9/9 tables)
- `make test-crm-acceptance` (9/9 engine pairs)
- `make test-live-ai`
- `VERSION=v1.4.0 make release-checksums`
- checksums verified; Darwin artifact reports `smt version v1.4.0`

The release remains described as a target until this PR is merged, exact-commit CI passes, and the annotated tag/assets are published.