### PR TITLE
docs: record SMT v1.4.0 publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ SMT is the schema-only counterpart to [DMT](https://github.com/johndauphine/dmt)
 
 ## Release Status
 
-SMT v1.4.0 is the release target for this source tree. The release publishes
-Linux, macOS, and Windows artifacts with SHA-256 checksums after the documented
-validation gates pass. See
+SMT v1.4.0 is published as a
+[stable GitHub Release](https://github.com/johndauphine/smt/releases/tag/v1.4.0).
+Its annotated tag points to release commit
+`3f1e459189e0c90fee0c5d7a42069798064d2994`, whose required CI and acceptance
+gates passed. Linux, macOS, and Windows artifacts are published with verified
+SHA-256 checksums. See
 [docs/release-checklist.md](docs/release-checklist.md#current-release-status)
-for the target status, validation gates, and asset list, and
+for the published status, validation gates, and asset list, and
 [CHANGELOG.md](CHANGELOG.md#140---2026-07-26) for the release notes.
 
 ## Supported databases

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -2,18 +2,19 @@
 
 ## Current Release Status
 
-SMT v1.4.0 is the current release target. Treat it as published only after the
-annotated tag, release assets, checksums, and stable GitHub Release are present.
+SMT v1.4.0 was published as a stable GitHub Release on 2026-07-26. The
+annotated tag, release assets, checksums, required CI, and acceptance evidence
+have all been verified.
 
 | Item | Status |
 |------|--------|
-| Release | Target: stable GitHub Release `v1.4.0`; not complete until published |
-| Tag | Create annotated tag `v1.4.0` at the commit that passed every release gate |
-| CI | Unit Tests, Race Tests, Lint, and Build CLI must pass on the release commit |
-| Release blockers | Confirm there are no open release-blocking issues before tagging |
-| Assets | `smt-linux-amd64`, `smt-darwin-arm64`, `smt-windows-amd64.exe`, `checksums.txt` |
-| Checksums | Generate locally, verify before upload, then verify the published `checksums.txt` |
-| Acceptance artifacts | Generate `so2010_verification.json`, `crm_acceptance_matrix.json`, and `live_ai_smoke.json` under `.acceptance-artifacts/` during release validation |
+| Release | [Stable GitHub Release `v1.4.0`](https://github.com/johndauphine/smt/releases/tag/v1.4.0), published 2026-07-26 |
+| Tag | Annotated tag `v1.4.0` points to `3f1e459189e0c90fee0c5d7a42069798064d2994` |
+| CI | Unit Tests, Race Tests, Lint, Build CLI, and CRM Fixture Matrix passed on the exact release commit |
+| Release blockers | No open issues or pull requests remained at release verification |
+| Assets | Published `smt-linux-amd64`, `smt-darwin-arm64`, `smt-windows-amd64.exe`, and `checksums.txt` |
+| Checksums | Generated locally, verified before upload, and reverified from the published `checksums.txt` |
+| Acceptance artifacts | `so2010_verification.json`, `crm_acceptance_matrix.json`, and `live_ai_smoke.json` were generated under `.acceptance-artifacts/` and passed |
 
 ## v1.4 Scope
 


### PR DESCRIPTION
## Summary
- replace stale release-target wording with the verified published status
- record the exact annotated-tag commit and green release gates
- link the stable v1.4.0 release and published assets

## Verification
- `git diff --check`
- verified tag and release commit `3f1e459189e0c90fee0c5d7a42069798064d2994`
- verified all five release-commit checks, assets/checksums, acceptance artifacts, and no open issues/PRs

The v1.4.0 tag is unchanged.